### PR TITLE
Implement setObject on PreparedStatement

### DIFF
--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltPreparedStatementTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltPreparedStatementTest.java
@@ -40,6 +40,7 @@ import java.sql.BatchUpdateException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -496,7 +497,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 	/*------------------------------*/
 
 	@Test public void setObjectShouldInsertTheCorrectObjectValue() throws SQLException {
-		Object obj = new Object();
+		Object obj = new HashMap<>();
 		this.preparedStatementOneParam.setObject(1, obj);
 		HashMap<String, Object> value = Whitebox.getInternalState(this.preparedStatementOneParam, "parameters");
 		assertEquals(obj, value.get("1"));
@@ -507,12 +508,12 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 	}
 
 	@Test public void setObjectShouldOverrideOldValue() throws SQLException {
-		Object obj = new Object();
+		Object obj = new HashMap<>();
 		this.preparedStatementOneParam.setObject(1, obj);
 		HashMap<String, Object> value = Whitebox.getInternalState(this.preparedStatementOneParam, "parameters");
 		assertEquals(obj, value.get("1"));
 
-		Object newObj = new Object();
+		Object newObj = new ArrayList<>();;
 		this.preparedStatementOneParam.setObject(1, newObj);
 		value = Whitebox.getInternalState(this.preparedStatementOneParam, "parameters");
 		assertEquals(newObj, value.get("1"));
@@ -521,16 +522,21 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 	@Test public void setObjectShouldThrowExceptionIfIndexDoesNotCorrespondToParameterMarker() throws SQLException {
 		expectedEx.expect(SQLException.class);
 
-		this.preparedStatementOneParam.setObject(99, new Object());
+		this.preparedStatementOneParam.setObject(99, new HashMap<>());
 	}
 
 	@Test public void setObjectShouldThrowExceptionIfClosedPreparedStatement() throws SQLException {
 		expectedEx.expect(SQLException.class);
 
 		this.preparedStatementOneParam.close();
-		this.preparedStatementOneParam.setObject(1, new Object());
+		this.preparedStatementOneParam.setObject(1, new HashMap<>());
 	}
 
+	@Test public void setObjectShouldThrowExceptionIfObjectIsNotSupported() throws SQLException {
+		expectedEx.expect(SQLException.class);
+
+		this.preparedStatementOneParam.setObject(1, new Object());
+	}
 
 	/*------------------------------*/
 	/*     getParameterMetaData     */

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltPreparedStatementTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltPreparedStatementTest.java
@@ -492,6 +492,47 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 
 	/*------------------------------*/
+	/*          setObject           */
+	/*------------------------------*/
+
+	@Test public void setObjectShouldInsertTheCorrectObjectValue() throws SQLException {
+		Object obj = new Object();
+		this.preparedStatementOneParam.setObject(1, obj);
+		HashMap<String, Object> value = Whitebox.getInternalState(this.preparedStatementOneParam, "parameters");
+		assertEquals(obj, value.get("1"));
+
+		this.preparedStatementTwoParams.setObject(2, obj);
+		value = Whitebox.getInternalState(this.preparedStatementTwoParams, "parameters");
+		assertEquals(obj, value.get("2"));
+	}
+
+	@Test public void setObjectShouldOverrideOldValue() throws SQLException {
+		Object obj = new Object();
+		this.preparedStatementOneParam.setObject(1, obj);
+		HashMap<String, Object> value = Whitebox.getInternalState(this.preparedStatementOneParam, "parameters");
+		assertEquals(obj, value.get("1"));
+
+		Object newObj = new Object();
+		this.preparedStatementOneParam.setObject(1, newObj);
+		value = Whitebox.getInternalState(this.preparedStatementOneParam, "parameters");
+		assertEquals(newObj, value.get("1"));
+	}
+
+	@Test public void setObjectShouldThrowExceptionIfIndexDoesNotCorrespondToParameterMarker() throws SQLException {
+		expectedEx.expect(SQLException.class);
+
+		this.preparedStatementOneParam.setObject(99, new Object());
+	}
+
+	@Test public void setObjectShouldThrowExceptionIfClosedPreparedStatement() throws SQLException {
+		expectedEx.expect(SQLException.class);
+
+		this.preparedStatementOneParam.close();
+		this.preparedStatementOneParam.setObject(1, new Object());
+	}
+
+
+	/*------------------------------*/
 	/*     getParameterMetaData     */
 	/*------------------------------*/
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/PreparedStatement.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/PreparedStatement.java
@@ -165,6 +165,12 @@ public abstract class PreparedStatement extends Statement implements java.sql.Pr
 		this.insertParameter(parameterIndex, x);
 	}
 
+	@Override public void setObject(int parameterIndex, Object x) throws SQLException {
+		this.checkClosed();
+		this.checkParamsNumber(parameterIndex);
+		this.insertParameter(parameterIndex, x);
+	}
+
 	@Override public void clearParameters() throws SQLException {
 		this.checkClosed();
 		this.parameters.clear();
@@ -261,10 +267,6 @@ public abstract class PreparedStatement extends Statement implements java.sql.Pr
 	}
 
 	@Override public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
-		throw new UnsupportedOperationException("Not implemented yet.");
-	}
-
-	@Override public void setObject(int parameterIndex, Object x) throws SQLException {
 		throw new UnsupportedOperationException("Not implemented yet.");
 	}
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/PreparedStatement.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/PreparedStatement.java
@@ -28,7 +28,10 @@ import java.net.URL;
 import java.sql.*;
 import java.sql.ResultSet;
 import java.util.Calendar;
+import java.util.Iterator;
+import java.util.List;
 import java.util.HashMap;
+import java.util.Map;
 
 import static java.sql.Types.*;
 
@@ -83,6 +86,40 @@ public abstract class PreparedStatement extends Statement implements java.sql.Pr
 	protected void checkParamsNumber(int parameterIndex) throws SQLException {
 		if (parameterIndex > this.parametersNumber) {
 			throw new SQLException("ParameterIndex does not correspond to a parameter marker in the SQL statement");
+		}
+	}
+
+	/** Check if the given object is a valid type that Neo4J can handle.
+	 * If it's not we throw an exception.
+	 *
+	 * @param obj The object to check
+	 * @throws SQLException
+     */
+	protected void checkValidObject(Object obj) throws SQLException {
+		// TODO: this may belong into org.neo4j.driver.v1.Values
+		if (!(
+				obj == null ||
+				obj instanceof Boolean ||
+				obj instanceof String ||
+				obj instanceof Character ||
+				obj instanceof Long ||
+				obj instanceof Short ||
+				obj instanceof Byte ||
+				obj instanceof Integer ||
+				obj instanceof Double ||
+				obj instanceof Float ||
+				obj instanceof List ||
+				obj instanceof Iterable ||
+				obj instanceof Map ||
+				obj instanceof Iterator ||
+				obj instanceof boolean[] ||
+				obj instanceof String[] ||
+				obj instanceof long[] ||
+				obj instanceof int[] ||
+				obj instanceof double[] ||
+				obj instanceof float[] ||
+				obj instanceof Object[])) {
+			throw new SQLException("Object of type '" + obj.getClass() + "' isn't supported");
 		}
 	}
 
@@ -168,6 +205,7 @@ public abstract class PreparedStatement extends Statement implements java.sql.Pr
 	@Override public void setObject(int parameterIndex, Object x) throws SQLException {
 		this.checkClosed();
 		this.checkParamsNumber(parameterIndex);
+		this.checkValidObject(x);
 		this.insertParameter(parameterIndex, x);
 	}
 


### PR DESCRIPTION
This adds the capability to use the `setObject(int paramIndex, Object x)` Method on a prepared statement. The only thing which could be done were to move the check if a given Object is supported by Neo4J into the Values class which belongs to the general Neo4J driver module.
