### PR TITLE
Fix for #20, statement shouldn't close transaction

### DIFF
--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltPreparedStatement.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltPreparedStatement.java
@@ -180,25 +180,6 @@ public class BoltPreparedStatement extends PreparedStatement implements Loggable
 		return result;
 	}
 
-	/*-------------------*/
-	/*       Close       */
-	/*-------------------*/
-
-	/**
-	 * Override the default implementation to close the transaction.
-	 */
-	@Override public void close() throws SQLException {
-		if (!this.isClosed()) {
-			super.close();
-
-			// closing transaction
-			if (this.transaction != null) {
-				this.transaction.failure();
-				this.transaction.close();
-			}
-		}
-	}
-
 	/*--------------------*/
 	/*       Logger       */
 	/*--------------------*/

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltStatement.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltStatement.java
@@ -176,25 +176,6 @@ public class BoltStatement extends Statement implements Loggable {
 		return result;
 	}
 
-	/*-------------------*/
-	/*       Close       */
-	/*-------------------*/
-
-	/**
-	 * Override the default implementation to close the transaction.
-	 */
-	@Override public void close() throws SQLException {
-		if (!this.isClosed()) {
-			super.close();
-
-			// closing transaction
-			if (this.transaction != null) {
-				this.transaction.failure();
-				this.transaction.close();
-			}
-		}
-	}
-
 	/*--------------------*/
 	/*       Logger       */
 	/*--------------------*/

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltStatementIT.java
@@ -162,4 +162,20 @@ public class BoltStatementIT {
 
 		connection.close();
 	}
+
+	/*------------------------------*/
+	/*             close            */
+	/*------------------------------*/
+	@Test public void closeShouldNotCloseTransaction() throws SQLException {
+		try (Connection connection = DriverManager.getConnection("jdbc:" + neo4j.getBoltUrl())) {
+			connection.setAutoCommit(false);
+
+			Statement statement = connection.createStatement();
+			statement.execute("RETURN true AS result");
+			statement.close();
+
+			assertTrue(((BoltConnection) connection).getTransaction().isOpen());
+		}
+	}
+
 }

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltStatementTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltStatementTest.java
@@ -101,7 +101,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 		verify(mockedRS, times(1)).close();
 	}
 
-	@Test public void closeShouldCloseTheTransactionNotCommitting() throws Exception {
+	@Test public void closeShouldNotTouchTheTransaction() throws Exception {
 
 		Transaction mockTransaction = mock(Transaction.class);
 
@@ -112,8 +112,9 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 		statement.close();
 
-		verify(mockTransaction, times(1)).failure();
-		verify(mockTransaction, times(1)).close();
+		verify(mockTransaction, never()).failure();
+		verify(mockTransaction, never()).success();
+		verify(mockTransaction, never()).close();
 	}
 
 	/*------------------------------*/


### PR DESCRIPTION
Closing a statement shouldn't close a transaction as a transaction may span several statements.
