### PR TITLE
Fix #58: roll back the transaction on error

### DIFF
--- a/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/driver/CypherExecutor.java
+++ b/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/driver/CypherExecutor.java
@@ -331,7 +331,11 @@ public class CypherExecutor {
 		// Make the request
 		try (CloseableHttpResponse response = http.execute(request)) {
 			result = new Neo4jResponse(response, mapper);
-			if (result.location != null) {
+			if (result.hasErrors()) {
+				// The transaction *was* rolled back server-side. Whether a transaction existed or not before, it should
+				// now be considered rolled back on this side as well.
+				this.currentTransactionUrl = this.transactionUrl;
+			} else if (result.location != null) {
 				// Here we reconstruct the location in case of a proxy, but in this case you should redirect write queries to the master.
 				Integer transactionId = this.getTransactionId(result.location);
 				this.currentTransactionUrl = this.transactionUrl + "/" + transactionId;

--- a/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/driver/CypherExecutorIT.java
+++ b/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/driver/CypherExecutorIT.java
@@ -117,6 +117,25 @@ public class CypherExecutorIT extends Neo4jHttpIT {
 		Assert.assertNotEquals("Unknown", executor.getServerVersion());
 	}
 
+	@Test public void executeInvalidQueryShouldNotOpenTransaction() throws Exception {
+		executor.setAutoCommit(Boolean.FALSE);
+
+		Neo4jResponse response = executor.executeQuery(new Neo4jStatement("invalid", null, Boolean.FALSE));
+
+		Assert.assertTrue(response.hasErrors());
+		Assert.assertEquals(Integer.valueOf(-1), executor.getOpenTransactionId());
+	}
+
+	@Test public void executeValidThenInvalidQueryShouldRollbackTransaction() throws Exception {
+		executor.setAutoCommit(Boolean.FALSE);
+		executor.executeQuery(new Neo4jStatement("MATCH (n) RETURN count(n)", null, Boolean.FALSE));
+
+		Neo4jResponse response = executor.executeQuery(new Neo4jStatement("invalid", null, Boolean.FALSE));
+
+		Assert.assertTrue(response.hasErrors());
+		Assert.assertEquals(Integer.valueOf(-1), executor.getOpenTransactionId());
+	}
+
 	@After public void after() throws SQLException {
 		executor.close();
 	}


### PR DESCRIPTION
The REST transactional endpoint will always return a transaction, but that
transaction will actually have been rolled back server-side if the response
contains errors. The transaction is now also considered rolled back
client-side in that case.

It allows the Connection to be closed properly, because it won't try to
roll back the transaction explicitly, which fails and interrupts the closing
when the transaction does not exist anymore.
