### PR TITLE
Allow rolling back empty transactions with the HTTP driver

### DIFF
--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltConnectionIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltConnectionIT.java
@@ -203,6 +203,15 @@ public class BoltConnectionIT {
 		reader.close();
 	}
 
+	@Test public void shouldRollbackAnEmptyTransaction() throws SQLException {
+		// Connect (autoCommit = false)
+		try (Connection connection = DriverManager.getConnection(NEO4J_JDBC_BOLT_URL)) {
+			connection.setAutoCommit(false);
+
+			connection.rollback();
+		}
+	}
+
 	/*------------------------------*/
 	/*         getMetaData          */
 	/*------------------------------*/

--- a/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/driver/CypherExecutor.java
+++ b/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/driver/CypherExecutor.java
@@ -175,8 +175,6 @@ public class CypherExecutor {
 				throw new SQLException(response.displayErrors());
 			}
 			this.currentTransactionUrl = this.transactionUrl;
-		} else {
-			throw new SQLException("There is no transaction to commit");
 		}
 	}
 
@@ -194,8 +192,6 @@ public class CypherExecutor {
 				throw new SQLException(response.displayErrors());
 			}
 			this.currentTransactionUrl = this.transactionUrl;
-		} else {
-			throw new SQLException("There is no transaction to rollback");
 		}
 	}
 

--- a/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/HttpConnectionIT.java
+++ b/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/HttpConnectionIT.java
@@ -120,6 +120,15 @@ public class HttpConnectionIT extends Neo4jHttpIT {
 		writer.close();
 	}
 
+	@Test public void shouldRollbackAnEmptyTransaction() throws SQLException {
+		// Connect (autoCommit = false)
+		try (Connection connection = DriverManager.getConnection(getJDBCUrl())) {
+			connection.setAutoCommit(false);
+
+			connection.rollback();
+		}
+	}
+
 	@Test
 	public void getMetaDataShouldWork() throws SQLException {
 		// Write something

--- a/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/HttpConnectionIT.java
+++ b/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/HttpConnectionIT.java
@@ -120,6 +120,15 @@ public class HttpConnectionIT extends Neo4jHttpIT {
 		writer.close();
 	}
 
+	@Test public void shouldCommitAnEmptyTransaction() throws SQLException {
+		// Connect (autoCommit = false)
+		try (Connection connection = DriverManager.getConnection(getJDBCUrl())) {
+			connection.setAutoCommit(false);
+
+			connection.commit();
+		}
+	}
+
 	@Test public void shouldRollbackAnEmptyTransaction() throws SQLException {
 		// Connect (autoCommit = false)
 		try (Connection connection = DriverManager.getConnection(getJDBCUrl())) {

--- a/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/driver/CypherExecutorIT.java
+++ b/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/driver/CypherExecutorIT.java
@@ -75,31 +75,15 @@ public class CypherExecutorIT extends Neo4jHttpIT {
 		assertEquals(2, response.results.get(0).rows.size());
 	}
 
-	@Test public void rollbackClosedTransactionShouldFail() throws SQLException {
-		expectedEx.expect(SQLException.class);
-
+	@Test public void shouldRollbackAnEmptyTransaction() throws SQLException {
 		executor.setAutoCommit(Boolean.FALSE);
-		String randomLabel = "Test" + UUID.randomUUID();
-		executor.executeQuery(new Neo4jStatement("CREATE (:`" + randomLabel + "` {value:1})", null, Boolean.FALSE));
-		executor.executeQuery(new Neo4jStatement("CREATE (:`" + randomLabel + "` {value:2})", null, Boolean.FALSE));
-		executor.commit();
 
 		executor.rollback();
 	}
 
-	@Test public void rollbackOnAutocommitShouldFail() throws SQLException {
-		expectedEx.expect(SQLException.class);
+	@Test public void shouldCommitAnEmptyTransaction() throws SQLException {
+		executor.setAutoCommit(Boolean.FALSE);
 
-		String randomLabel = "Test" + UUID.randomUUID();
-		executor.executeQuery(new Neo4jStatement("CREATE (:`" + randomLabel + "` {value:1})", null, Boolean.FALSE));
-		executor.rollback();
-	}
-
-	@Test public void commitOnAutocommitShouldFail() throws SQLException {
-		expectedEx.expect(SQLException.class);
-
-		String randomLabel = "Test" + UUID.randomUUID();
-		executor.executeQuery(new Neo4jStatement("CREATE (:`" + randomLabel + "` {value:1})", null, Boolean.FALSE));
 		executor.commit();
 	}
 


### PR DESCRIPTION
This PR adds integration tests showing bug #62 (i.e. the behavior differs between the Bolt and HTTP drivers) and also proposes a fix in a second commit.
