### PR TITLE
change the determine of "BoltPreparedStatement.hasResultSet()" from c…

### DIFF
--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltPreparedStatement.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltPreparedStatement.java
@@ -118,7 +118,7 @@ public class BoltPreparedStatement extends PreparedStatement implements Loggable
 	}
 
 	private boolean hasResultSet() {
-		return this.statement != null && this.statement.toLowerCase().contains("return");
+		return this.statement != null && this.statement.toLowerCase().contains(" return ");
 	}
 	
 	@Override public ParameterMetaData getParameterMetaData() throws SQLException {


### PR DESCRIPTION
if I commit a "create" statement that the node has a property named "returnTime",the bolt jdbc would not 
 execute I expected.