### PR TITLE
fixes #96

### DIFF
--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltPreparedStatement.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltPreparedStatement.java
@@ -75,7 +75,7 @@ public class BoltPreparedStatement extends PreparedStatement implements Loggable
 	@Override public boolean execute() throws SQLException {
 		StatementResult result = executeInternal();
 
-		boolean hasResultSet = hasResultSet();
+		boolean hasResultSet = hasResultSet(result);
 		if (hasResultSet) {
 			this.currentResultSet = InstanceFactory.debug(BoltResultSet.class, new BoltResultSet(this,result, this.rsParams), this.isLoggable());
 			this.currentUpdateCount = -1;
@@ -118,14 +118,17 @@ public class BoltPreparedStatement extends PreparedStatement implements Loggable
 		return result;
 	}
 
-	private boolean hasResultSet() {
-		return this.statement != null && this.statement.toLowerCase().contains("return");
+	private boolean hasResultSet(StatementResult result) {
+		try {
+			return result != null && result.hasNext();
+		} catch (Exception e) {
+			return false;
+		}
 	}
 	
 	@Override public ParameterMetaData getParameterMetaData() throws SQLException {
 		this.checkClosed();
-		ParameterMetaData pmd = new BoltParameterMetaData(this);
-		return pmd;
+		return new BoltParameterMetaData(this);
 	}
 
 	@Override public ResultSetMetaData getMetaData() throws SQLException {

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltPreparedStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltPreparedStatementIT.java
@@ -110,7 +110,12 @@ public class BoltPreparedStatementIT {
 		statement.setString(1, "test");
 		boolean result = statement.execute();
 		assertTrue(result);
-
+		ResultSet resultSet = statement.getResultSet();
+		assertTrue(resultSet.next());
+		assertEquals("testAgain", resultSet.getString("n.surname"));
+		assertFalse(resultSet.next());
+		resultSet.close();
+		statement.close();
 		connection.close();
 		neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CLEAR_DB);
 	}


### PR DESCRIPTION
In order to check if the cypher statement has a result set we try to call `StatementResult.hasNext`. If `NoSuchRecordException` is thrown whether we have an empty result set or we don't have it at all: in both cases `BoltPreparedStatement.execute` will return `false`.