### PR TITLE
issue #87 - fixed error when using DriverManager.

### DIFF
--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltDriverTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltDriverTest.java
@@ -80,7 +80,7 @@ import static org.mockito.Mockito.mock;
 		assertNull(driver.connect("jdbc:neo4j:http://localhost:7474", null));
 		assertNull(driver.connect("bolt://localhost:7474", null));
 		assertNull(driver.connect("jdbcbolt://localhost:7474", null));
-		assertNull(driver.connect("jdbc:mysql:http://localhost:7474", null));
+		assertNull(driver.connect("jdbc:mysql://localhost:3306/sakila", null));
 	}
 
 	@Test public void shouldConnectThrowExceptionOnNullURL() throws SQLException {

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltDriverTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltDriverTest.java
@@ -80,6 +80,7 @@ import static org.mockito.Mockito.mock;
 		assertNull(driver.connect("jdbc:neo4j:http://localhost:7474", null));
 		assertNull(driver.connect("bolt://localhost:7474", null));
 		assertNull(driver.connect("jdbcbolt://localhost:7474", null));
+		assertNull(driver.connect("jdbc:mysql:http://localhost:7474", null));
 	}
 
 	@Test public void shouldConnectThrowExceptionOnNullURL() throws SQLException {

--- a/neo4j-jdbc-driver/src/main/java/org/neo4j/jdbc/Driver.java
+++ b/neo4j-jdbc-driver/src/main/java/org/neo4j/jdbc/Driver.java
@@ -30,6 +30,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 public class Driver extends BaseDriver {
@@ -52,7 +53,11 @@ public class Driver extends BaseDriver {
 	}
 
 	@Override public Connection connect(String url, Properties info) throws SQLException {
-		return getDriver(url).connect(url, info);
+		Connection connection = null;
+		if(!Objects.isNull(getDriver(url))) {
+			connection = getDriver(url).connect(url, info);
+		}
+		return connection;
 	}
 
 	/**
@@ -86,10 +91,6 @@ public class Driver extends BaseDriver {
 			}
 		} catch (Exception e) {
 			throw new SQLException(e);
-		}
-
-		if (driver == null) {
-			throw new SQLException("Cannot find a suitable driver from the url " + url);
 		}
 
 		return driver;

--- a/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/HttpDriver.java
+++ b/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/HttpDriver.java
@@ -64,8 +64,6 @@ public class HttpDriver extends BaseDriver {
 					port = neo4jUrl.getPort();
 				}
 				connection = InstanceFactory.debug(HttpConnection.class, new HttpConnection(host, port, secure, props, url), HttpConnection.hasDebug(props));
-			} else {
-				throw new SQLException("JDBC URL is not correct.\nA valid URL format is: 'jdbc:neo4j:http://<host>:<port>'");
 			}
 		} catch (MalformedURLException e) {
 			throw new SQLException(e);

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/BaseDriverTest.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/BaseDriverTest.java
@@ -33,8 +33,8 @@ public class BaseDriverTest {
         assertTrue(baseDriver.acceptsURL("jdbc:neo4j:http://localhost:7373?noSSL"));
         assertTrue(baseDriver.acceptsURL("jdbc:neo4j:http://localhost:7373?user=neo4j"));
         assertTrue(baseDriver.acceptsURL("jdbc:neo4j:http://localhost:7373?user=neo4j,password=test"));
-        assertFalse(baseDriver.acceptsURL("jdbc:mysql:http://localhost:7373"));
-        assertFalse(baseDriver.acceptsURL("jdbc:postgres:http://localhost:7373"));
+        assertFalse(baseDriver.acceptsURL("jdbc:mysql://localhost:3306/sakila"));
+        assertFalse(baseDriver.acceptsURL("jdbc:postgresql://localhost/test"));
     }
 
     @Test

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/BaseDriverTest.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/BaseDriverTest.java
@@ -33,6 +33,8 @@ public class BaseDriverTest {
         assertTrue(baseDriver.acceptsURL("jdbc:neo4j:http://localhost:7373?noSSL"));
         assertTrue(baseDriver.acceptsURL("jdbc:neo4j:http://localhost:7373?user=neo4j"));
         assertTrue(baseDriver.acceptsURL("jdbc:neo4j:http://localhost:7373?user=neo4j,password=test"));
+        assertFalse(baseDriver.acceptsURL("jdbc:mysql:http://localhost:7373"));
+        assertFalse(baseDriver.acceptsURL("jdbc:postgres:http://localhost:7373"));
     }
 
     @Test


### PR DESCRIPTION
- Added assertions to unit tests to check also non neo4j urls.
- Added an integration test to check if the desired behaviour is met.
- Fixed methods in HTTP and BOLT to solve the issue