### PR TITLE
Upgrade Bolt driver to 1.5.0

### DIFF
--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltConnectionTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltConnectionTest.java
@@ -24,20 +24,32 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.Mockito;
 import org.neo4j.driver.internal.NetworkSession;
 import org.neo4j.driver.internal.logging.DevNullLogging;
-import org.neo4j.driver.internal.spi.*;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.jdbc.bolt.data.StatementData;
 
-import java.sql.*;
 import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.neo4j.jdbc.bolt.utils.Mocker.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.neo4j.jdbc.bolt.utils.Mocker.mockSessionClosed;
+import static org.neo4j.jdbc.bolt.utils.Mocker.mockSessionException;
+import static org.neo4j.jdbc.bolt.utils.Mocker.mockSessionOpen;
+import static org.neo4j.jdbc.bolt.utils.Mocker.mockSessionOpenSlow;
 
 /**
  * @author AgileLARUS
@@ -118,20 +130,6 @@ public class BoltConnectionTest {
 		connection.close();
 		verify(session, never()).close();
 		assertTrue(connection.isClosed());
-	}
-
-	@Ignore
-	@Test public void closeShouldThrowExceptionWhenDatabaseAccessErrorOccurred() throws SQLException {
-		expectedEx.expect(SQLException.class);
-
-		PooledConnection boltConnection = Mockito.mock(PooledConnection.class);
-		doThrow(new IllegalStateException()).when(boltConnection).close();
-		ConnectionProvider connectionProvider = Mockito.mock(ConnectionProvider.class);
-		when(connectionProvider.acquireConnection(AccessMode.READ)).thenReturn(boltConnection);
-		Session session = new NetworkSession(connectionProvider, AccessMode.READ, null, DevNullLogging.DEV_NULL_LOGGING);
-		session.run("return 1");
-		Connection connection = new BoltConnection(session);
-		connection.close();
 	}
 
 	/*------------------------------*/

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltDriverTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltDriverTest.java
@@ -32,8 +32,8 @@ import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.AuthTokens;
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Session;
 import org.neo4j.jdbc.BaseDriver;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -41,9 +41,12 @@ import java.sql.Connection;
 import java.sql.SQLException;
 
 import static junit.framework.TestCase.assertFalse;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author AgileLARUS
@@ -58,7 +61,8 @@ import static org.mockito.Mockito.mock;
 	@BeforeClass public static void initialize() {
 		mockedDriver = mock(org.neo4j.driver.v1.Driver.class);
 		ConnectionProvider connectionProvider = mock(ConnectionProvider.class, RETURNS_MOCKS);
-		Mockito.when(mockedDriver.session()).thenReturn(new NetworkSession(connectionProvider, AccessMode.READ,null, DevNullLogging.DEV_NULL_LOGGING));
+		Session session = mock(Session.class, RETURNS_MOCKS);
+		when(mockedDriver.session()).thenReturn(session);
 	}
 
 	/*------------------------------*/
@@ -67,10 +71,10 @@ import static org.mockito.Mockito.mock;
 	//WARNING!! NOT COMPLETE TEST!! Needs tests for parameters
 
 	@Test public void shouldConnectCreateConnection() throws SQLException {
-		PowerMockito.mockStatic(GraphDatabase.class);
-		Mockito.when(GraphDatabase.driver(Mockito.eq("bolt://test"), Mockito.eq(AuthTokens.none()),Mockito.any(Config.class))).thenReturn(mockedDriver);
+		Neo4jDriverSupplier supplier = mock(Neo4jDriverSupplier.class);
+		when(supplier.supply(Mockito.eq("bolt://test"), Mockito.eq(AuthTokens.none()), Mockito.any(Config.class))).thenReturn(mockedDriver);
 
-		BaseDriver driver = new BoltDriver();
+		BaseDriver driver = new BoltDriver(supplier);
 		Connection connection = driver.connect("jdbc:neo4j:bolt://test", null);
 		assertNotNull(connection);
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<powermock.version>1.6.5</powermock.version>
 		<junit.version>4.12</junit.version>
 		<jmh.version>1.19</jmh.version>
-		<neo4j.java.driver.version>1.3.0</neo4j.java.driver.version>
+		<neo4j.java.driver.version>1.5.0</neo4j.java.driver.version>
 		<neo4j.version>3.1.4</neo4j.version>
 		<httpclient.version>4.5.3</httpclient.version>
 		<jackson.version>2.8.8</jackson.version>


### PR DESCRIPTION
I could not run the performance tests:

```
java.lang.IllegalStateException: failed to create a child event loop
	at org.neo4j.driver.internal.shaded.io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:88)
	at org.neo4j.driver.internal.shaded.io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:58)
	at org.neo4j.driver.internal.shaded.io.netty.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:52)
	at org.neo4j.driver.internal.shaded.io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:87)
	at org.neo4j.driver.internal.shaded.io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:82)
	at org.neo4j.driver.internal.shaded.io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:63)
	at org.neo4j.driver.internal.shaded.io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:51)
	at org.neo4j.driver.internal.shaded.io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:43)
	at org.neo4j.driver.internal.async.EventLoopGroupFactory$DriverEventLoopGroup.<init>(EventLoopGroupFactory.java:117)
	at org.neo4j.driver.internal.async.EventLoopGroupFactory.newEventLoopGroup(EventLoopGroupFactory.java:78)
	at org.neo4j.driver.internal.async.BootstrapFactory.newBootstrap(BootstrapFactory.java:33)
	at org.neo4j.driver.internal.DriverFactory.createBootstrap(DriverFactory.java:244)
	at org.neo4j.driver.internal.DriverFactory.newInstance(DriverFactory.java:76)
	at org.neo4j.driver.v1.GraphDatabase.driver(GraphDatabase.java:136)
	at org.neo4j.driver.v1.GraphDatabase.driver(GraphDatabase.java:119)
	at org.neo4j.driver.v1.GraphDatabase.driver(GraphDatabase.java:94)
	at org.neo4j.jdbc.bolt.SamplePT.testSimpleQueryBoltDriver(SamplePT.java:101)
	at org.neo4j.jdbc.bolt.generated.SamplePT_testSimpleQueryBoltDriver_jmhTest.testSimpleQueryBoltDriver_avgt_jmhStub(SamplePT_testSimpleQueryBoltDriver_jmhTest.java:191)
	at org.neo4j.jdbc.bolt.generated.SamplePT_testSimpleQueryBoltDriver_jmhTest.testSimpleQueryBoltDriver_AverageTime(SamplePT_testSimpleQueryBoltDriver_jmhTest.java:154)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.neo4j.driver.internal.shaded.io.netty.channel.ChannelException: failed to open a new selector
	at org.neo4j.driver.internal.shaded.io.netty.channel.nio.NioEventLoop.openSelector(NioEventLoop.java:175)
	at org.neo4j.driver.internal.shaded.io.netty.channel.nio.NioEventLoop.<init>(NioEventLoop.java:149)
	at org.neo4j.driver.internal.shaded.io.netty.channel.nio.NioEventLoopGroup.newChild(NioEventLoopGroup.java:127)
	at org.neo4j.driver.internal.shaded.io.netty.channel.nio.NioEventLoopGroup.newChild(NioEventLoopGroup.java:36)
	at org.neo4j.driver.internal.shaded.io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:84)
	... 30 more
Caused by: java.io.IOException: Too many open files in system
	at sun.nio.ch.IOUtil.makePipe(Native Method)
	at sun.nio.ch.KQueueSelectorImpl.<init>(KQueueSelectorImpl.java:84)
	at sun.nio.ch.KQueueSelectorProvider.openSelector(KQueueSelectorProvider.java:42)
	at org.neo4j.driver.internal.shaded.io.netty.channel.nio.NioEventLoop.openSelector(NioEventLoop.java:173)
	... 34 more
```