### PR TITLE
Fix #143

### DIFF
--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSet.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSet.java
@@ -487,13 +487,17 @@ public class BoltNeo4jResultSet extends Neo4jResultSet {
 	@Override public Neo4jArray getArray(int columnIndex) throws SQLException {
 		checkClosed();
 		List<Object> list = this.fetchValueFromIndex(columnIndex).asList();
-		return new ListArray(list, Neo4jArray.getObjectType(list.get(0)));
+		Object obj = (list.isEmpty())?new Object():list.get(0);
+
+		return new ListArray(list, Neo4jArray.getObjectType(obj));
 	}
 
 	@SuppressWarnings("rawtypes") @Override public Neo4jArray getArray(String columnLabel) throws SQLException {
 		checkClosed();
 		List list = this.fetchValueFromLabel(columnLabel).asList();
-		return new ListArray(list, Neo4jArray.getObjectType(list.get(0)));
+		Object obj = (list.isEmpty())?new Object():list.get(0);
+
+		return new ListArray(list, Neo4jArray.getObjectType(obj));
 	}
 
 	@Override public double getDouble(String columnLabel) throws SQLException {

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jStatementIT.java
@@ -19,19 +19,6 @@
  */
 package org.neo4j.jdbc.bolt;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.sql.BatchUpdateException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,6 +26,10 @@ import org.junit.rules.ExpectedException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.jdbc.Neo4jResultSet;
 import org.neo4j.jdbc.bolt.data.StatementData;
+
+import java.sql.*;
+
+import static org.junit.Assert.*;
 
 /**
  * @author AgileLARUS
@@ -252,6 +243,78 @@ public class BoltNeo4jStatementIT {
 			statement.close();
 
 			assertTrue(((BoltNeo4jConnection) connection).getTransaction().isOpen());
+		}
+	}
+
+	/*
+	Array
+	 */
+
+	@Test public void testGetEmptyArrayByIndex() throws SQLException {
+		try (Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl")) {
+			connection.setAutoCommit(true);
+
+			Statement statement = connection.createStatement();
+			statement.execute("RETURN [] AS result");
+
+			ResultSet resultSet = statement.getResultSet();
+			resultSet.next();
+			Array array = resultSet.getArray(1);
+			Object[] arrayResult = (Object[]) array.getArray();
+			assertEquals(0, arrayResult.length);
+
+			statement.close();
+		}
+	}
+
+	@Test public void testGetEmptyArrayByName() throws SQLException {
+		try (Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl")) {
+			connection.setAutoCommit(true);
+
+			Statement statement = connection.createStatement();
+			statement.execute("RETURN [] AS result");
+
+			ResultSet resultSet = statement.getResultSet();
+			resultSet.next();
+			Array array = resultSet.getArray("result");
+			Object[] arrayResult = (Object[]) array.getArray();
+			assertEquals(0, arrayResult.length);
+
+			statement.close();
+		}
+	}
+
+	@Test public void testGetOneArrayByIndex() throws SQLException {
+		try (Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl")) {
+			connection.setAutoCommit(true);
+
+			Statement statement = connection.createStatement();
+			statement.execute("RETURN [10] AS result");
+
+			ResultSet resultSet = statement.getResultSet();
+			resultSet.next();
+			Array array = resultSet.getArray(1);
+			Long[] arrayResult = (Long[]) array.getArray();
+			assertEquals(new Long(10), arrayResult[0]);
+
+			statement.close();
+		}
+	}
+
+	@Test public void testGetOneArrayByName() throws SQLException {
+		try (Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl")) {
+			connection.setAutoCommit(true);
+
+			Statement statement = connection.createStatement();
+			statement.execute("RETURN [10] AS result");
+
+			ResultSet resultSet = statement.getResultSet();
+			resultSet.next();
+			Array array = resultSet.getArray("result");
+			Long[] arrayResult = (Long[]) array.getArray();
+			assertEquals(new Long(10), arrayResult[0]);
+
+			statement.close();
 		}
 	}
 

--- a/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/HttpNeo4jResultSetMetaData.java
+++ b/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/HttpNeo4jResultSetMetaData.java
@@ -65,7 +65,7 @@ public class HttpNeo4jResultSetMetaData extends Neo4jResultSetMetaData {
 	}
 
 	@SuppressWarnings("unchecked") @Override public int getColumnType(int column) throws SQLException {
-		final Object object = ((List<Object>) this.result.getRows().get(0).get("row")).get(column - 1);
+		final Object object = extractObject(column);
 
 		if (object == null) {
 			return Types.NULL;
@@ -80,7 +80,7 @@ public class HttpNeo4jResultSetMetaData extends Neo4jResultSetMetaData {
 	}
 
 	@SuppressWarnings("unchecked") @Override public String getColumnClassName(int column) throws SQLException {
-		final Object object = ((List<Object>) this.result.getRows().get(0).get("row")).get(column - 1);
+		final Object object = extractObject(column);
 
 		if (object == null) {
 			return null;
@@ -92,5 +92,41 @@ public class HttpNeo4jResultSetMetaData extends Neo4jResultSetMetaData {
 		}
 		return Object.class.getName();
 	}
+
+	/**
+	 * Safe method to get the object at column index. Null if cannot extract it.
+	 * @param column
+	 * @return
+	 */
+	private Object extractObject(int column) {
+		if(this.result == null){
+			return null;
+		}
+
+		if(this.result.getRows() == null || this.result.getRows().isEmpty()){
+			return null;
+		}
+
+		Map map = this.result.getRows().get(0);
+
+		if (!map.containsKey("row")){
+			return null;
+		}
+
+		Object row = map.get("row");
+
+		if (! (row instanceof List)){
+			return null;
+		}
+
+		List<Object> rowList = (List<Object>) row;
+
+		if (rowList.size() < column){
+			return null;
+		}
+
+		return rowList.get(column - 1);
+	}
+
 }
 

--- a/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/HttpNeo4jResultSetIT.java
+++ b/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/HttpNeo4jResultSetIT.java
@@ -92,4 +92,75 @@ public class HttpNeo4jResultSetIT extends Neo4jHttpITUtil {
 		assertFalse(rs.next());
 		connection.close();
 	}
+
+	/*
+	Array
+	 */
+
+	@Test public void testGetEmptyArrayByIndex() throws SQLException {
+		Connection connection = DriverManager.getConnection(getJDBCUrl());
+		connection.setAutoCommit(true);
+
+		Statement statement = connection.createStatement();
+		statement.execute("RETURN [] AS result");
+
+		ResultSet resultSet = statement.getResultSet();
+		resultSet.next();
+		Array array = resultSet.getArray(1);
+		Object[] arrayResult = (Object[]) array.getArray();
+		assertEquals(0, arrayResult.length);
+
+		statement.close();
+
+	}
+
+	@Test public void testGetEmptyArrayByName() throws SQLException {
+		Connection connection = DriverManager.getConnection(getJDBCUrl());
+		connection.setAutoCommit(true);
+
+		Statement statement = connection.createStatement();
+		statement.execute("RETURN [] AS result");
+
+		ResultSet resultSet = statement.getResultSet();
+		resultSet.next();
+		Array array = resultSet.getArray("result");
+		Object[] arrayResult = (Object[]) array.getArray();
+		assertEquals(0, arrayResult.length);
+
+		statement.close();
+	}
+
+	@Test public void testGetOneArrayByIndex() throws SQLException {
+		Connection connection = DriverManager.getConnection(getJDBCUrl());
+		connection.setAutoCommit(true);
+
+		Statement statement = connection.createStatement();
+		statement.execute("RETURN [10] AS result");
+
+		ResultSet resultSet = statement.getResultSet();
+		resultSet.next();
+		Array array = resultSet.getArray(1);
+		Long[] arrayResult = (Long[]) array.getArray();
+		assertEquals(new Long(10), arrayResult[0]);
+
+		statement.close();
+
+	}
+
+	@Test public void testGetOneArrayByName() throws SQLException {
+		Connection connection = DriverManager.getConnection(getJDBCUrl());
+		connection.setAutoCommit(true);
+
+		Statement statement = connection.createStatement();
+		statement.execute("RETURN [10] AS result");
+
+		ResultSet resultSet = statement.getResultSet();
+		resultSet.next();
+		Array array = resultSet.getArray("result");
+		Long[] arrayResult = (Long[]) array.getArray();
+		assertEquals(new Long(10), arrayResult[0]);
+
+		statement.close();
+	}
+
 }


### PR DESCRIPTION
Fix #143  - HttpNeo4jResultSetMetaData NPE for empty resultsets

Managed the `<something>.get(0).<npe_risk>` case in some points in order to reduce the NullPointerException during the execution.