### PR TITLE
Fix 141

### DIFF
--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementIT.java
@@ -19,23 +19,14 @@
  */
 package org.neo4j.jdbc.bolt;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.sql.BatchUpdateException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.graphdb.Result;
 import org.neo4j.jdbc.bolt.data.StatementData;
+
+import java.sql.*;
+
+import static org.junit.Assert.*;
 
 /**
  * @author AgileLARUS
@@ -51,7 +42,7 @@ public class BoltNeo4jPreparedStatementIT {
 
 	@Test public void executeQueryShouldExecuteAndReturnCorrectData() throws SQLException {
 		neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CREATE_TWO_PROPERTIES);
-		Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl");
+		Connection connection = getConnection();
 		PreparedStatement statement = connection.prepareStatement(StatementData.STATEMENT_MATCH_ALL_STRING_PARAMETRIC);
 		statement.setString(1, "test");
 		ResultSet rs = statement.executeQuery();
@@ -65,7 +56,7 @@ public class BoltNeo4jPreparedStatementIT {
 
 	@Test public void executeQueryWithNamedParamShouldExecuteAndReturnCorrectData() throws SQLException {
 		neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CREATE_TWO_PROPERTIES);
-		Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl");
+		Connection connection = getConnection();
 		PreparedStatement statement = connection.prepareStatement(StatementData.STATEMENT_MATCH_ALL_STRING_PARAMETRIC_NAMED);
 		statement.setString(1, "test");
 		ResultSet rs = statement.executeQuery();
@@ -81,7 +72,7 @@ public class BoltNeo4jPreparedStatementIT {
 	/*         executeUpdate        */
 	/*------------------------------*/
 	@Test public void executeUpdateShouldExecuteAndReturnCorrectData() throws SQLException {
-		Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl");
+		Connection connection = getConnection();
 		PreparedStatement statement = connection.prepareStatement(StatementData.STATEMENT_CREATE_TWO_PROPERTIES_PARAMETRIC);
 		statement.setString(1, "test1");
 		statement.setString(2, "test2");
@@ -105,7 +96,7 @@ public class BoltNeo4jPreparedStatementIT {
 	/*------------------------------*/
 	@Test public void executeShouldExecuteAndReturnTrue() throws SQLException {
 		neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CREATE_TWO_PROPERTIES);
-		Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl");
+		Connection connection = getConnection();
 		PreparedStatement statement = connection.prepareStatement(StatementData.STATEMENT_MATCH_ALL_STRING_PARAMETRIC);
 		statement.setString(1, "test");
 		boolean result = statement.execute();
@@ -121,7 +112,7 @@ public class BoltNeo4jPreparedStatementIT {
 	}
 
 	@Test public void executeShouldExecuteAndReturnFalse() throws SQLException {
-		Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl");
+		Connection connection = getConnection();
 		PreparedStatement statement = connection.prepareStatement(StatementData.STATEMENT_CREATE_TWO_PROPERTIES_PARAMETRIC);
 		statement.setString(1, "test1");
 		statement.setString(2, "test2");
@@ -143,7 +134,7 @@ public class BoltNeo4jPreparedStatementIT {
 	/*         executeBatch         */
 	/*------------------------------*/
 	@Test public void executeBatchShouldWork() throws SQLException {
-		Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl");
+		Connection connection = getConnection();
 		PreparedStatement statement = connection.prepareStatement(StatementData.STATEMENT_CREATE_TWO_PROPERTIES_PARAMETRIC);
 		connection.setAutoCommit(true);
 		statement.setString(1, "test1");
@@ -166,7 +157,7 @@ public class BoltNeo4jPreparedStatementIT {
 	}
 
 	@Test public void executeBatchShouldWorkWhenError() throws SQLException {
-		Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl");
+		Connection connection = getConnection();
 		connection.setAutoCommit(true);
 		PreparedStatement statement = connection.prepareStatement("wrong cypher statement ?");
 		statement.setString(1, "test1");
@@ -189,7 +180,7 @@ public class BoltNeo4jPreparedStatementIT {
 	}
 
 	@Test public void executeBatchShouldWorkWithTransaction() throws SQLException {
-		Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl");
+		Connection connection = getConnection();
 		PreparedStatement statement = connection.prepareStatement(StatementData.STATEMENT_CREATE_TWO_PROPERTIES_PARAMETRIC);
 		connection.setAutoCommit(false);
 		statement.setString(1, "test1");
@@ -220,6 +211,10 @@ public class BoltNeo4jPreparedStatementIT {
 
 		neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CLEAR_DB);
 		connection.close();
+	}
+
+	private Connection getConnection() throws SQLException {
+		return DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl");
 	}
 }
 

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementIT.java
@@ -25,6 +25,7 @@ import org.neo4j.graphdb.Result;
 import org.neo4j.jdbc.bolt.data.StatementData;
 
 import java.sql.*;
+import java.util.Enumeration;
 
 import static org.junit.Assert.*;
 
@@ -47,7 +48,23 @@ public class BoltNeo4jPreparedStatementIT {
 	}
 
 	// 'a_' only to force execution at first position
-	@Test public void a_shouldHasTheDriver() throws SQLException {
+	@Test public void a_warmup() throws SQLException {
+
+
+		// WARM UP
+
+		long t0 = System.currentTimeMillis();
+		boolean driverLoaded = false;
+		while (!driverLoaded && System.currentTimeMillis() - t0 < 10_000){
+			Enumeration<Driver> drivers = DriverManager.getDrivers();
+			while (drivers.hasMoreElements()){
+				if(BoltDriver.class.equals(drivers.nextElement().getClass())){
+					driverLoaded = true;
+				}
+			}
+		}
+
+
 		Driver driver = DriverManager.getDriver("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl");
 		Assert.assertEquals(BoltDriver.class,driver.getClass());
 	}

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementIT.java
@@ -19,8 +19,8 @@
  */
 package org.neo4j.jdbc.bolt;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.runners.MethodSorters;
 import org.neo4j.graphdb.Result;
 import org.neo4j.jdbc.bolt.data.StatementData;
 
@@ -32,6 +32,7 @@ import static org.junit.Assert.*;
  * @author AgileLARUS
  * @since 3.0.0
  */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class BoltNeo4jPreparedStatementIT {
 
 	@ClassRule public static Neo4jBoltRule neo4j = new Neo4jBoltRule();
@@ -39,6 +40,17 @@ public class BoltNeo4jPreparedStatementIT {
 	/*------------------------------*/
 	/*          executeQuery        */
 	/*------------------------------*/
+
+	@Before
+	public void cleanDB(){
+		neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CLEAR_DB);
+	}
+
+	// 'a_' only to force execution at first position
+	@Test public void a_shouldHasTheDriver() throws SQLException {
+		Driver driver = DriverManager.getDriver("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl");
+		Assert.assertEquals(BoltDriver.class,driver.getClass());
+	}
 
 	@Test public void executeQueryShouldExecuteAndReturnCorrectData() throws SQLException {
 		neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CREATE_TWO_PROPERTIES);

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSetIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSetIT.java
@@ -27,6 +27,7 @@ import org.neo4j.jdbc.bolt.data.StatementData;
 import java.sql.*;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -130,4 +131,17 @@ public class BoltNeo4jResultSetIT {
 		con.close();
 	}
 
+	@Test public void shouldHasntNext() throws SQLException {
+		neo4j.getGraphDatabase().execute("unwind range(1,5) as x create (:User{number:x})");
+
+		Connection con = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl");
+		Statement stmt = con.createStatement();
+		ResultSet rs = stmt.executeQuery("MATCH (x:XXX) RETURN x LIMIT 1");
+
+		assertFalse(rs.next());
+
+		rs.close();
+
+		con.close();
+	}
 }

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/ExecutePT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/ExecutePT.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2016 LARUS Business Automation [http://www.larus-ba.it]
+ * <p>
+ * This file is part of the "LARUS Integration Framework for Neo4j".
+ * <p>
+ * The "LARUS Integration Framework for Neo4j" is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p>
+ * Created on 14/03/16
+ */
+package org.neo4j.jdbc.bolt;
+
+import org.junit.Test;
+import org.neo4j.jdbc.bolt.data.PerformanceTestData;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.io.IOException;
+import java.sql.*;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author AgileLARUS
+ * @since 3.3
+ * Created by the issue #141
+ */
+public class ExecutePT {
+
+	@Test public void launchBenchmark() throws Exception {
+		PerformanceTestData.loadABCXYData();
+
+		// @formatter:off
+		Options opt = new OptionsBuilder()
+				.include(this.getClass().getName() + ".*")
+				.mode(Mode.AverageTime)
+				.timeUnit(TimeUnit.MICROSECONDS)
+				//Warmup
+				//.warmupTime(TimeValue.seconds(1))
+				.warmupIterations(1)
+				//Measurement
+				.measurementTime(TimeValue.seconds(1))
+				.measurementIterations(10)
+				.threads(1)
+				.forks(1)
+				.shouldFailOnError(true)
+				//.shouldDoGC(true)
+				//.jvmArgs("-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining")
+				//.addProfiler(WinPerfAsmProfiler.class)
+				.build();
+
+		new Runner(opt).run();
+	}
+
+	@State(Scope.Thread) public static class Data {
+
+		@Setup public void initialize() throws ClassNotFoundException, SQLException, IOException {
+			connection = PerformanceTestData.getConnection();
+			stmt = connection.prepareStatement(query);
+			stmt.setLong(1, (long)(Math.random() * 100));
+		}
+
+		@TearDown public void close() throws ClassNotFoundException, SQLException, IOException {
+			stmt.close();
+			connection.close();
+		}
+
+
+		public String query = "MATCH (n:A {prop: ?}) RETURN n as NODO, id(n) as ID, n.prop as PROP LIMIT 2;";
+		public Connection connection;
+		public PreparedStatement stmt;
+	}
+
+	@Benchmark public void testExecuteNoMetadata(Data data, Blackhole bh) throws ClassNotFoundException, SQLException {
+		PreparedStatement stmt = data.stmt;
+
+		stmt.execute();
+		ResultSet resultSet = stmt.getResultSet();
+
+		while(resultSet.next()){
+			resultSet.getObject(1);
+		}
+
+		resultSet.close();
+	}
+
+	@Benchmark public void testExecuteQueryNoMetadata(Data data, Blackhole bh) throws ClassNotFoundException, SQLException {
+		PreparedStatement stmt = data.stmt;
+
+		ResultSet resultSet = stmt.executeQuery();
+
+		while(resultSet.next()){
+			resultSet.getObject(1);
+		}
+
+		resultSet.close();
+	}
+
+	@Benchmark public void testExecuteQueryWithMetadata(Data data, Blackhole bh) throws ClassNotFoundException, SQLException {
+		PreparedStatement stmt = data.stmt;
+
+		ResultSet resultSet = stmt.executeQuery();
+		ResultSetMetaData metaData = resultSet.getMetaData();
+
+		int columnCount = metaData.getColumnCount();
+		for(int c=1; c<=columnCount;c++){
+			metaData.getColumnName(c);
+			metaData.getColumnType(c);
+			metaData.getColumnLabel(c);
+			metaData.getColumnClassName(c);
+		}
+
+		while(resultSet.next()){
+			resultSet.getObject("NODO");
+			resultSet.getObject("PROP");
+			resultSet.getObject("ID");
+		}
+
+		resultSet.close();
+	}
+
+	@Benchmark public void testExecuteWithMetadata(Data data, Blackhole bh) throws ClassNotFoundException, SQLException {
+		PreparedStatement stmt = data.stmt;
+
+		stmt.execute();
+		ResultSet resultSet = stmt.getResultSet();
+		ResultSetMetaData metaData = resultSet.getMetaData();
+
+		int columnCount = metaData.getColumnCount();
+		for(int c=1; c<=columnCount;c++){
+			metaData.getColumnName(c);
+			metaData.getColumnType(c);
+			metaData.getColumnLabel(c);
+			metaData.getColumnClassName(c);
+		}
+
+		while(resultSet.next()){
+			resultSet.getObject("NODO");
+			resultSet.getObject("PROP");
+			resultSet.getObject("ID");
+		}
+
+		resultSet.close();
+	}
+
+}

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/data/PerformanceTestData.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/data/PerformanceTestData.java
@@ -1,0 +1,56 @@
+package org.neo4j.jdbc.bolt.data;
+
+import java.sql.*;
+
+/**
+ * An utility to manage the external database for the Performance Tests
+ */
+public class PerformanceTestData {
+
+    public static final String NEO_URL = "jdbc:neo4j:bolt://localhost:7687?user=neo4j,password=test";
+
+    /**
+     * Get a new connection to the external database
+     * @return
+     * @throws SQLException
+     */
+    public static Connection getConnection() throws SQLException {
+        return DriverManager.getConnection(NEO_URL);
+    }
+
+    /**
+     * Fill, if needed, the test random data.
+     * (:A)-[:X]->(:B)-[:Y]->(:C)
+     * @return true if the DB was empty and the load run
+     * @throws SQLException
+     */
+    public static boolean loadABCXYData() throws SQLException {
+        Connection conn = getConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("MATCH (n) RETURN n LIMIT 1");
+        boolean hasDataLoaded = rs.next();
+        rs.close();
+        if(hasDataLoaded){
+            Statement stmtCheck = conn.createStatement();
+            ResultSet checkRs = stmtCheck.executeQuery("MATCH (x:PerformanceTestData) RETURN x LIMIT 1");
+            boolean hasTestDataLoaded = checkRs.next();
+            if(!hasTestDataLoaded){
+                throw new IllegalStateException("The database is loaded without test data. Make sure you are using the correct db at "+NEO_URL);
+            }
+            stmtCheck.close();
+        } else{
+            for (int i = 0; i < 100; i++) {
+                stmt.executeQuery("CREATE (:A {prop:" + (int) (Math.random() * 100) + "})" + (Math.random() * 10 > 5 ?
+                        "-[:X]->(:B {prop:'" + (int) (Math.random() * 100) + "'})" :
+                        ""));
+            }
+            stmt.executeQuery("CREATE (:C)");
+            stmt.executeQuery("MATCH (b:B), (c:C) MERGE (c)<-[:Y]-(b)");
+            stmt.executeQuery("CREATE (x:PerformanceTestData {when: timestamp()})");
+            stmt.close();
+            conn.close();
+        }
+
+        return !hasDataLoaded;
+    }
+}

--- a/neo4j-jdbc-driver/src/main/java/org/neo4j/jdbc/Driver.java
+++ b/neo4j-jdbc-driver/src/main/java/org/neo4j/jdbc/Driver.java
@@ -31,7 +31,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 
 public class Driver extends Neo4jDriver {
@@ -58,7 +57,7 @@ public class Driver extends Neo4jDriver {
 
 	@Override public Connection connect(String url, Properties info) throws SQLException {
 		Connection connection = null;
-		if(!Objects.isNull(getDriver(url))) {
+		if(null != getDriver(url)) {
 			connection = getDriver(url).connect(url, info);
 		}
 		return connection;

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDataSource.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDataSource.java
@@ -24,7 +24,6 @@ import org.neo4j.jdbc.utils.ExceptionBuilder;
 import java.io.PrintWriter;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.util.Objects;
 import java.util.logging.Logger;
 
 /**
@@ -120,9 +119,9 @@ public abstract class Neo4jDataSource implements javax.sql.DataSource {
 		String url = NEO4J_JDBC_PREFIX + protocol + "://" + getServerName() + ((getPortNumber() > 0) ? ":" + getPortNumber() : "") + "?" + ((!getIsSsl()) ?
 				"nossl," :
 				"");
-		if (Objects.nonNull(getUser())) {
+		if (null != getUser()) {
 			url += "user=" + getUser();
-			if (Objects.nonNull(getPassword())) {
+			if (null != getPassword()) {
 				url += ",password=" + getPassword();
 			}
 		}


### PR DESCRIPTION
There are some tests proving there's not difference between `execute` and `executeQuery`.

The `selectAll` method in [SqlRunner](https://github.com/mybatis/mybatis-3/blob/mybatis-3.4.5/src/main/java/org/apache/ibatis/jdbc/SqlRunner.java) uses the `executeQuery` to run the cypher. Then the metadata are used to do the mapping. At this point there's the delay.

I suggest to change the mapping using the [resultMap](http://www.mybatis.org/mybatis-3/sqlmap-xml.html#Result_Maps) instead of the `resultType` to improve the performance.