### PR TITLE
Fix #136 - Support reading Temporal functions

### DIFF
--- a/neo4j-jdbc-bolt/README.adoc
+++ b/neo4j-jdbc-bolt/README.adoc
@@ -56,3 +56,88 @@ you will have only the columns (u, a) with flattening disabled;
 with flatten=1 you will have u, u.id, u.labels, u.username, a, a.id, a.type, a.age
 
 with flatten=-1 you will have u, u.id, u.labels, u.username, a, a.id, a.type, a.age, a.full_name
+
+== Temporal functions ==
+Since the 3.4 version you can get the temporal information stored in the database both as `java.sql.\*` typs and `java.time.*`.
+
+These methods are implemented to get temporal data:
+
+* `resultSet.getObject(int)` returns the `java.sql.` objects
+* `resultSet.getObject(String)` returns the `java.sql.` objects
+* `resultSet.getObject(int, Class)` returns the `java.time.` types, if you pass it.
+* `resultSet.getObject(String, Class)` returns the `java.time.` types, if you pass it.
+* `resultSet.getTimestamp` for `datetime()` and `localdatetime()`
+* `resultSet.getDate` for `date()`
+* `resultSet.getTime` for `time()` and `localtime()`
+
+.Java types for neo4j temporal functions
+|===
+|java.time | neo4j | java.sql
+
+|LocalDate | date() | Date
+
+|LocalTime | localtime() | Time
+
+|OffsetTime | time() | Time
+
+|LocalDateTime | localdatetime() | Timestamp
+
+|ZonedDateTime | datetime() | Timestamp
+
+|===
+
+=== Duration ===
+The Duration concept is not in the JDBC specifications, so you can retrieve it using:
+
+* `resultSet.getObject(int | String)` returns a `Map<String, Object>` with Long values for the keys: `'months', 'days','seconds', 'nanoseconds'`
+
+* `resultSet.getObject(int | String, org.neo4j.driver.v1.types.IsoDuration.class)` returns the internal object.
+
+
+=== Inside nodes, relationships or arrays ===
+When you retrieve a Node, Relationship or an array, the internal object created by a temporal function contains
+always a `java.sql` type value.
+
+E.g:
+```
+ResultSet rs = statement.executeQuery("CREATE (e:Event {when: [localdatetime('2015-12-31T19:32:24')] }) RETURN e AS event");
+
+rs.next();
+Map<String, Object> map = (Map)rs.getObject(1);
+Object whenField = map.get("when");
+List whenList = (List) whenField;
+
+java.sql.Timestamp when = (java.sql.Timestamp)whenList.get(0);
+```
+
+== Spatial functions ==
+Since the 3.4 version you can get the spatial information stored in the database both as `Map`.
+
+You can retrieve the spatial data using:
+
+* `resultSet.getObject(int | String)` returns a `Map<String, Object>`
+* `resultSet.getObject(int | String, org.neo4j.driver.v1.types.Point)` returns a `Point`
+
+.Keys for Spatial functions
+|===
+|neo4j | keys(value)
+
+| point({x, y}) | srid(7203), crs('cartesian'), x, y
+| point({x, y, z}) | srid(9157), crs('cartesian-3d'), x, y, z
+| point({latitude, longitude}) |  srid(4326), crs('wgs-84'), x, y, latitude, longitude
+| point({latitude, longitude, height}) |  srid(4979), crs('wgs-84-3d'), x, y, z, latitude, longitude, height
+|===
+
+=== Inside nodes, relationships or arrays ===
+When you retrieve a Node, Relationship or an array, the internal object created by a spatial function contains
+always a `Map<String, Object>`
+
+E.g:
+```
+ResultSet rs = statement.executeQuery("RETURN [point({ latitude: 12, longitude: 56, height: 4321 })] AS geo_3d");
+
+rs.next();
+Object points = rs.getObject(1);
+List pointList = (List) points;
+Map pointMap = (Map) point;
+```

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSet.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSet.java
@@ -40,6 +40,7 @@ import java.sql.Date;
 import java.sql.*;
 import java.time.*;
 import java.util.*;
+import java.util.concurrent.Callable;
 
 /**
  * @author AgileLARUS
@@ -674,33 +675,78 @@ public class BoltNeo4jResultSet extends Neo4jResultSet {
 	}
 
 	@Override public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+		try {
+			return getObject(type, ()-> this.fetchValueFromLabel(columnLabel), () -> this.getObject(columnLabel));
+		} catch (Exception e) {
+			throw new SQLException(e);
+		}
+	}
+
+	/**
+	 * Check if the argument is a internal data used by neo4j
+	 * @param type
+	 * @return
+	 */
+	private boolean isNeo4jDatatype(Class type){
+		return ObjectValueAdapter.class.isAssignableFrom(type);
+	}
+
+	private <T> T getObject (Class<T> type, Callable fetch, Callable getObject) throws Exception {
 		checkClosed();
 		if (type == null) {
 			throw new SQLException("Type to cast cannot be null");
 		}
-		Object obj = this.getObject(columnLabel);
-		T ret;
-		try {
-			ret = ObjectConverter.convert(obj, type);
-		} catch (Exception e) {
-			throw new SQLException(e);
+
+		if (isNeo4jDatatype(type)){
+			return (T) fetch.call();
 		}
-		return ret;
+
+		if (type == ZonedDateTime.class){
+			DateTimeValue value = (DateTimeValue) fetch.call();
+			return (T) value.asZonedDateTime();
+		}
+		else if (type == LocalDateTime.class){
+			LocalDateTimeValue value = (LocalDateTimeValue) fetch.call();
+			return (T) value.asLocalDateTime();
+		}
+		else if (type == IsoDuration.class){
+			DurationValue value = (DurationValue) fetch.call();
+			return (T) value.asIsoDuration();
+		}
+		else if (type == LocalDate.class){
+			DateValue value = (DateValue) fetch.call();
+			return (T) value.asLocalDate();
+		}
+		else if (type == LocalTime.class){
+			LocalTimeValue value = (LocalTimeValue) fetch.call();
+			return (T) value.asLocalTime();
+		}
+		else if (type == OffsetTime.class){
+			TimeValue value = (TimeValue) fetch.call();
+			return (T) value.asOffsetTime();
+		}
+		else if (type == Point.class){
+			PointValue value = (PointValue) fetch.call();
+			return (T) value.asPoint();
+		}
+		else {
+			Object obj = getObject.call();
+			T ret;
+			try {
+				ret = ObjectConverter.convert(obj, type);
+			} catch (Exception e) {
+				throw new SQLException(e);
+			}
+			return ret;
+		}
 	}
 
 	@Override public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
-		checkClosed();
-		if (type == null) {
-			throw new SQLException("Type to cast cannot be null");
-		}
-		Object obj = this.getObject(columnIndex);
-		T ret;
 		try {
-			ret = ObjectConverter.convert(obj, type);
+			return getObject(type, ()-> this.fetchValueFromIndex(columnIndex), () -> this.getObject(columnIndex));
 		} catch (Exception e) {
 			throw new SQLException(e);
 		}
-		return ret;
 	}
 
 	@Override public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
@@ -742,12 +788,24 @@ public class BoltNeo4jResultSet extends Neo4jResultSet {
 	 * @return
 	 */
 	private Time valueToTime(Value value){
+		return valueToTime(value, Calendar.getInstance());
+	}
+
+	/**
+	 * Convert Value to sql.Time with timezone
+	 * @param value
+	 * @return
+	 */
+	private Time valueToTime(Value value, Calendar cal){
 		if (value.isNull()){
 			return null;
 		}
 
 		if (value instanceof TimeValue){
-			return offsetTimeToTime(((TimeValue)value).asOffsetTime());
+			ZoneOffset zoneOffset = ZoneOffset.ofTotalSeconds(cal.get(Calendar.ZONE_OFFSET) / 1000);
+			TimeValue timeValue = (TimeValue) value;
+			OffsetTime offsetTime = timeValue.asOffsetTime().withOffsetSameInstant(zoneOffset);
+			return offsetTimeToTime(offsetTime);
 		}
 
 		if (value instanceof LocalTimeValue){
@@ -805,17 +863,26 @@ public class BoltNeo4jResultSet extends Neo4jResultSet {
 	}
 
 	/**
-	 * Convert Value to Timestamp
+	 * Convert Value to Timestamp with system timezone
 	 * @param value
 	 * @return
 	 */
 	private Timestamp valueToTimestamp(Value value){
+		return valueToTimestamp(value, ZoneId.systemDefault() );
+	}
+
+	/**
+	 * Convert Value to Timestamp with timezone
+	 * @param value
+	 * @return
+	 */
+	private Timestamp valueToTimestamp(Value value, ZoneId zone) {
 		if (value.isNull()){
 			return null;
 		}
 
 		if (value instanceof DateTimeValue){
-			return zonedDateTimeToTimestamp(value.asZonedDateTime());
+			return zonedDateTimeToTimestamp(value.asZonedDateTime().withZoneSameInstant(zone));
 		}
 
 		if (value instanceof LocalDateTimeValue){
@@ -877,5 +944,33 @@ public class BoltNeo4jResultSet extends Neo4jResultSet {
 		checkClosed();
 		Value value = this.fetchValueFromLabel(columnLabel);
 		return valueToTime(value);
+	}
+
+	@Override
+	public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+		checkClosed();
+		Value value = this.fetchValueFromIndex(columnIndex);
+		return valueToTimestamp(value, cal.getTimeZone().toZoneId());
+	}
+
+	@Override
+	public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+		checkClosed();
+		Value value = this.fetchValueFromLabel(columnLabel);
+		return valueToTimestamp(value, cal.getTimeZone().toZoneId());
+	}
+
+	@Override
+	public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+		checkClosed();
+		Value value = this.fetchValueFromIndex(columnIndex);
+		return valueToTime(value,cal);
+	}
+
+	@Override
+	public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+		checkClosed();
+		Value value = this.fetchValueFromLabel(columnLabel);
+		return valueToTime(value,cal);
 	}
 }

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSet.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSet.java
@@ -907,7 +907,7 @@ public class BoltNeo4jResultSet extends Neo4jResultSet {
 	 * @return
 	 */
 	private Timestamp zonedDateTimeToTimestamp(ZonedDateTime zdt){
-		return new Timestamp(zdt.toEpochSecond()*1000L + zdt.getNano() / 1000_000L);
+		return new Timestamp(zdt.toInstant().toEpochMilli());
 	}
 
 	@Override public Timestamp getTimestamp(int columnIndex) throws SQLException {

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jAuthenticationIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jAuthenticationIT.java
@@ -20,6 +20,7 @@
 package org.neo4j.jdbc.bolt;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -38,7 +39,9 @@ import static org.junit.Assert.assertTrue;
  */
 public class BoltNeo4jAuthenticationIT {
 
-	@Rule public Neo4jBoltRule neo4j = new Neo4jBoltRule(true);  // here we're firing up neo4j with bolt enabled
+	//@Rule public Neo4jBoltRule neo4j = new Neo4jBoltRule(true);  // here we're firing up neo4j with bolt enabled
+	@ClassRule
+	public static Neo4jBoltRule neo4j = new Neo4jBoltRule(true);
 
 	@Rule public ExpectedException expectedEx = ExpectedException.none();
 

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jConnectionIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jConnectionIT.java
@@ -19,10 +19,7 @@
  */
 package org.neo4j.jdbc.bolt;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.neo4j.jdbc.bolt.data.StatementData;
 import org.neo4j.jdbc.bolt.utils.JdbcConnectionTestUtils;
@@ -49,6 +46,13 @@ public class BoltNeo4jConnectionIT {
 		writer = JdbcConnectionTestUtils.verifyConnection(writer,neo4j);
 		reader = JdbcConnectionTestUtils.verifyConnection(reader,neo4j);
 	}
+
+	@After
+	public void tearDown() throws SQLException {
+		JdbcConnectionTestUtils.closeConnection(writer);
+		JdbcConnectionTestUtils.closeConnection(reader);
+	}
+
 
 	@Test public void commitShouldWorkFine() throws SQLException {
 		writer.setAutoCommit(false);

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jDataSourceIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jDataSourceIT.java
@@ -62,5 +62,8 @@ public class BoltNeo4jDataSourceIT {
 
 		Statement statement = connection.createStatement();
 		assertTrue(statement.execute("RETURN 1"));
+
+		statement.close();
+		JdbcConnectionTestUtils.closeConnection(connection);
 	}
 }

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaDataIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaDataIT.java
@@ -21,12 +21,16 @@
  */
 package org.neo4j.jdbc.bolt;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.jdbc.bolt.utils.JdbcConnectionTestUtils;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 import static org.junit.Assert.*;
 
@@ -41,6 +45,11 @@ public class BoltNeo4jDatabaseMetaDataIT {
 
 	@Before public void setUp(){
 		connection = JdbcConnectionTestUtils.verifyConnection(connection,neo4j);
+	}
+
+	@After
+	public void tearDown() throws SQLException {
+		JdbcConnectionTestUtils.closeConnection(connection);
 	}
 
 	@Test public void getDatabaseVersionShouldBeOK() throws SQLException, NoSuchFieldException, IllegalAccessException {

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jDateIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jDateIT.java
@@ -3,13 +3,19 @@ package org.neo4j.jdbc.bolt;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.neo4j.driver.internal.value.*;
+import org.neo4j.driver.v1.types.IsoDuration;
 import org.neo4j.jdbc.bolt.data.StatementData;
 import org.neo4j.jdbc.bolt.utils.JdbcConnectionTestUtils;
 
 import java.sql.*;
+import java.text.ParseException;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -33,27 +39,31 @@ public class BoltNeo4jDateIT {
     /*
     =============================
             DATETIME
-    TODO: manage the timezone
     =============================
      */
 
     @Test
-    public void executeQueryShouldReturnFieldDatetime() throws SQLException {
+    public void executeQueryShouldReturnFieldDatetime() throws SQLException, ParseException {
 
         Statement statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery("CREATE (e:Event {when: datetime('2015-06-24T12:50:35.556+0100') }) RETURN e AS event");
+        ResultSet rs = statement.executeQuery("CREATE (e:Event {when: datetime('2015-06-24T12:50:35.556[America/New_York]') }) RETURN e AS event");
 
         assertTrue(rs.next());
 
         Map<String, Object> geo = (Map)rs.getObject(1);
+
+        //to avoid problems running the test all around the world
+        ZonedDateTime newyork = ZonedDateTime.parse("2015-06-24T12:50:35.556-04:00[America/New_York]");
+        ZonedDateTime local = newyork.withZoneSameInstant(ZoneId.systemDefault());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+        String format = local.format(formatter);
 
         Object when = geo.get("when");
 
         assertTrue(when instanceof java.sql.Timestamp);
 
         java.sql.Timestamp timestamp = (Timestamp) when;
-
-        assertEquals(1435146635556L,timestamp.getTime());
+        assertEquals(format, timestamp.toString());
 
         rs.close();
         statement.close();
@@ -63,30 +73,24 @@ public class BoltNeo4jDateIT {
     public void executeQueryShouldReturnDatetime() throws SQLException {
 
         Statement statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery("RETURN datetime('2015-06-24T12:50:35.556+0100') AS event");
+        ResultSet rs = statement.executeQuery("RETURN datetime('2015-06-24T12:50:35.556[America/New_York]') AS event");
 
         assertTrue(rs.next());
 
         //int columnType = rs.getMetaData().getColumnType(1);
         assertEquals(Types.TIMESTAMP_WITH_TIMEZONE, rs.getMetaData().getColumnType(1));
 
-        java.sql.Timestamp timestamp = rs.getTimestamp(1);
-        assertEquals(1435146635556L,timestamp.getTime());
+        Calendar berlin = Calendar.getInstance(TimeZone.getTimeZone("Europe/Berlin"));
 
-        java.sql.Timestamp timestampByString = rs.getTimestamp("event");
-        assertEquals(1435146635556L,timestampByString.getTime());
+        java.sql.Timestamp timestampByIntCal = rs.getTimestamp(1, berlin);
+        assertEquals("2015-06-24 18:50:35.556", timestampByIntCal.toString());
 
-        /*
-        java.sql.Timestamp timestampByIntCal = rs.getTimestamp(1, Calendar.getInstance());
-        assertEquals(1435146635556L,timestampByIntCal.getTime());
-
-        java.sql.Timestamp timestampByStringCal = rs.getTimestamp("event", Calendar.getInstance());
-        assertEquals(1435146635556L,timestampByStringCal.getTime());
-        */
+        java.sql.Timestamp timestampByStringCal = rs.getTimestamp("event", berlin);
+        assertEquals("2015-06-24 18:50:35.556", timestampByStringCal.toString());
 
         Object when = rs.getObject(1);
         assertTrue(when instanceof java.sql.Timestamp);
-        assertEquals(1435146635556L, ((java.sql.Timestamp)when).getTime());
+        assertEquals("2015-06-24 18:50:35.556", when.toString());
 
         rs.close();
         statement.close();
@@ -96,10 +100,16 @@ public class BoltNeo4jDateIT {
     public void executeQueryShouldReturnArrayFieldDatetime() throws SQLException {
 
         Statement statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery("CREATE (e:Event {when: [datetime('2015-06-24T12:50:35.556+0100')] }) RETURN e AS event");
+        ResultSet rs = statement.executeQuery("CREATE (e:Event {when: [datetime('2015-06-24T12:50:35.556[America/New_York]')] }) RETURN e AS event");
 
         assertTrue(rs.next());
         Map<String, Object> geo = (Map)rs.getObject(1);
+
+        //to avoid problems running the test all around the world
+        ZonedDateTime newyork = ZonedDateTime.parse("2015-06-24T12:50:35.556-04:00[America/New_York]");
+        ZonedDateTime local = newyork.withZoneSameInstant(ZoneId.systemDefault());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+        String format = local.format(formatter);
 
         Object whenField = geo.get("when");
         assertTrue(whenField instanceof List);
@@ -108,7 +118,7 @@ public class BoltNeo4jDateIT {
 
         Object when = whenList.get(0);
         assertTrue(when instanceof java.sql.Timestamp);
-        assertEquals(1435146635556L, ((java.sql.Timestamp)when).getTime());
+        assertEquals(format, when.toString());
 
         rs.close();
         statement.close();
@@ -118,10 +128,16 @@ public class BoltNeo4jDateIT {
     public void executeQueryShouldReturnArrayDatetime() throws SQLException {
 
         Statement statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery("RETURN [datetime('2015-06-24T12:50:35.556+0100')] AS event");
+        ResultSet rs = statement.executeQuery("RETURN [datetime('2015-06-24T12:50:35.556[America/New_York]')] AS event");
 
         assertTrue(rs.next());
         Object event = rs.getObject(1);
+
+        //to avoid problems running the test all around the world
+        ZonedDateTime newyork = ZonedDateTime.parse("2015-06-24T12:50:35.556-04:00[America/New_York]");
+        ZonedDateTime local = newyork.withZoneSameInstant(ZoneId.systemDefault());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+        String format = local.format(formatter);
 
         assertTrue(event instanceof List);
         List eventList = (List) event;
@@ -129,7 +145,7 @@ public class BoltNeo4jDateIT {
         Object when = eventList.get(0);
 
         assertTrue(when instanceof java.sql.Timestamp);
-        assertEquals(1435146635556L, ((java.sql.Timestamp)when).getTime());
+        assertEquals(format, when.toString());
 
         rs.close();
         statement.close();
@@ -394,8 +410,9 @@ public class BoltNeo4jDateIT {
     /*
     =============================
             TIME
-    TODO: manage the offset (if possible)
-    TODO: manage the (int, Calendar) method
+
+       Only with getTime(col, Calendar) you can manage the offset,
+       otherwise is always a LocalTime
     =============================
     */
 
@@ -403,7 +420,7 @@ public class BoltNeo4jDateIT {
     public void executeQueryShouldReturnFieldTime() throws SQLException {
 
         Statement statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery("CREATE (e:Event {when: time('125035.556+0100') }) RETURN e AS event");
+        ResultSet rs = statement.executeQuery("CREATE (e:Event {when: time('21:40:32+01:00') }) RETURN e AS event");
 
         assertTrue(rs.next());
 
@@ -413,16 +430,9 @@ public class BoltNeo4jDateIT {
 
         assertTrue(when instanceof java.sql.Time);
 
-        Time date = (java.sql.Time) when;
+        Time time = (java.sql.Time) when;
 
-        Calendar cal = Calendar.getInstance();
-        cal.setTimeInMillis(date.getTime());
-
-        assertEquals(12, cal.get(Calendar.HOUR_OF_DAY));
-        assertEquals(50, cal.get(Calendar.MINUTE));
-        assertEquals(35, cal.get(Calendar.SECOND));
-        assertEquals(556, cal.get(Calendar.MILLISECOND));
-        //assertEquals(1, cal.get(Calendar.ZONE_OFFSET));
+        assertEquals("21:40:32", time.toString());
 
         rs.close();
         statement.close();
@@ -432,29 +442,24 @@ public class BoltNeo4jDateIT {
     public void executeQueryShouldReturnTime() throws SQLException {
 
         Statement statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery("RETURN time('125035.556+0100') AS event");
+        ResultSet rs = statement.executeQuery("RETURN time('21:40:32+01:00') AS event");
 
         assertTrue(rs.next());
 
-        //int columnType = rs.getMetaData().getColumnType(1);
         assertEquals(Types.TIME, rs.getMetaData().getColumnType(1));
 
-        Time time = rs.getTime(1);
-        Calendar cal = Calendar.getInstance();
-        cal.setTimeInMillis(time.getTime());
+        Calendar gmt = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
 
-        assertEquals(12, cal.get(Calendar.HOUR_OF_DAY));
-        assertEquals(50, cal.get(Calendar.MINUTE));
-        assertEquals(35, cal.get(Calendar.SECOND));
-        assertEquals(556, cal.get(Calendar.MILLISECOND));
-        //assertEquals(1, cal.get(Calendar.ZONE_OFFSET));
+        Time time = rs.getTime(1, gmt);
+        assertEquals("20:40:32", time.toString());
 
-        Time timeByString = rs.getTime("event");
-        assertEquals(time,timeByString);
+
+        Time timeByString = rs.getTime("event", gmt);
+        assertEquals("20:40:32", timeByString.toString());
 
         Object when = rs.getObject(1);
         assertTrue(when instanceof java.sql.Time);
-        assertEquals(time,when);
+        assertEquals("21:40:32", when.toString());
 
         rs.close();
         statement.close();
@@ -464,7 +469,7 @@ public class BoltNeo4jDateIT {
     public void executeQueryShouldReturnArrayFieldTime() throws SQLException {
 
         Statement statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery("CREATE (e:Event {when: [time('125035.556+0100')] }) RETURN e AS event");
+        ResultSet rs = statement.executeQuery("CREATE (e:Event {when: [time('21:40:32+01:00')] }) RETURN e AS event");
 
         assertTrue(rs.next());
         Map<String, Object> geo = (Map)rs.getObject(1);
@@ -477,15 +482,9 @@ public class BoltNeo4jDateIT {
         Object when = whenList.get(0);
         assertTrue(when instanceof java.sql.Time);
 
-        java.sql.Time date = (Time) when;
+        java.sql.Time time = (Time) when;
 
-        Calendar cal = Calendar.getInstance();
-        cal.setTimeInMillis(date.getTime());
-
-        assertEquals(12, cal.get(Calendar.HOUR_OF_DAY));
-        assertEquals(50, cal.get(Calendar.MINUTE));
-        assertEquals(35, cal.get(Calendar.SECOND));
-        assertEquals(556, cal.get(Calendar.MILLISECOND));
+        assertEquals("21:40:32", time.toString());
 
         rs.close();
         statement.close();
@@ -495,7 +494,7 @@ public class BoltNeo4jDateIT {
     public void executeQueryShouldReturnArrayTime() throws SQLException {
 
         Statement statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery("RETURN [time('125035.556+0100')] AS event");
+        ResultSet rs = statement.executeQuery("RETURN [time('21:40:32+01:00')] AS event");
 
         assertTrue(rs.next());
         Object event = rs.getObject(1);
@@ -507,15 +506,9 @@ public class BoltNeo4jDateIT {
         Object when = eventList.get(0);
         assertTrue(when instanceof java.sql.Time);
 
-        java.sql.Time date = (Time) when;
+        java.sql.Time time = (Time) when;
 
-        Calendar cal = Calendar.getInstance();
-        cal.setTimeInMillis(date.getTime());
-
-        assertEquals(12, cal.get(Calendar.HOUR_OF_DAY));
-        assertEquals(50, cal.get(Calendar.MINUTE));
-        assertEquals(35, cal.get(Calendar.SECOND));
-        assertEquals(556, cal.get(Calendar.MILLISECOND));
+        assertEquals("21:40:32", time.toString());
 
         rs.close();
         statement.close();
@@ -764,4 +757,221 @@ public class BoltNeo4jDateIT {
         statement.close();
     }
 
+    /*
+    ======================================
+            GET OBJECT
+            NEO4J VALUES
+    ======================================
+     */
+
+    @Test
+    public void executeGetObjectShouldReturnDateValue() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN date('2015-12-31') AS event");
+
+        rs.next();
+
+        DateValue object = rs.getObject(1, DateValue.class);
+        assertEquals("2015-12-31", object.asLocalDate().toString());
+
+        DateValue label = rs.getObject("event", DateValue.class);
+        assertEquals("2015-12-31", label.asLocalDate().toString());
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldReturnLocalTimeValue() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN localtime('125035.556') AS event");
+
+        rs.next();
+
+        LocalTimeValue object = rs.getObject(1, LocalTimeValue.class);
+        assertEquals("12:50:35.556", object.asLocalTime().toString());
+
+        LocalTimeValue label = rs.getObject("event", LocalTimeValue.class);
+        assertEquals("12:50:35.556", label.asLocalTime().toString());
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldReturnTimeValue() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN time('21:40:32+01:00') AS event");
+
+        rs.next();
+
+        TimeValue object = rs.getObject(1, TimeValue.class);
+        assertEquals("21:40:32+01:00", object.asOffsetTime().toString());
+
+        TimeValue label = rs.getObject("event", TimeValue.class);
+        assertEquals("21:40:32+01:00", label.asOffsetTime().toString());
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldLocalDateTimeValue() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN localdatetime('2015-12-31T19:32:24') AS event");
+
+        rs.next();
+
+        LocalDateTimeValue object = rs.getObject(1, LocalDateTimeValue.class);
+        assertEquals("2015-12-31T19:32:24", object.asLocalDateTime().toString());
+
+        LocalDateTimeValue label = rs.getObject("event", LocalDateTimeValue.class);
+        assertEquals("2015-12-31T19:32:24", label.asLocalDateTime().toString());
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldDateTimeValue() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN datetime('2015-06-24T12:50:35.556[America/New_York]') AS event");
+
+        rs.next();
+
+        DateTimeValue object = rs.getObject(1, DateTimeValue.class);
+        assertEquals("2015-06-24T12:50:35.556-04:00[America/New_York]", object.asZonedDateTime().toString());
+
+        DateTimeValue label = rs.getObject("event", DateTimeValue.class);
+        assertEquals("2015-06-24T12:50:35.556-04:00[America/New_York]", label.asZonedDateTime().toString());
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldDurationValue() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("return duration.between(datetime('2015-06-24T12:50:35.556+0100'),datetime('2014-05-23T11:49:34.555+0100')) AS duration");
+
+        rs.next();
+
+        DurationValue object = rs.getObject(1, DurationValue.class);
+        assertEquals("P-13M-1DT-3661.001000000S", object.asIsoDuration().toString());
+
+        DurationValue label = rs.getObject("duration", DurationValue.class);
+        assertEquals("P-13M-1DT-3661.001000000S", label.asIsoDuration().toString());
+
+        rs.close();
+        statement.close();
+    }
+
+        /*
+    ======================================
+            GET OBJECT
+            JAVA VALUES
+    ======================================
+     */
+
+    @Test
+    public void executeGetObjectShouldReturnDate() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN date('2015-12-31') AS event");
+
+        rs.next();
+
+        LocalDate object = rs.getObject(1, LocalDate.class);
+        assertEquals("2015-12-31", object.toString());
+
+        LocalDate label = rs.getObject("event", LocalDate.class);
+        assertEquals("2015-12-31", label.toString());
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldReturnLocalTime() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN localtime('125035.556') AS event");
+
+        rs.next();
+
+        LocalTime object = rs.getObject(1, LocalTime.class);
+        assertEquals("12:50:35.556", object.toString());
+
+        LocalTime label = rs.getObject("event", LocalTime.class);
+        assertEquals("12:50:35.556", label.toString());
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldReturnTime() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN time('21:40:32+01:00') AS event");
+
+        rs.next();
+
+        OffsetTime object = rs.getObject(1, OffsetTime.class);
+        assertEquals("21:40:32+01:00", object.toString());
+
+        OffsetTime label = rs.getObject("event", OffsetTime.class);
+        assertEquals("21:40:32+01:00", label.toString());
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldReturnLocalDateTime() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN localdatetime('2015-12-31T19:32:24') AS event");
+
+        rs.next();
+
+        LocalDateTime object = rs.getObject(1, LocalDateTime.class);
+        assertEquals("2015-12-31T19:32:24", object.toString());
+
+        LocalDateTime label = rs.getObject("event", LocalDateTime.class);
+        assertEquals("2015-12-31T19:32:24", label.toString());
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldReturnDateTime() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN datetime('2015-06-24T12:50:35.556[America/New_York]') AS event");
+
+        rs.next();
+
+        ZonedDateTime object = rs.getObject(1, ZonedDateTime.class);
+        assertEquals("2015-06-24T12:50:35.556-04:00[America/New_York]", object.toString());
+
+        ZonedDateTime label = rs.getObject("event", ZonedDateTime.class);
+        assertEquals("2015-06-24T12:50:35.556-04:00[America/New_York]", label.toString());
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldReturnDuration() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("return duration.between(datetime('2015-06-24T12:50:35.556+0100'),datetime('2014-05-23T11:49:34.555+0100')) AS duration");
+
+        rs.next();
+
+        IsoDuration object = rs.getObject(1, IsoDuration.class);
+        assertEquals("P-13M-1DT-3661.001000000S", object.toString());
+
+        IsoDuration label = rs.getObject("duration", IsoDuration.class);
+        assertEquals("P-13M-1DT-3661.001000000S", label.toString());
+
+        rs.close();
+        statement.close();
+    }
 }

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jDateIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jDateIT.java
@@ -86,17 +86,20 @@ public class BoltNeo4jDateIT {
         //int columnType = rs.getMetaData().getColumnType(1);
         assertEquals(Types.TIMESTAMP_WITH_TIMEZONE, rs.getMetaData().getColumnType(1));
 
-        Calendar berlin = Calendar.getInstance(TimeZone.getTimeZone("Europe/Berlin"));
+        Calendar gmt = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
 
-        java.sql.Timestamp timestampByIntCal = rs.getTimestamp(1, berlin);
-        assertEquals("2015-06-24 18:50:35.556", timestampByIntCal.toString());
+        java.sql.Timestamp timestampByIntCal = rs.getTimestamp(1, gmt);
+        //assertEquals("2015-06-24 16:50:35.556", timestampByIntCal.toString()); // toString formats the time using system timezone
+        assertEquals(1435164635556L, timestampByIntCal.getTime());
 
-        java.sql.Timestamp timestampByStringCal = rs.getTimestamp("event", berlin);
-        assertEquals("2015-06-24 18:50:35.556", timestampByStringCal.toString());
+        java.sql.Timestamp timestampByStringCal = rs.getTimestamp("event", gmt);
+        //assertEquals("2015-06-24 16:50:35.556", timestampByStringCal.toString());
+        assertEquals(1435164635556L, timestampByStringCal.getTime());
 
         Object when = rs.getObject(1);
         assertTrue(when instanceof java.sql.Timestamp);
-        assertEquals("2015-06-24 18:50:35.556", when.toString());
+        //assertEquals("2015-06-24 16:50:35.556", when.toString());
+        assertEquals(1435164635556L, ((java.sql.Timestamp)when).getTime());
 
         rs.close();
         statement.close();

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jDateIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jDateIT.java
@@ -1,5 +1,6 @@
 package org.neo4j.jdbc.bolt;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -28,12 +29,17 @@ public class BoltNeo4jDateIT {
     @ClassRule
     public static Neo4jBoltRule neo4j = new Neo4jBoltRule();
 
-    Connection connection;
+    static Connection connection;
 
     @Before
     public void cleanDB() throws SQLException {
         neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CLEAR_DB);
         connection = JdbcConnectionTestUtils.verifyConnection(connection, neo4j);
+    }
+
+    @AfterClass
+    public static void tearDown(){
+        JdbcConnectionTestUtils.closeConnection(connection);
     }
 
     /*

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementIT.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.jdbc.bolt;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -38,10 +39,15 @@ public class BoltNeo4jPreparedStatementIT {
 
 	@ClassRule public static Neo4jBoltRule neo4j = new Neo4jBoltRule();
 
-	Connection connection;
+	static Connection connection;
 
 	@Before public void setUp(){
 		connection = JdbcConnectionTestUtils.verifyConnection(connection, neo4j);
+	}
+
+	@AfterClass
+	public static void tearDown(){
+		JdbcConnectionTestUtils.closeConnection(connection);
 	}
 
 	/*------------------------------*/

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSetIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSetIT.java
@@ -19,17 +19,20 @@
  */
 package org.neo4j.jdbc.bolt;
 
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.neo4j.jdbc.bolt.data.StatementData;
 import org.neo4j.jdbc.bolt.utils.JdbcConnectionTestUtils;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author AgileLARUS
@@ -37,9 +40,15 @@ import static org.junit.Assert.assertTrue;
  */
 public class BoltNeo4jResultSetIT {
 
-	@Rule public Neo4jBoltRule neo4j = new Neo4jBoltRule();
+	@ClassRule
+	public static Neo4jBoltRule neo4j = new Neo4jBoltRule();
 
 	@Rule public ExpectedException expectedEx = ExpectedException.none();
+
+	@Before
+	public void setUp() throws SQLException {
+		JdbcConnectionTestUtils.clearDatabase(neo4j);
+	}
 
 	/*------------------------------*/
 	/*          flattening          */
@@ -59,7 +68,7 @@ public class BoltNeo4jResultSetIT {
 		assertEquals(4, rs.findColumn("u.name"));
 		assertEquals("name", rs.getString("u.name"));
 
-		conn.close();
+		JdbcConnectionTestUtils.closeConnection(conn, stmt, rs);
 	}
 
 	@Test public void flatteningNumberWorkingMoreRows() throws SQLException {
@@ -80,7 +89,7 @@ public class BoltNeo4jResultSetIT {
 		assertEquals(5, rs.findColumn("u.surname"));
 		assertEquals("surname", rs.getString("u.surname"));
 
-		conn.close();
+		JdbcConnectionTestUtils.closeConnection(conn, stmt, rs);
 	}
 
 	@Test public void flatteningNumberWorkingAllRows() throws SQLException {
@@ -101,7 +110,7 @@ public class BoltNeo4jResultSetIT {
 		assertEquals(5, rs.findColumn("u.surname"));
 		assertEquals("surname", rs.getString("u.surname"));
 
-		conn.close();
+		JdbcConnectionTestUtils.closeConnection(conn, stmt, rs);
 	}
 
 	@Test public void findColumnShouldWorkWithFlattening() throws SQLException {
@@ -115,7 +124,7 @@ public class BoltNeo4jResultSetIT {
 
 		neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CREATE_REV);
 
-		con.close();
+		JdbcConnectionTestUtils.closeConnection(con, stmt, rs);
 	}
 
 	@Test public void shouldGetRowReturnValidNumbers() throws SQLException {
@@ -129,7 +138,7 @@ public class BoltNeo4jResultSetIT {
 			assertEquals(rs.getRow(), rs.getInt("number"));
 
 		}
-		con.close();
+		JdbcConnectionTestUtils.closeConnection(con, stmt, rs);
 	}
 
 	@Test public void shouldHasntNext() throws SQLException {
@@ -141,8 +150,6 @@ public class BoltNeo4jResultSetIT {
 
 		assertFalse(rs.next());
 
-		rs.close();
-
-		con.close();
+		JdbcConnectionTestUtils.closeConnection(con, stmt, rs);
 	}
 }

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSetMetaDataIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSetMetaDataIT.java
@@ -19,10 +19,7 @@
  */
 package org.neo4j.jdbc.bolt;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.*;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.jdbc.bolt.data.StatementData;
 import org.neo4j.jdbc.bolt.utils.JdbcConnectionTestUtils;
@@ -43,7 +40,7 @@ public class BoltNeo4jResultSetMetaDataIT {
 
 	//private final static String FLATTEN_URI = "flatten=1";
 
-	Connection connectionFlatten;
+	static Connection connectionFlatten;
 
 	@ClassRule public static Neo4jBoltRule neo4j = new Neo4jBoltRule();
 
@@ -57,6 +54,11 @@ public class BoltNeo4jResultSetMetaDataIT {
 
 	@After public void tearDown() {
 		neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CLEAR_DB);
+	}
+
+	@AfterClass
+	public static void tearDownConnection(){
+		JdbcConnectionTestUtils.closeConnection(connectionFlatten);
 	}
 
 	/*------------------------------*/

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jSpatialIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jSpatialIT.java
@@ -1,5 +1,6 @@
 package org.neo4j.jdbc.bolt;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -24,12 +25,17 @@ public class BoltNeo4jSpatialIT {
     @ClassRule
     public static Neo4jBoltRule neo4j = new Neo4jBoltRule();
 
-    Connection connection;
+    static Connection connection;
 
     @Before
     public void cleanDB() throws SQLException {
         neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CLEAR_DB);
         connection = JdbcConnectionTestUtils.verifyConnection(connection, neo4j);
+    }
+
+    @AfterClass
+    public static void tearDown(){
+        JdbcConnectionTestUtils.closeConnection(connection);
     }
 
     /**

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jSpatialIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jSpatialIT.java
@@ -3,10 +3,14 @@ package org.neo4j.jdbc.bolt;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.neo4j.driver.v1.types.Point;
 import org.neo4j.jdbc.bolt.data.StatementData;
 import org.neo4j.jdbc.bolt.utils.JdbcConnectionTestUtils;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
 
@@ -488,5 +492,82 @@ public class BoltNeo4jSpatialIT {
         rs.close();
         statement.close();
         conn.close();
+    }
+
+    /**
+     * ================
+     * GET OBJECT
+     * ================
+     */
+
+    @Test
+    public void executeGetObjectShouldReturnCartesian2D() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN point({ x:3, y:-0.1 }) AS point");
+
+        rs.next();
+
+        Point object = rs.getObject(1, Point.class);
+        assertEquals("Point{srid=7203, x=3.0, y=-0.1}", object.toString());
+
+        Point label = rs.getObject("point", Point.class);
+        assertEquals("Point{srid=7203, x=3.0, y=-0.1}", label.toString());
+
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldReturnCartesian3D() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN point({ x:3, y:-0.1, z:2 }) AS point");
+
+        rs.next();
+
+        Point object = rs.getObject(1, Point.class);
+        assertEquals("Point{srid=9157, x=3.0, y=-0.1, z=2.0}", object.toString());
+
+        Point label = rs.getObject("point", Point.class);
+        assertEquals("Point{srid=9157, x=3.0, y=-0.1, z=2.0}", label.toString());
+
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldReturnCartesianGeo2D() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN point({ latitude: 12, longitude: 56 }) AS point");
+
+        rs.next();
+
+        Point object = rs.getObject(1, Point.class);
+        assertEquals("Point{srid=4326, x=56.0, y=12.0}", object.toString());
+
+        Point label = rs.getObject("point", Point.class);
+        assertEquals("Point{srid=4326, x=56.0, y=12.0}", label.toString());
+
+
+        rs.close();
+        statement.close();
+    }
+
+    @Test
+    public void executeGetObjectShouldReturnCartesianGeo3D() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("RETURN point({ latitude: 12, longitude: 56, height: 4321 }) AS point");
+
+        rs.next();
+
+        Point object = rs.getObject(1, Point.class);
+        assertEquals("Point{srid=4979, x=56.0, y=12.0, z=4321.0}", object.toString());
+
+        Point label = rs.getObject("point", Point.class);
+        assertEquals("Point{srid=4979, x=56.0, y=12.0, z=4321.0}", label.toString());
+
+        rs.close();
+        statement.close();
     }
 }

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jStatementIT.java
@@ -19,10 +19,7 @@
  */
 package org.neo4j.jdbc.bolt;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.jdbc.Neo4jResultSet;
@@ -43,13 +40,17 @@ public class BoltNeo4jStatementIT {
 
 	@Rule public ExpectedException expectedEx = ExpectedException.none();
 
-	Connection connection;
+	static Connection connection;
 
 	@Before
 	public void setUp(){
 		connection = JdbcConnectionTestUtils.verifyConnection(connection, neo4j);
 	}
 
+	@AfterClass
+	public static void tearDown(){
+		JdbcConnectionTestUtils.closeConnection(connection);
+	}
 
 	/*------------------------------*/
 	/*          executeQuery        */

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/utils/JdbcConnectionTestUtils.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/utils/JdbcConnectionTestUtils.java
@@ -2,11 +2,9 @@ package org.neo4j.jdbc.bolt.utils;
 
 import org.neo4j.jdbc.bolt.BoltDriver;
 import org.neo4j.jdbc.bolt.Neo4jBoltRule;
+import org.neo4j.jdbc.bolt.data.StatementData;
 
-import java.sql.Connection;
-import java.sql.Driver;
-import java.sql.DriverManager;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.Enumeration;
 
 /**
@@ -71,12 +69,42 @@ public class JdbcConnectionTestUtils {
     }
 
     public static void closeConnection(Connection connection){
+        closeConnection(connection, null, null);
+    }
+
+    public static void closeConnection(Connection connection, Statement stmt){
+        closeConnection(connection, stmt, null);
+    }
+
+    public static void closeStatement(Statement stmt, ResultSet rs){
+        closeConnection(null, stmt, rs);
+    }
+
+    public static void closeStatement(Statement stmt){
+        closeConnection(null, stmt, null);
+    }
+
+    public static void closeResultSet(ResultSet rs){
+        closeConnection(null, null, rs);
+    }
+
+    public static void closeConnection(Connection connection, Statement stmt, ResultSet rs){
         try {
+            if(rs != null &&  !rs.isClosed()){
+                rs.close();
+            }
+            if(stmt != null &&  !stmt.isClosed()){
+                stmt.close();
+            }
             if(connection != null &&  !connection.isClosed()){
                 connection.close();
             }
         } catch (SQLException e) {
             e.printStackTrace();
         }
+    }
+
+    public static void clearDatabase(Neo4jBoltRule neo4j){
+        neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CLEAR_DB);
     }
 }

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/utils/JdbcConnectionTestUtils.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/utils/JdbcConnectionTestUtils.java
@@ -69,4 +69,14 @@ public class JdbcConnectionTestUtils {
     public static Connection verifyConnection(Connection connection, Neo4jBoltRule neo4j){
         return verifyConnection(connection,neo4j,"");
     }
+
+    public static void closeConnection(Connection connection){
+        try {
+            if(connection != null &&  !connection.isClosed()){
+                connection.close();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
 }


### PR DESCRIPTION
Only for Bolt protocol, the reading methods for temporal functions are supported.
