### PR TITLE
Fix #163 - Squirrel (jre 1.8) complaining about the driver is not JDB…

### DIFF
--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
@@ -736,7 +736,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean supportsResultSetType(int type) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return type == ResultSet.TYPE_FORWARD_ONLY;
 	}
 
 	@Override public boolean supportsResultSetConcurrency(int type, int concurrency) throws SQLException {
@@ -788,7 +788,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean supportsSavepoints() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsNamedParameters() throws SQLException {

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDatabaseMetaDataTest.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDatabaseMetaDataTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
+import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.junit.Assert.*;
@@ -157,5 +158,20 @@ public class Neo4jDatabaseMetaDataTest {
 	@Test public void supportsMixedCaseQuotedIdentifiersShouldBeReturnFalse() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
 		assertFalse(databaseMetaData.supportsMixedCaseQuotedIdentifiers());
+	}
+
+	@Test public void supportsResultSetType_TYPE_FORWARD_ONLY_true() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertTrue(databaseMetaData.supportsResultSetType(ResultSet.TYPE_FORWARD_ONLY));
+	}
+
+	@Test public void supportsResultSetType_FETCH_REVERSE_false() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsResultSetType(ResultSet.FETCH_REVERSE));
+	}
+
+	@Test public void supportsSavepointsReturnFalse() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsSavepoints());
 	}
 }


### PR DESCRIPTION
Squirrel checks the compliance using these methods in the *DatabaseMetaData*:

- supportsResultSetType
- supportsSavepoints

In the PR there's the implementation of those methods, according to the neo4j behaviour.