### PR TITLE
Driver not implementing getProcedureTerm()

### DIFF
--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
@@ -164,6 +164,10 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 		return "Neo4j";
 	}
 
+	@Override public String getProcedureTerm() throws SQLException {
+		return "Procedure";
+	}
+	
 	@Override public String getDatabaseProductVersion() throws SQLException {
 		return this.databaseVersion;
 	}


### PR DESCRIPTION
Actually the driver does not implement the getProcedureTerm() function (https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html), causing Squirrel exceptions see https://github.com/neo4j-contrib/neo4j-jdbc/issues/165

This code should fix these errors