### PR TITLE
Fix 170 - Parsing decimal error

### DIFF
--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSet.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSet.java
@@ -251,7 +251,7 @@ public class BoltNeo4jResultSet extends Neo4jResultSet {
 		} else if (value instanceof IntegerValue) {
 			result += Long.toString(((IntegerValue) value).asLong());
 		} else if (value instanceof FloatValue) {
-			result += Float.toString(((FloatValue) value).asFloat());
+			result += Double.toString(((FloatValue) value).asDouble());
 		} else if (value instanceof BooleanValue) {
 			result += Boolean.toString(((BooleanValue) value).asBoolean());
 		} else if (value instanceof ListValue) {

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSetGettersTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSetGettersTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.jdbc.bolt;
 
-import org.neo4j.driver.internal.InternalNode;
-import org.neo4j.jdbc.Neo4jConnection;
-import org.neo4j.jdbc.Neo4jResultSet;
-import org.neo4j.jdbc.Neo4jStatement;
-import org.neo4j.jdbc.bolt.data.ResultSetData;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,13 +26,16 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.Whitebox;
 import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.jdbc.Neo4jConnection;
+import org.neo4j.jdbc.Neo4jResultSet;
+import org.neo4j.jdbc.Neo4jStatement;
+import org.neo4j.jdbc.bolt.data.ResultSetData;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.spy;
 
 /**
  * @author AgileLARUS
@@ -741,7 +739,7 @@ public class BoltNeo4jResultSetGettersTest {
 			{
 				this.put("_id", 2L);
 				this.put("_labels", Collections.singletonList("label"));
-				this.put("property", (double) 1.6F);
+				this.put("property", 1.6);
 			}
 		}, resultSet.getObject(1));
 	}
@@ -768,7 +766,7 @@ public class BoltNeo4jResultSetGettersTest {
 			{
 				this.put("_id", 2L);
 				this.put("_type", "type2");
-				this.put("property", (double) 2.6F);
+				this.put("property", 2.6);
 				this.put("_startId", 3L);
 				this.put("_endId", 4L);
 			}

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/data/ResultSetData.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/data/ResultSetData.java
@@ -35,7 +35,6 @@ import org.neo4j.driver.v1.types.Entity;
 import org.neo4j.driver.v1.types.Node;
 import org.neo4j.driver.v1.types.Path;
 
-import java.lang.reflect.Method;
 import java.util.*;
 
 import static java.util.Arrays.asList;
@@ -118,7 +117,7 @@ public class ResultSetData {
 			}
 		}, new HashMap<String, Value>() {
 			{
-				this.put("property", new FloatValue(1.6f));
+				this.put("property", new FloatValue(1.6));
 			}
 		}) });
 
@@ -133,7 +132,7 @@ public class ResultSetData {
 
 		RECORD_LIST_MORE_ELEMENTS_RELATIONS.add(new Object[] { new InternalRelationship(2, 3, 4, "type2", new HashMap<String, Value>() {
 			{
-				this.put("property", new FloatValue(2.6f));
+				this.put("property", new FloatValue(2.6));
 			}
 		}) });
 


### PR DESCRIPTION
`rs.getString("n")` where 'n' is a node or relationship containing a `double` value, it threw an exception. 

Changing a convertion method using `double` instead of `float`, it works.