### PR TITLE
Fix #175 - Version 3.4 doesn't close properly on Tomcat

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -157,6 +157,28 @@ As most JDBC clients and tools don't support complex objects, the driver can fla
 This is enabled with the JDBC-URL parameter `flatten=<rows>`, where `<rows>` indicates how many rows are sampled to determine those columns.
 With `-1` all rows are sampled and with any other value you determine the number of rows being looked at.
 
+=== Tomcat
+When the JDBC driver is configured as a JNDI resource into Tomcat, you must include these two arguments on `Resource` configuration:
+
+* `removeAbandonedOnBorrow="true"`
+* `closeMethod="close"`
+
+Here's an example:
+
+```
+    <Resource name="jdbc/neo4j"
+              auth="Container"
+              type="javax.sql.DataSource"
+              username="neo4j"
+              password="password"
+              driverClassName="org.neo4j.jdbc.bolt.BoltDriver"
+              url="jdbc:neo4j:bolt://localhost"
+              removeAbandonedOnBorrow="true"
+              closeMethod="close"
+              />
+```
+
+
 === Building the driver yourself
 
 First clone https://github.com/neo4j-contrib/neo4j-jdbc[the repository].

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaData.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaData.java
@@ -30,7 +30,6 @@ import org.neo4j.jdbc.utils.Neo4jInvocationHandler;
 
 import java.lang.reflect.Proxy;
 import java.sql.DatabaseMetaData;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,15 +57,12 @@ public class BoltNeo4jDatabaseMetaData extends Neo4jDatabaseMetaData {
 
 		// compute database metadata: version, tables == labels, columns = properties (by label)
 		if (connection != null) {
-			try {
-				BoltNeo4jConnection conn = (BoltNeo4jConnection) DriverManager.getConnection(connection.getUrl(), connection.getProperties());
-				Session session = conn.getSession();
+			try (Session session = connection.newNeo4jSession()){
 				getDatabaseVersion(session);
 				getDatabaseLabels(session);
 				getDatabaseProperties(session);
 				functions = callDbmsFunctions(session);
-				conn.close();
-			} catch (SQLException e) {
+			} catch (Exception e) {
 				LOGGER.log(Level.SEVERE, e.getMessage(), e);
 			}
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<powermock.version>1.7.3</powermock.version>
 		<junit.version>4.12</junit.version>
 		<jmh.version>1.19</jmh.version>
-		<neo4j.java.driver.version>1.6.1</neo4j.java.driver.version>
+		<neo4j.java.driver.version>1.6.3</neo4j.java.driver.version>
 		<neo4j.version>3.4.1</neo4j.version>
 		<httpclient.version>4.5.3</httpclient.version>
 		<jackson.version>2.9.2</jackson.version>


### PR DESCRIPTION
Improved the metadata management to aim to better performances and avoiding leaks.
Added into the Readme the documentation for the Tomcat connection pool usage.