### PR TITLE
Fix #176 - Improve/Optimize the Driver management in pool

### DIFF
--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaData.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaData.java
@@ -57,13 +57,17 @@ public class BoltNeo4jDatabaseMetaData extends Neo4jDatabaseMetaData {
 
 		// compute database metadata: version, tables == labels, columns = properties (by label)
 		if (connection != null) {
-			try (Session session = connection.newNeo4jSession()){
+			Session session = null;
+			try {
+				session = connection.newNeo4jSession();
 				getDatabaseVersion(session);
 				getDatabaseLabels(session);
 				getDatabaseProperties(session);
 				functions = callDbmsFunctions(session);
 			} catch (Exception e) {
 				LOGGER.log(Level.SEVERE, e.getMessage(), e);
+			}finally{
+				connection.closeSession(session);
 			}
 		}
 	}

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/cache/BoltDriverCache.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/cache/BoltDriverCache.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2016 LARUS Business Automation [http://www.larus-ba.it]
+ * <p>
+ * This file is part of the "LARUS Integration Framework for Neo4j".
+ * <p>
+ * The "LARUS Integration Framework for Neo4j" is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p>
+ * Created on 02/10/18
+ */
+package org.neo4j.jdbc.bolt.cache;
+
+import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Driver;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * A cache for the driver instances in order to reduce the number of them.
+ * In the JDBC specification the connection has the properties meanwhile in Neo4j they are on the driver.
+ */
+public class BoltDriverCache {
+
+    private Map<BoltDriverCacheKey, Driver> cache;
+    private Function<BoltDriverCacheKey, Driver> builder;
+
+    /**
+     * Setup the cache for the specific building function
+     * @param builder
+     */
+    public BoltDriverCache(Function<BoltDriverCacheKey, Driver> builder){
+        this.builder = builder;
+        this.cache = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Get driver from cache, building it if necessary
+     * @param routingUris
+     * @param config
+     * @param authToken
+     * @param info
+     * @return
+     * @throws URISyntaxException
+     */
+    public Driver getDriver(List<URI> routingUris, Config config, AuthToken authToken, Properties info) throws URISyntaxException {
+        BoltDriverCacheKey key = new BoltDriverCacheKey(routingUris, config, authToken, info);
+        Driver driver = cache.get(key);
+        if(null == driver){
+            driver = new BoltDriverCached(builder.apply(key), this, key);
+            cache.put(key, driver);
+        }
+        return driver;
+    }
+
+    public Driver removeFromCache(BoltDriverCacheKey key){
+        return cache.remove(key);
+    }
+
+    /**
+     * The internal cache, for inspection only
+     * @return
+     */
+    public Map<BoltDriverCacheKey, Driver> getCache() {
+        return cache;
+    }
+}

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/cache/BoltDriverCacheKey.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/cache/BoltDriverCacheKey.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2016 LARUS Business Automation [http://www.larus-ba.it]
+ * <p>
+ * This file is part of the "LARUS Integration Framework for Neo4j".
+ * <p>
+ * The "LARUS Integration Framework for Neo4j" is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p>
+ * Created on 02/10/18
+ */
+package org.neo4j.jdbc.bolt.cache;
+
+import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.Config;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * Implement the logic to cache driver instances (equals method)
+ */
+public class BoltDriverCacheKey {
+
+    private List<URI> routingUris;
+    private Config config;
+    private AuthToken authToken;
+    private Properties info;
+
+    /**
+     * Create the key as a combination of all the connection values
+     * @param routingUris
+     * @param config
+     * @param authToken
+     * @param info
+     */
+    public BoltDriverCacheKey(List<URI> routingUris, Config config, AuthToken authToken,Properties info) {
+        this.routingUris = routingUris;
+        this.config = config;
+        this.authToken = authToken;
+        this.info = info;
+    }
+
+    @Override
+    public int hashCode() {
+        // use equals
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BoltDriverCacheKey that = (BoltDriverCacheKey) o;
+        return Objects.equals(routingUris, that.routingUris) &&
+                compareConfig(config, that.config) &&
+                Objects.equals(authToken, that.authToken) &&
+                Objects.equals(info, that.info)
+                ;
+    }
+
+    public List<URI> getRoutingUris() {
+        return routingUris;
+    }
+
+    public Config getConfig() {
+        return config;
+    }
+
+    public AuthToken getAuthToken() {
+        return authToken;
+    }
+
+    public Properties getInfo() {
+        return info;
+    }
+
+    /**
+     * Config has no equals implemented method
+     * @param o1
+     * @param o2
+     * @return
+     */
+    protected static boolean compareConfig(Config o1, Config o2){
+        boolean equal = o1.encrypted() == o2.encrypted();
+        equal = equal && o1.idleTimeBeforeConnectionTest() == o2.idleTimeBeforeConnectionTest();
+        equal = equal && o1.maxConnectionLifetimeMillis() == o2.maxConnectionLifetimeMillis();
+        equal = equal && o1.maxConnectionPoolSize() == o2.maxConnectionPoolSize();
+        equal = equal && o1.connectionAcquisitionTimeoutMillis() == o2.connectionAcquisitionTimeoutMillis();
+        equal = equal && o1.logLeakedSessions() == o2.logLeakedSessions();
+
+        equal = equal && trustStrategyEquals(o1.trustStrategy(),o2.trustStrategy());
+
+        return equal;
+    }
+
+    /**
+     * TrustStrategy has not equals method
+     * @param t1
+     * @param t2
+     * @return
+     */
+    protected static boolean trustStrategyEquals(Config.TrustStrategy t1, Config.TrustStrategy t2 ){
+
+        if(t1 == t2){
+            return true;
+        }
+
+        // if one is null
+        if(t1 == null || t2 == null){
+            return false;
+        }
+
+        return Objects.equals(t1.certFile(),t2.certFile()) && t1.strategy() == t2.strategy();
+    }
+}

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/cache/BoltDriverCached.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/cache/BoltDriverCached.java
@@ -1,0 +1,86 @@
+package org.neo4j.jdbc.bolt.cache;
+
+import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.Session;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A driver wrapper to keep connected the instance with the cache
+ */
+public class BoltDriverCached implements Driver {
+
+    private Driver internal;
+    private BoltDriverCache cache;
+    private BoltDriverCacheKey key;
+
+    private final AtomicInteger sessionCounter = new AtomicInteger(0);
+
+    /**
+     *
+     * @param internal
+     * @param cache
+     * @param key
+     */
+    public BoltDriverCached(Driver internal, BoltDriverCache cache, BoltDriverCacheKey key) {
+        this.internal = internal;
+        this.cache = cache;
+        this.key = key;
+    }
+
+    @Override
+    public boolean isEncrypted() {
+        return internal.isEncrypted();
+    }
+
+    @Override
+    public Session session() {
+        sessionCounter.incrementAndGet();
+        return internal.session();
+    }
+
+    @Override
+    public Session session(AccessMode mode) {
+        sessionCounter.incrementAndGet();
+        return internal.session(mode);
+    }
+
+    @Override
+    public Session session(String bookmark) {
+        sessionCounter.incrementAndGet();
+        return internal.session(bookmark);
+    }
+
+    @Override
+    public Session session(AccessMode mode, String bookmark) {
+        sessionCounter.incrementAndGet();
+        return internal.session(mode, bookmark);
+    }
+
+    @Override
+    public Session session(Iterable<String> bookmarks) {
+        sessionCounter.incrementAndGet();
+        return internal.session(bookmarks);
+    }
+
+    @Override
+    public Session session(AccessMode mode, Iterable<String> bookmarks) {
+        sessionCounter.incrementAndGet();
+        return internal.session(mode, bookmarks);
+    }
+
+    @Override
+    public void close() {
+        if(sessionCounter.decrementAndGet() <= 0){
+            cache.removeFromCache(key);
+            internal.close();
+        }
+    }
+
+    @Override
+    public CompletionStage<Void> closeAsync() {
+        return internal.closeAsync();
+    }
+}

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/impl/BoltNeo4jConnectionImpl.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/impl/BoltNeo4jConnectionImpl.java
@@ -94,6 +94,7 @@ public class BoltNeo4jConnectionImpl extends Neo4jConnectionImpl implements Bolt
 
 	/**
 	 * Build an internal neo4j session, without saving reference (stateless)
+	 * Close using {@link #closeSession(Session)} for driver management
 	 * @return
 	 */
 	public Session newNeo4jSession(){
@@ -237,6 +238,17 @@ public class BoltNeo4jConnectionImpl extends Neo4jConnectionImpl implements Bolt
             }
 		} catch (Exception e) {
 			throw new SQLException("A database access error has occurred: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * If has used {@link #newNeo4jSession()}
+	 * @param session
+	 */
+	public void closeSession(Session session){
+		if (session != null) {
+			session.close();
+			this.driver.close();
 		}
 	}
 

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/impl/BoltNeo4jDriverImpl.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/impl/BoltNeo4jDriverImpl.java
@@ -91,7 +91,7 @@ public abstract class BoltNeo4jDriverImpl extends Neo4jDriver {
                 Properties routingContext = getRoutingContext(boltUrl, info);
                 boltUrl = addRoutingPolicy(boltUrl, routingContext);
                 List<URI> routingUris = buildRoutingUris(boltUrl, routingContext);
-                Driver driver = getDriver(routingUris, config, authToken);
+                Driver driver = getDriver(routingUris, config, authToken, info);
                 connection = BoltNeo4jConnectionImpl.newInstance(driver, info, url);
             } catch (Exception e) {
                 throw new SQLException(e);
@@ -100,7 +100,7 @@ public abstract class BoltNeo4jDriverImpl extends Neo4jDriver {
         return connection;
     }
 
-    protected abstract Driver getDriver(List<URI> routingUris, Config config, AuthToken authToken) throws URISyntaxException;
+    protected abstract Driver getDriver(List<URI> routingUris, Config config, AuthToken authToken, Properties info) throws URISyntaxException;
 
     private AuthToken getAuthToken(Properties properties) {
         if (!properties.containsKey("user") ) {

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/boltrouting/BoltRoutingNeo4jDriver.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/boltrouting/BoltRoutingNeo4jDriver.java
@@ -18,7 +18,11 @@
  */
 package org.neo4j.jdbc.boltrouting;
 
-import org.neo4j.driver.v1.*;
+import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.jdbc.bolt.cache.BoltDriverCache;
 import org.neo4j.jdbc.bolt.impl.BoltNeo4jDriverImpl;
 
 import java.net.URI;
@@ -44,6 +48,12 @@ public class BoltRoutingNeo4jDriver extends BoltNeo4jDriverImpl {
     public static final String LIST_SEPARATOR = ";";
     public static final String CUSTOM_ROUTING_POLICY_SEPARATOR = "&";
 
+    private static final BoltDriverCache cache = new BoltDriverCache(params ->
+    {
+        return GraphDatabase.routingDriver(params.getRoutingUris(), params.getAuthToken(), params.getConfig());
+    }
+    );
+
     static {
         try {
             BoltRoutingNeo4jDriver driver = new BoltRoutingNeo4jDriver();
@@ -58,8 +68,8 @@ public class BoltRoutingNeo4jDriver extends BoltNeo4jDriverImpl {
     }
 
     @Override
-    protected Driver getDriver(List<URI> routingUris, Config config, AuthToken authToken) throws URISyntaxException {
-        return GraphDatabase.routingDriver(routingUris, authToken, config);
+    protected Driver getDriver(List<URI> routingUris, Config config, AuthToken authToken, Properties info) throws URISyntaxException {
+        return cache.getDriver(routingUris, config, authToken, info);
     }
 
     @Override

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/cache/BoltDriverCacheTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/cache/BoltDriverCacheTest.java
@@ -1,0 +1,289 @@
+package org.neo4j.jdbc.bolt.cache;
+
+import org.junit.Test;
+import org.neo4j.driver.v1.*;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BoltDriverCacheTest {
+
+    Function<BoltDriverCacheKey, Driver> builder = (params -> {
+        return new Driver() {
+            @Override
+            public boolean isEncrypted() {
+                return false;
+            }
+
+            @Override
+            public Session session() {
+                return null;
+            }
+
+            @Override
+            public Session session(AccessMode mode) {
+                return null;
+            }
+
+            @Override
+            public Session session(String bookmark) {
+                return null;
+            }
+
+            @Override
+            public Session session(AccessMode mode, String bookmark) {
+                return null;
+            }
+
+            @Override
+            public Session session(Iterable<String> bookmarks) {
+                return null;
+            }
+
+            @Override
+            public Session session(AccessMode mode, Iterable<String> bookmarks) {
+                return null;
+            }
+
+            @Override
+            public void close() {
+
+            }
+
+            @Override
+            public CompletionStage<Void> closeAsync() {
+                return null;
+            }
+        };
+    });
+
+    @Test
+    public void shouldBeSameInstance() throws URISyntaxException {
+        List<URI> url = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder = Config.build();
+        AuthToken authToken = AuthTokens.basic("neo4j", "password");
+
+        BoltDriverCache cache = new BoltDriverCache(builder);
+        assertEquals(0, cache.getCache().size());
+
+        Driver driver1 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        List<URI> url2 = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder2 = Config.build();
+        AuthToken authToken2 = AuthTokens.basic("neo4j", "password");
+        Driver driver2 = cache.getDriver(url2, configBuilder2.toConfig(), authToken2, new Properties());
+
+        assertEquals(1, cache.getCache().size());
+        assertTrue(driver1 == driver2);
+    }
+
+    @Test
+    public void shouldCreateNewInstanceByURI() throws URISyntaxException {
+        List<URI> url = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder = Config.build();
+        AuthToken authToken = AuthTokens.basic("neo4j", "password");
+        BoltDriverCache cache = new BoltDriverCache(builder);
+
+        Driver driver1 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        url = Arrays.asList(URI.create("bolt://another"));
+
+        Driver driver2 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        assertEquals(2, cache.getCache().size());
+        assertTrue(driver1 != driver2);
+    }
+
+    @Test
+    public void shouldCreateNewInstanceByAuth() throws URISyntaxException {
+        List<URI> url = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder = Config.build();
+        AuthToken authToken = AuthTokens.basic("neo4j", "password");
+        BoltDriverCache cache = new BoltDriverCache(builder);
+
+        Driver driver1 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        authToken = AuthTokens.basic("admin", "password");
+
+        Driver driver2 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        assertEquals(2, cache.getCache().size());
+        assertTrue(driver1 != driver2);
+    }
+
+    @Test
+    public void shouldCreateNewInstanceByProperties() throws URISyntaxException {
+        List<URI> url = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder = Config.build();
+        AuthToken authToken = AuthTokens.basic("neo4j", "password");
+        BoltDriverCache cache = new BoltDriverCache(builder);
+        Properties info1 = new Properties();
+        info1.setProperty("flatten", "1");
+
+        Driver driver1 = cache.getDriver(url, configBuilder.toConfig(), authToken, info1);
+
+        Properties info2 = new Properties();
+        info2.setProperty("flatten", "2");
+
+        Driver driver2 = cache.getDriver(url, configBuilder.toConfig(), authToken, info2);
+
+        assertEquals(2, cache.getCache().size());
+        assertTrue(driver1 != driver2);
+    }
+
+    @Test
+    public void shouldCreateNewInstanceByConfigEncryption() throws URISyntaxException {
+        List<URI> url = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder = Config.build();
+        AuthToken authToken = AuthTokens.basic("neo4j", "password");
+        BoltDriverCache cache = new BoltDriverCache(builder);
+
+        Driver driver1 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        Config.ConfigBuilder configBuilder2 = Config.build().withoutEncryption();
+
+        Driver driver2 = cache.getDriver(url, configBuilder2.toConfig(), authToken, new Properties());
+
+        assertEquals(2, cache.getCache().size());
+        assertTrue(driver1 != driver2);
+    }
+
+    @Test
+    public void shouldCreateNewInstanceByConfigIdleTimeBeforeConnectionTest() throws URISyntaxException {
+        List<URI> url = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder = Config.build();
+        AuthToken authToken = AuthTokens.basic("neo4j", "password");
+        BoltDriverCache cache = new BoltDriverCache(builder);
+
+        Driver driver1 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        Config.ConfigBuilder configBuilder2 = Config.build().withConnectionLivenessCheckTimeout(1, TimeUnit.MILLISECONDS);
+
+        Driver driver2 = cache.getDriver(url, configBuilder2.toConfig(), authToken, new Properties());
+
+        assertEquals(2, cache.getCache().size());
+        assertTrue(driver1 != driver2);
+    }
+
+    @Test
+    public void shouldCreateNewInstanceByConfigMaxConnectionLifetimeMillis() throws URISyntaxException {
+        List<URI> url = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder = Config.build();
+        AuthToken authToken = AuthTokens.basic("neo4j", "password");
+        BoltDriverCache cache = new BoltDriverCache(builder);
+
+        Driver driver1 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        Config.ConfigBuilder configBuilder2 = Config.build().withMaxConnectionLifetime(1, TimeUnit.MILLISECONDS);
+
+        Driver driver2 = cache.getDriver(url, configBuilder2.toConfig(), authToken, new Properties());
+
+        assertEquals(2, cache.getCache().size());
+        assertTrue(driver1 != driver2);
+    }
+
+    @Test
+    public void shouldCreateNewInstanceByConfigMaxConnectionPoolSize() throws URISyntaxException {
+        List<URI> url = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder = Config.build();
+        AuthToken authToken = AuthTokens.basic("neo4j", "password");
+        BoltDriverCache cache = new BoltDriverCache(builder);
+
+        Driver driver1 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        Config.ConfigBuilder configBuilder2 = Config.build().withMaxConnectionPoolSize(1);
+
+        Driver driver2 = cache.getDriver(url, configBuilder2.toConfig(), authToken, new Properties());
+
+        assertEquals(2, cache.getCache().size());
+        assertTrue(driver1 != driver2);
+    }
+
+    @Test
+    public void shouldCreateNewInstanceByConfigConnectionAcquisitionTimeoutMillis() throws URISyntaxException {
+        List<URI> url = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder = Config.build();
+        AuthToken authToken = AuthTokens.basic("neo4j", "password");
+        BoltDriverCache cache = new BoltDriverCache(builder);
+
+        Driver driver1 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        Config.ConfigBuilder configBuilder2 = Config.build().withConnectionAcquisitionTimeout(1, TimeUnit.MILLISECONDS);
+
+        Driver driver2 = cache.getDriver(url, configBuilder2.toConfig(), authToken, new Properties());
+
+        assertEquals(2, cache.getCache().size());
+        assertTrue(driver1 != driver2);
+    }
+
+    @Test
+    public void shouldCreateNewInstanceByConfigLogLeakedSessions() throws URISyntaxException {
+        List<URI> url = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder = Config.build();
+        AuthToken authToken = AuthTokens.basic("neo4j", "password");
+        BoltDriverCache cache = new BoltDriverCache(builder);
+
+        Driver driver1 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        Config.ConfigBuilder configBuilder2 = Config.build().withLeakedSessionsLogging();
+
+        Driver driver2 = cache.getDriver(url, configBuilder2.toConfig(), authToken, new Properties());
+
+        assertEquals(2, cache.getCache().size());
+        assertTrue(driver1 != driver2);
+    }
+
+    @Test
+    public void shouldCreateNewInstanceByConfigTrustStrategy() throws URISyntaxException {
+        List<URI> url = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder = Config.build();
+        AuthToken authToken = AuthTokens.basic("neo4j", "password");
+        BoltDriverCache cache = new BoltDriverCache(builder);
+
+        Driver driver1 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        Config.ConfigBuilder configBuilder2 = Config.build().withTrustStrategy(Config.TrustStrategy.trustSystemCertificates());
+
+        Driver driver2 = cache.getDriver(url, configBuilder2.toConfig(), authToken, new Properties());
+
+        assertEquals(2, cache.getCache().size());
+        assertTrue(driver1 != driver2);
+    }
+
+    // SESSION MANAGEMENT //
+
+    @Test
+    public void shouldRemoveDriver() throws URISyntaxException {
+        List<URI> url = Arrays.asList(URI.create("bolt://localhost"));
+        Config.ConfigBuilder configBuilder = Config.build();
+        AuthToken authToken = AuthTokens.basic("neo4j", "password");
+
+        BoltDriverCache cache = new BoltDriverCache(builder);
+
+        Driver driver1 = cache.getDriver(url, configBuilder.toConfig(), authToken, new Properties());
+
+        List<URI> url2 = Arrays.asList(URI.create("bolt://another"));
+        Driver driver2 = cache.getDriver(url2, configBuilder.toConfig(), authToken, new Properties());
+
+        assertEquals(2, cache.getCache().size());
+
+        Session s1_1 = driver1.session(AccessMode.READ, "bookmark");
+        Session s1_2 = driver1.session(AccessMode.READ, "bookmark");
+
+        //it doesn't remove the driver from cache because the cache receive driver.close for each connection (session)
+        //so it remains in the cache if there are other opened sessions
+        driver1.close();
+        assertEquals(2, cache.getCache().size());
+        driver1.close();
+        assertEquals(1, cache.getCache().size());
+    }
+}


### PR DESCRIPTION
Added a cache layer to reduce the number of new Driver instances. The cached instance checks the opened sessions on it and when all are closed, it closes itself.  The goal of the current implementation is to reduce the overload into a connection pool (ref #175)