### PR TITLE
fixes #181: Giving exception if Labels contains space

### DIFF
--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaData.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaData.java
@@ -44,6 +44,8 @@ import java.util.logging.Logger;
  */
 public class BoltNeo4jDatabaseMetaData extends Neo4jDatabaseMetaData {
 
+	private static final String DB_PROPERTIES_QUERY = "MATCH (n:`%s`) WITH n LIMIT %d UNWIND keys(n) as key RETURN collect(distinct key) as keys";
+
 	/**
 	 * Used for some extra logging (for example in the constructor)
 	 */
@@ -96,8 +98,7 @@ public class BoltNeo4jDatabaseMetaData extends Neo4jDatabaseMetaData {
 	private void getDatabaseProperties(Session session) {
 		if (this.databaseLabels != null) {
 			for (Table databaseLabel : this.databaseLabels) {
-				StatementResult rs = session.run("MATCH (n:" + databaseLabel.getTableName() + ") WITH n LIMIT " + Neo4jDatabaseMetaData.PROPERTY_SAMPLE_SIZE
-						+ " UNWIND keys(n) as key RETURN collect(distinct key) as keys");
+				StatementResult rs = session.run(String.format(DB_PROPERTIES_QUERY, databaseLabel.getTableName(), Neo4jDatabaseMetaData.PROPERTY_SAMPLE_SIZE));
 				if (rs != null) {
 					cycleResultSetToSetDatabaseProperties(rs, databaseLabel);
 				}

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaDataIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaDataIT.java
@@ -21,11 +21,6 @@
  */
 package org.neo4j.jdbc.bolt;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -34,6 +29,8 @@ import java.sql.Statement;
 
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Neo4jDatabaseMetaData IT Tests class
@@ -53,12 +50,12 @@ public class BoltNeo4jDatabaseMetaDataIT {
 		connection.close();
 	}
 
-	@Test public void getDatabaseLabelsShouldBeOK() throws SQLException, NoSuchFieldException, IllegalAccessException {
+	@Test public void getDatabaseLabelsShouldBeOK() throws SQLException {
 		Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl","user","password");
 
 		try (Statement statement = connection.createStatement()) {
 			statement.execute("create (a:A {one:1, two:2})");
-			statement.execute("create (b:B {three:3, four:4})");
+			statement.execute("create (b:`B B` {foo:3, bar:4})");
 		}
 		
 		ResultSet labels = connection.getMetaData().getTables(null, null, null, null);
@@ -67,7 +64,7 @@ public class BoltNeo4jDatabaseMetaDataIT {
 		assertTrue(labels.next());
 		assertEquals("A", labels.getString("TABLE_NAME"));
 		assertTrue(labels.next());
-		assertEquals("B", labels.getString("TABLE_NAME"));
+		assertEquals("B B", labels.getString("TABLE_NAME"));
 		assertTrue(!labels.next());
 
 		connection.close();
@@ -77,6 +74,27 @@ public class BoltNeo4jDatabaseMetaDataIT {
 		Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl","user","password");
 		connection.setAutoCommit(false);
 		connection.getMetaData();
+
+		connection.close();
+	}
+
+	@Test public void getDatabaseColumnsShouldBeOK() throws SQLException {
+		Connection connection = DriverManager.getConnection("jdbc:neo4j:" + neo4j.getBoltUrl() + "?nossl","user","password");
+
+		try (Statement statement = connection.createStatement()) {
+			statement.execute("create (p:Person{name: 'Andrea', age: 80, `foo bar`: 'foo bar'})");
+		}
+
+		ResultSet columns = connection.getMetaData().getColumns(null, null, null, null);
+
+		assertNotNull(columns);
+		assertTrue(columns.next());
+		assertEquals("foo bar", columns.getString(4));
+		assertTrue(columns.next());
+		assertEquals("name", columns.getString(4));
+		assertTrue(columns.next());
+		assertEquals("age", columns.getString(4));
+		assertFalse(columns.next());
 
 		connection.close();
 	}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/utils/SanitizeUtils.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/utils/SanitizeUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019 LARUS Business Automation [http://www.larus-ba.it]
+ * <p>
+ * This file is part of the "LARUS Integration Framework for Neo4j".
+ * <p>
+ * The "LARUS Integration Framework for Neo4j" is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.utils;
+
+import java.util.regex.Pattern;
+
+/**
+ * This class contains static methods used to sanitize data
+ *
+ * @author AgileLARUS
+ * @since 3.3.1
+ */
+public class SanitizeUtils {
+
+    private SanitizeUtils() {}
+
+    private static final String BACKTICK = "`";
+
+    /**
+     * This method return a String that is the sanitized version of the string.
+     * <br>
+     * i.e. input: `property name` => output => property name
+     *
+     * @param raw The string to be sanitized.
+     * @return The sanitized string.
+     */
+    public static String sanitizePropertyName(String property) {
+        return property.replaceAll(BACKTICK, "");
+    }
+
+    /**
+     * This method return a quoted String with backtick (<b>`</b>) if the input is not a valid java identifier, otherwise
+     * returns the string itself
+     * <br>
+     * i.e. input: property name => output => `property name`
+     *
+     * @param raw The string to be quoted.
+     * @return The quoted string.
+     */
+    public static String quote(String value) {
+        return isValidJavaIdentifier(value) ? value : BACKTICK + value + BACKTICK;
+    }
+
+    private static boolean isValidJavaIdentifier(String identifier) {
+        if (identifier == null || identifier.isEmpty() || !Character.isJavaIdentifierStart(identifier.charAt(0))) {
+            return false;
+        }
+        for (int i = 1; i < identifier.length(); i++) {
+            if (!Character.isJavaIdentifierPart(identifier.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/utils/Neo4jPreparedStatementBuilderTest.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/utils/Neo4jPreparedStatementBuilderTest.java
@@ -83,4 +83,14 @@ public class Neo4jPreparedStatementBuilderTest {
 		String raw = "MATCH n RETURN n WHERE param = {2} AND paramString = \"string{3}\"\n" + "AND param2 = {1}";
 		assertEquals(2, PreparedStatementBuilder.namedParameterCount(raw));
 	}
+
+	@Test public void replacePlaceholderWithBacktickShouldReplaceQuestionMarksMultiline() {
+		String raw = "MATCH (n:`My Label`) RETURN same WHERE `there Is APlaceholder` = ? \nAND `new Line Par` = ?";
+		assertEquals("MATCH (n:`My Label`) RETURN same WHERE `there Is APlaceholder` = {1} \nAND `new Line Par` = {2}", replacePlaceholders(raw));
+	}
+
+	@Test public void placeholdersCountShouldCountCorrectlyWithBacktickIfOneLine() {
+		String raw = "MATCH (n:`My Label`) RETURN n WHERE `param name` = {1}";
+		assertEquals(1, PreparedStatementBuilder.namedParameterCount(raw));
+	}
 }


### PR DESCRIPTION
Changes:
- Fixed metadata resolution in case of backtick
- Fixed node property resolution in case of a property contains a backtick
- Fixed relationship property resolution in case of a property contains a backtick