### PR TITLE
fixes #179: BoltRoutingNeo4jDriver - Issue with Boolean Data type

### DIFF
--- a/neo4j-jdbc-bolt/pom.xml
+++ b/neo4j-jdbc-bolt/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>neo4j-jdbc</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
         <!-- Performance tests dependencies -->
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/DataConverterUtils.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/DataConverterUtils.java
@@ -1,0 +1,295 @@
+package org.neo4j.jdbc.utils;
+
+import org.neo4j.driver.internal.InternalIsoDuration;
+import org.neo4j.driver.internal.value.*;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.types.Node;
+import org.neo4j.driver.v1.types.Path;
+import org.neo4j.driver.v1.types.Point;
+import org.neo4j.driver.v1.types.Relationship;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.*;
+import java.util.*;
+
+public class DataConverterUtils {
+
+    /**
+     * Convert Value to sql.Time
+     * @param value
+     * @return
+     */
+    public static Time valueToTime(Value value){
+        return valueToTime(value, Calendar.getInstance());
+    }
+
+    /**
+     * Convert Value to sql.Time with timezone
+     * @param value
+     * @return
+     */
+    public static Time valueToTime(Value value, Calendar cal){
+        if (value.isNull()){
+            return null;
+        }
+
+        if (value instanceof TimeValue){
+            ZoneOffset zoneOffset = ZoneOffset.ofTotalSeconds(cal.get(Calendar.ZONE_OFFSET) / 1000);
+            TimeValue timeValue = (TimeValue) value;
+            OffsetTime offsetTime = timeValue.asOffsetTime().withOffsetSameInstant(zoneOffset);
+            return offsetTimeToTime(offsetTime);
+        }
+
+        if (value instanceof LocalTimeValue){
+            return localTimeToTime(((LocalTimeValue)value).asLocalTime());
+        }
+
+        return null;
+    }
+
+    /**
+     * Convert LocalTime to sql.Time
+     * @param localTime
+     * @return
+     */
+    public static Time localTimeToTime(LocalTime localTime) {
+        Time time = Time.valueOf(localTime);
+        time.setTime(time.getTime()+localTime.getNano() / 1000_000L);
+        return time;
+    }
+
+    /**
+     * Convert OffsetTime to sql.Time
+     * @param offsetTime
+     * @return
+     */
+    public static Time offsetTimeToTime(OffsetTime offsetTime) {
+        return localTimeToTime(offsetTime.toLocalTime());
+    }
+
+
+    /**
+     * Convert Value to sql.Date
+     * @param value
+     * @return
+     */
+    public static Date valueToDate(Value value){
+        if (value.isNull()){
+            return null;
+        }
+
+        if (value instanceof DateValue){
+            return localDateToDate(((DateValue)value).asLocalDate());
+        }
+
+        return null;
+    }
+
+    /**
+     * Convert a LocalDate to sql.Date
+     * @param localDate
+     * @return
+     */
+    public static Date localDateToDate(LocalDate localDate) {
+        return Date.valueOf(localDate);
+    }
+
+    /**
+     * Convert Value to Timestamp with system timezone
+     * @param value
+     * @return
+     */
+    public static Timestamp valueToTimestamp(Value value){
+        return valueToTimestamp(value, ZoneId.systemDefault() );
+    }
+
+    /**
+     * Convert Value to Timestamp with timezone
+     * @param value
+     * @return
+     */
+    public static Timestamp valueToTimestamp(Value value, ZoneId zone) {
+        if (value.isNull()){
+            return null;
+        }
+
+        if (value instanceof DateTimeValue){
+            return zonedDateTimeToTimestamp(value.asZonedDateTime().withZoneSameInstant(zone));
+        }
+
+        if (value instanceof LocalDateTimeValue){
+            return localDateTimeToTimestamp(value.asLocalDateTime());
+        }
+
+        return null;
+    }
+
+    /**
+     * Convert a LocalDataTime to sql.Timestamp
+     * @param ldt
+     * @return
+     */
+    public static Timestamp localDateTimeToTimestamp(LocalDateTime ldt) {
+        return Timestamp.valueOf(ldt);
+    }
+
+    /**
+     * Convert a ZonedDateTime to sql.Timestamp
+     * @param zdt
+     * @return
+     */
+    public static Timestamp zonedDateTimeToTimestamp(ZonedDateTime zdt){
+        return new Timestamp(zdt.toInstant().toEpochMilli());
+    }
+
+    /**
+     * It hides the neo4j type with standard Java type (or sql java type)
+     * @param value
+     * @return
+     */
+    public static Object convertObject(Object value) {
+        Object converted = value;
+        if (value instanceof List) {
+            return convertList((List) value);
+        }
+        if (value instanceof ZonedDateTime) {
+            return zonedDateTimeToTimestamp((ZonedDateTime) value);
+        }
+        if (value instanceof LocalDateTime) {
+            return localDateTimeToTimestamp((LocalDateTime) value);
+        }
+        if (value instanceof LocalDate) {
+            return localDateToDate((LocalDate) value);
+        }
+        if (value instanceof OffsetTime){
+            return offsetTimeToTime((OffsetTime) value);
+        }
+        if (value instanceof LocalTime){
+            return localTimeToTime((LocalTime) value);
+        }
+        if (value instanceof InternalIsoDuration){
+            return durationToMap((InternalIsoDuration)value);
+        }
+        if (value instanceof Path) {
+            return PathSerializer.toPath((Path) value);
+        }
+        if (value instanceof Node) {
+            return nodeToMap((Node) value);
+        }
+        if (value instanceof Relationship) {
+            return relationshipToMap((Relationship) value);
+        }
+        if (value instanceof Point) {
+            return pointToMap((Point) converted);
+        }
+
+        return converted;
+    }
+
+    /**
+     * It transforms a Neo4j Point (Spatial) into a java Map
+     * @param point
+     * @return
+     */
+    public static Map<String, Object> pointToMap(Point point) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("srid",point.srid());
+        map.put("x", point.x());
+        map.put("y", point.y());
+
+        switch(point.srid()){
+            case 7203:
+                map.put("crs","cartesian");
+                break;
+            case 9157:
+                map.put("crs","cartesian-3d");
+                map.put("z", point.z());
+                break;
+            case 4326:
+                map.put("crs","wgs-84");
+                map.put("longitude", point.x());
+                map.put("latitude", point.y());
+                break;
+            case 4979:
+                map.put("crs","wgs-84-3d");
+                map.put("longitude", point.x());
+                map.put("latitude", point.y());
+                map.put("height",point.z());
+                map.put("z", point.z());
+                break;
+        }
+
+        return map;
+    }
+
+
+    /**
+     * It builds a new List with the items converted into java type
+     * @param list
+     * @return
+     */
+    public static List convertList(List list) {
+        List converted = new ArrayList(list.size());
+
+        for (Object o : list) {
+            converted.add(convertObject(o));
+        }
+
+        return converted;
+    }
+
+    /**
+     * Convert a InternalIsoDuration to a Map with the same fields you can get with cypher
+     * @param obj
+     * @return
+     */
+    public static Map<String, Object> durationToMap(InternalIsoDuration obj) {
+        Map<String, Object> converted = new HashMap<>(16);
+
+        converted.put("duration", obj.toString());
+        converted.put("months", obj.months());
+        converted.put("days", obj.days());
+        converted.put("seconds", obj.seconds());
+        converted.put("nanoseconds", obj.nanoseconds());
+
+        return converted;
+    }
+
+    /**
+     * It build a new Map with the same keys but with pure java type, instead of Neo4j types
+     * @param fields
+     * @return
+     */
+    public static Map<String, Object> convertFields(Map<String, Object> fields){
+        Map<String, Object> converted = new HashMap();
+
+        Set<Map.Entry<String, Object>> entrySet = fields.entrySet();
+
+        for (Map.Entry<String, Object> entry : entrySet) {
+            converted.put(entry.getKey(), convertObject(entry.getValue()));
+        }
+
+        return converted;
+    }
+
+    public static Map<String, Object> nodeToMap(Node value) {
+        Map<String, Object> nodeMap = new LinkedHashMap<>();
+        nodeMap.put("_id", value.id());
+        nodeMap.put("_labels", value.labels());
+        nodeMap.putAll(convertFields(value.asMap()));
+        return nodeMap;
+    }
+
+    public static Map<String, Object> relationshipToMap(Relationship value) {
+        Map<String, Object> relMap = new LinkedHashMap<>();
+        relMap.put("_id", value.id());
+        relMap.put("_type", value.type());
+        relMap.put("_startId", value.startNodeId());
+        relMap.put("_endId", value.endNodeId());
+        relMap.putAll(convertFields(value.asMap()));
+        return relMap;
+    }
+
+}

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/JSONUtils.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/JSONUtils.java
@@ -1,0 +1,43 @@
+package org.neo4j.jdbc.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.neo4j.driver.v1.types.Node;
+import org.neo4j.driver.v1.types.Path;
+import org.neo4j.driver.v1.types.Point;
+import org.neo4j.driver.v1.types.Relationship;
+
+
+public class JSONUtils {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectWriter OBJECT_WRITER;
+    static {
+        OBJECT_MAPPER.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        SimpleModule module = new SimpleModule("Neo4jJdbcSerializer");
+        module.addSerializer(Node.class, new NodeSerializer());
+        module.addSerializer(Relationship.class, new RelationshipSerializer());
+        module.addSerializer(Path.class, new PathSerializer());
+        module.addSerializer(Point.class, new PointSerializer()); // TODO add more serializers in order to remove ObjectConverter
+        OBJECT_MAPPER.registerModule(module);
+        OBJECT_MAPPER.setDefaultPrettyPrinter(new Neo4jJdbcPrettyPrinter());
+        OBJECT_WRITER = OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
+    }
+
+    public static String writeValueAsString(Object value) {
+        try {
+            return OBJECT_WRITER.writeValueAsString(value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> T convertValue(Object value, Class<T> type) {
+        try {
+            return OBJECT_MAPPER.convertValue(value, type);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/Neo4jJdbcPrettyPrinter.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/Neo4jJdbcPrettyPrinter.java
@@ -1,0 +1,26 @@
+package org.neo4j.jdbc.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
+
+import java.io.IOException;
+
+public class Neo4jJdbcPrettyPrinter extends MinimalPrettyPrinter {
+    private static final char COMMA = ',';
+    private static final char WHITE_SPACE = ' ';
+
+    private void writeSeparator(JsonGenerator jsonGenerator) throws IOException {
+        jsonGenerator.writeRaw(COMMA);
+        jsonGenerator.writeRaw(WHITE_SPACE);
+    }
+
+    @Override
+    public void writeObjectEntrySeparator(JsonGenerator jsonGenerator) throws IOException {
+        writeSeparator(jsonGenerator);
+    }
+
+    @Override
+    public void writeArrayValueSeparator(JsonGenerator jsonGenerator) throws IOException {
+        writeSeparator(jsonGenerator);
+    }
+}

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/NodeSerializer.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/NodeSerializer.java
@@ -1,0 +1,19 @@
+package org.neo4j.jdbc.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.neo4j.driver.v1.types.Node;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.neo4j.jdbc.utils.DataConverterUtils.nodeToMap;
+
+public class NodeSerializer extends JsonSerializer<Node> {
+    @Override
+    public void serialize(Node value, JsonGenerator jsonGenerator, SerializerProvider serializers) throws IOException {
+        Map<String, Object> nodeMap = nodeToMap(value);
+        jsonGenerator.writeObject(nodeMap);
+    }
+}

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/PathSerializer.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/PathSerializer.java
@@ -1,0 +1,32 @@
+package org.neo4j.jdbc.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.neo4j.driver.v1.types.Path;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.neo4j.jdbc.utils.DataConverterUtils.nodeToMap;
+import static org.neo4j.jdbc.utils.DataConverterUtils.relationshipToMap;
+
+public class PathSerializer extends JsonSerializer<Path> {
+    @Override
+    public void serialize(Path value, JsonGenerator jsonGenerator, SerializerProvider serializers) throws IOException {
+        List<Map<String, Object>> list = toPath(value);
+        jsonGenerator.writeObject(list);
+    }
+
+    public static List<Map<String, Object>> toPath(Path value) {
+        List<Map<String, Object>> list = new ArrayList<>();
+        list.add(nodeToMap(value.start()));
+        for (Path.Segment s : value) {
+            list.add(relationshipToMap(s.relationship()));
+            list.add(nodeToMap(s.end()));
+        }
+        return list;
+    }
+}

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/PointSerializer.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/PointSerializer.java
@@ -1,0 +1,21 @@
+package org.neo4j.jdbc.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.neo4j.driver.v1.types.Point;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.neo4j.jdbc.utils.DataConverterUtils.pointToMap;
+
+public class PointSerializer extends JsonSerializer<Point> {
+
+    @Override
+    public void serialize(Point value, JsonGenerator jsonGenerator, SerializerProvider serializers) throws IOException {
+        Map<String, Object> point = pointToMap(value);
+        jsonGenerator.writeObject(point);
+    }
+
+}

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/RelationshipSerializer.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/utils/RelationshipSerializer.java
@@ -1,0 +1,19 @@
+package org.neo4j.jdbc.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.neo4j.driver.v1.types.Relationship;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.neo4j.jdbc.utils.DataConverterUtils.relationshipToMap;
+
+public class RelationshipSerializer extends JsonSerializer<Relationship> {
+    @Override
+    public void serialize(Relationship value, JsonGenerator jsonGenerator, SerializerProvider serializers) throws IOException {
+        Map<String, Object> relMap = relationshipToMap(value);
+        jsonGenerator.writeObject(relMap);
+    }
+}

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSetGettersTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSetGettersTest.java
@@ -205,10 +205,22 @@ public class BoltNeo4jResultSetGettersTest {
 		ResultSet resultSet = BoltNeo4jResultSet.newInstance(false, null, statementResult);
 
 		resultSet.next();
-		assertEquals("{\"id\":1, \"labels\":[\"label1\", \"label2\"], \"property2\":1, \"property1\":\"value1\"}", resultSet.getString("node"));
+		assertEquals("{\"_id\":1, \"_labels\":[\"label1\", \"label2\"], \"property2\":1, \"property1\":\"value1\"}", resultSet.getString("node"));
 
 		resultSet.next();
-		assertEquals("{\"id\":2, \"labels\":[\"label\"], \"property\":1.6}", resultSet.getString(1));
+		assertEquals("{\"_id\":2, \"_labels\":[\"label\"], \"property\":1.6}", resultSet.getString(1));
+	}
+
+	@Test public void getObjectShouldReturnStringOnNode() throws SQLException {
+		StatementResult statementResult = ResultSetData
+				.buildResultCursor(ResultSetData.KEYS_RECORD_LIST_MORE_ELEMENTS_NODES, ResultSetData.RECORD_LIST_MORE_ELEMENTS_NODES);
+		ResultSet resultSet = BoltNeo4jResultSet.newInstance(false, null, statementResult);
+
+		resultSet.next();
+		assertEquals("{\"_id\":1, \"_labels\":[\"label1\", \"label2\"], \"property2\":1, \"property1\":\"value1\"}", resultSet.getString("node"));
+
+		resultSet.next();
+		assertEquals("{\"_id\":2, \"_labels\":[\"label\"], \"property\":1.6}", resultSet.getString(1));
 	}
 
 	@Test public void getStringShouldReturnStringOnRelationship() throws SQLException {
@@ -217,10 +229,10 @@ public class BoltNeo4jResultSetGettersTest {
 		ResultSet resultSet = BoltNeo4jResultSet.newInstance(false, null, statementResult);
 
 		resultSet.next();
-		assertEquals("{\"id\":1, \"type\":\"type1\", \"startId\":1, \"endId\":2, \"property2\":100, \"property1\":\"value\"}", resultSet.getString("relation"));
+		assertEquals("{\"_id\":1, \"_type\":\"type1\", \"_startId\":1, \"_endId\":2, \"property2\":100, \"property1\":\"value\"}", resultSet.getString("relation"));
 
 		resultSet.next();
-		assertEquals("{\"id\":2, \"type\":\"type2\", \"startId\":3, \"endId\":4, \"property\":2.6}", resultSet.getString(1));
+		assertEquals("{\"_id\":2, \"_type\":\"type2\", \"_startId\":3, \"_endId\":4, \"property\":2.6}", resultSet.getString(1));
 	}
 
 	@Test public void getStringShouldReturnStringOnPath() throws SQLException {
@@ -230,12 +242,12 @@ public class BoltNeo4jResultSetGettersTest {
 
 		resultSet.next();
 		assertEquals(
-				"[{\"id\":1, \"labels\":[\"label1\"], \"property\":\"value\"}, {\"id\":3, \"type\":\"type\", \"startId\":1, \"endId\":2, \"relProperty\":\"value3\"}, {\"id\":2, \"labels\":[\"label1\"], \"property\":\"value2\"}]",
+				"[{\"_id\":1, \"_labels\":[\"label1\"], \"property\":\"value\"}, {\"_id\":3, \"_type\":\"type\", \"_startId\":1, \"_endId\":2, \"relProperty\":\"value3\"}, {\"_id\":2, \"_labels\":[\"label1\"], \"property\":\"value2\"}]",
 				resultSet.getString("path"));
 
 		resultSet.next();
 		assertEquals(
-				"[{\"id\":4, \"labels\":[\"label1\"], \"property\":\"value\"}, {\"id\":7, \"type\":\"type\", \"startId\":4, \"endId\":5, \"relProperty\":\"value4\"}, {\"id\":5, \"labels\":[\"label1\"], \"property\":\"value2\"}, {\"id\":8, \"type\":\"type\", \"startId\":6, \"endId\":5, \"relProperty\":\"value5\"}, {\"id\":6, \"labels\":[\"label1\"], \"property\":\"value3\"}]",
+				"[{\"_id\":4, \"_labels\":[\"label1\"], \"property\":\"value\"}, {\"_id\":7, \"_type\":\"type\", \"_startId\":4, \"_endId\":5, \"relProperty\":\"value4\"}, {\"_id\":5, \"_labels\":[\"label1\"], \"property\":\"value2\"}, {\"_id\":8, \"_type\":\"type\", \"_startId\":6, \"_endId\":5, \"relProperty\":\"value5\"}, {\"_id\":6, \"_labels\":[\"label1\"], \"property\":\"value3\"}]",
 				resultSet.getString(1));
 	}
 
@@ -1049,9 +1061,13 @@ public class BoltNeo4jResultSetGettersTest {
 
 		resultSet.next();
 		assertTrue(resultSet.getBoolean("columnBoolean"));
+		assertEquals("true", resultSet.getString("columnBoolean"));
+		assertTrue((Boolean) resultSet.getObject("columnBoolean"));
 
 		resultSet.next();
 		assertFalse(resultSet.getBoolean("columnBoolean"));
+		assertEquals("false", resultSet.getString("columnBoolean"));
+		assertFalse((Boolean) resultSet.getObject("columnBoolean"));
 	}
 
 	@Test public void getBooleanByLabelShouldThrowExceptionNoLabel() throws SQLException {

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSetIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSetIT.java
@@ -184,7 +184,7 @@ public class BoltNeo4jResultSetIT {
 		String json = rs.getString("x");
 		assertTrue(json.startsWith("{"));
 		assertTrue(json.endsWith("}"));
-		assertTrue(json.contains("\"labels\":[\"Test\"]"));
+		assertTrue(json.contains("\"_labels\":[\"Test\"]"));
 		assertTrue(json.contains("\"floatn\":1.123"));
 		assertTrue(json.contains("\"intn\":1"));
 
@@ -219,7 +219,7 @@ public class BoltNeo4jResultSetIT {
 		String json = rs.getString("r");
 		assertTrue(json.startsWith("{"));
 		assertTrue(json.endsWith("}"));
-		assertTrue(json.contains("\"type\":\"Rel\""));
+		assertTrue(json.contains("\"_type\":\"Rel\""));
 		assertTrue(json.contains("\"floatn\":1.123"));
 		assertTrue(json.contains("\"intn\":1"));
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -66,7 +66,7 @@ public abstract class Neo4jDriver implements java.sql.Driver {
 	}
 
 	@Override public int getMinorVersion() {
-		return 2;
+		return 4;
 	}
 
 	@Override public boolean jdbcCompliant() {


### PR DESCRIPTION
List of provided changes:
- Moved the conversion methods into the `DataConverterUtils` class
- Added Node/Relationship/Path serializers to Jackson in order to have a unique source of serialization
- Unified the json representation of a graph entity; i.e. a relationship was represented as `{id:1, startId: 1, endId: 2, ...}` with the`getString` method and as map `{_id:1, _startId: 1, _endId: 2, ...}` with the `getObject` method.