### PR TITLE
fixes #187: Intellj Datasource browser Method supportsSavepoints in class org.neo4j.jdbc.Neo4jDatabaseMetaData is not yet implemented.

### DIFF
--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
@@ -422,7 +422,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	@Override public boolean nullsAreSortedAtStart() throws SQLException {
 		return false;
 	}
-	
+
 	@Override public boolean nullsAreSortedAtEnd() throws SQLException {
 		return false;
 	}
@@ -432,119 +432,119 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	/*---------------------------------*/
 
 	@Override public boolean usesLocalFiles() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean usesLocalFilePerTable() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public String getSystemFunctions() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return "";
 	}
 
 	@Override public boolean supportsAlterTableWithAddColumn() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsAlterTableWithDropColumn() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsColumnAliasing() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean nullPlusNonNullIsNull() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsConvert() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsConvert(int fromType, int toType) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsTableCorrelationNames() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsDifferentTableCorrelationNames() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsExpressionsInOrderBy() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsOrderByUnrelated() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsGroupBy() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsGroupByUnrelated() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsGroupByBeyondSelect() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsLikeEscapeClause() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsMultipleTransactions() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsNonNullableColumns() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsMinimumSQLGrammar() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsCoreSQLGrammar() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsExtendedSQLGrammar() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsANSI92EntryLevelSQL() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsANSI92IntermediateSQL() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsANSI92FullSQL() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsIntegrityEnhancementFacility() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsOuterJoins() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsFullOuterJoins() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsLimitedOuterJoins() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public String getSchemaTerm() throws SQLException {
@@ -552,7 +552,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public String getProcedureTerm() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return "";
 	}
 
 	@Override public boolean isCatalogAtStart() throws SQLException {
@@ -580,55 +580,55 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean supportsPositionedDelete() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsPositionedUpdate() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsSubqueriesInComparisons() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsSubqueriesInExists() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsSubqueriesInIns() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsSubqueriesInQuantifieds() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsCorrelatedSubqueries() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsUnion() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsUnionAll() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsOpenCursorsAcrossCommit() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsOpenCursorsAcrossRollback() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsOpenStatementsAcrossCommit() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsOpenStatementsAcrossRollback() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public int getMaxBinaryLiteralLength() throws SQLException {
@@ -688,7 +688,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean doesMaxRowSizeIncludeBlobs() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public int getMaxStatementLength() throws SQLException {
@@ -708,61 +708,61 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean supportsTransactionIsolationLevel(int level) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsDataDefinitionAndDataManipulationTransactions() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsDataManipulationTransactionsOnly() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean dataDefinitionCausesTransactionCommit() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean dataDefinitionIgnoredInTransactions() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public ResultSet getProcedureColumns(String catalog, String schemaPattern, String procedureNamePattern, String columnNamePattern)
 			throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getColumnPrivileges(String catalog, String schema, String table, String columnNamePattern) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getBestRowIdentifier(String catalog, String schema, String table, int scope, boolean nullable) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getVersionColumns(String catalog, String schema, String table) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getPrimaryKeys(String catalog, String schema, String table) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getImportedKeys(String catalog, String schema, String table) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getExportedKeys(String catalog, String schema, String table) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getCrossReference(String parentCatalog, String parentSchema, String parentTable, String foreignCatalog, String foreignSchema,
 			String foreignTable) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getTypeInfo() throws SQLException {
@@ -770,7 +770,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public ResultSet getIndexInfo(String catalog, String schema, String table, boolean unique, boolean approximate) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public boolean supportsResultSetType(int type) throws SQLException {
@@ -778,51 +778,51 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean supportsResultSetConcurrency(int type, int concurrency) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean ownUpdatesAreVisible(int type) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean ownDeletesAreVisible(int type) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean ownInsertsAreVisible(int type) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean othersUpdatesAreVisible(int type) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean othersDeletesAreVisible(int type) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean othersInsertsAreVisible(int type) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean updatesAreDetected(int type) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean deletesAreDetected(int type) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean insertsAreDetected(int type) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsBatchUpdates() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public ResultSet getUDTs(String catalog, String schemaPattern, String typeNamePattern, int[] types) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public boolean supportsSavepoints() throws SQLException {
@@ -830,31 +830,31 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean supportsNamedParameters() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsMultipleOpenResults() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsGetGeneratedKeys() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getAttributes(String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public boolean supportsResultSetHoldability(int holdability) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public int getResultSetHoldability() throws SQLException {
@@ -866,11 +866,11 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean locatorsUpdateCopy() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean supportsStatementPooling() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public RowIdLifetime getRowIdLifetime() throws SQLException {
@@ -878,36 +878,36 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public boolean supportsStoredFunctionsUsingCallSyntax() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean autoCommitFailureClosesAllResultSets() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public ResultSet getClientInfoProperties() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getFunctionColumns(String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern)
 			throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public ResultSet getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
 	@Override public boolean generatedKeyAlwaysReturned() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
@@ -26,9 +26,7 @@ import org.neo4j.jdbc.utils.ExceptionBuilder;
 import org.neo4j.jdbc.utils.Neo4jJdbcRuntimeException;
 
 import java.io.InputStream;
-import java.sql.ResultSet;
-import java.sql.RowIdLifetime;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
@@ -875,7 +875,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public RowIdLifetime getRowIdLifetime() throws SQLException {
-		return DatabaseMetaData.ROWID_UNSUPPORTED;
+		return RowIdLifetime.ROWID_UNSUPPORTED;
 	}
 
 	@Override public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
@@ -372,7 +372,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean supportsMixedCaseQuotedIdentifiers() throws SQLException {
-		return false;
+		return true;
 	}
 
 	@Override public boolean storesUpperCaseQuotedIdentifiers() throws SQLException {
@@ -384,7 +384,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean storesMixedCaseQuotedIdentifiers() throws SQLException {
-		return false;
+		return true;
 	}
 
 	@Override public boolean supportsSelectForUpdate() throws SQLException {
@@ -412,11 +412,11 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 	
 	@Override public boolean nullsAreSortedHigh() throws SQLException {
-		return true;
+		return false;
 	}
 	
 	@Override public boolean nullsAreSortedLow() throws SQLException {
-		return false;
+		return true;
 	}
 	
 	@Override public boolean nullsAreSortedAtStart() throws SQLException {
@@ -424,7 +424,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean nullsAreSortedAtEnd() throws SQLException {
-		return false;
+		return true;
 	}
 	
 	/*---------------------------------*/
@@ -452,11 +452,11 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean supportsColumnAliasing() throws SQLException {
-		return false;
+		return true;
 	}
 
 	@Override public boolean nullPlusNonNullIsNull() throws SQLException {
-		return false;
+		return true;
 	}
 
 	@Override public boolean supportsConvert() throws SQLException {
@@ -476,7 +476,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean supportsExpressionsInOrderBy() throws SQLException {
-		return false;
+		return true;
 	}
 
 	@Override public boolean supportsOrderByUnrelated() throws SQLException {
@@ -552,7 +552,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public String getProcedureTerm() throws SQLException {
-		return "";
+		return "procedure";
 	}
 
 	@Override public boolean isCatalogAtStart() throws SQLException {
@@ -608,11 +608,11 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean supportsUnion() throws SQLException {
-		return false;
+		return true;
 	}
 
 	@Override public boolean supportsUnionAll() throws SQLException {
-		return false;
+		return true;
 	}
 
 	@Override public boolean supportsOpenCursorsAcrossCommit() throws SQLException {
@@ -632,15 +632,15 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public int getMaxBinaryLiteralLength() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxCharLiteralLength() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxColumnNameLength() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxColumnsInGroupBy() throws SQLException {
@@ -648,43 +648,43 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public int getMaxColumnsInIndex() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxColumnsInOrderBy() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxColumnsInSelect() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxColumnsInTable() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxCursorNameLength() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxIndexLength() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxSchemaNameLength() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxProcedureNameLength() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxCatalogNameLength() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxRowSize() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public boolean doesMaxRowSizeIncludeBlobs() throws SQLException {
@@ -692,23 +692,23 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public int getMaxStatementLength() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxTableNameLength() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxTablesInSelect() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxUserNameLength() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public boolean supportsTransactionIsolationLevel(int level) throws SQLException {
-		return false;
+		return level == Connection.TRANSACTION_READ_COMMITTED;
 	}
 
 	@Override public boolean supportsDataDefinitionAndDataManipulationTransactions() throws SQLException {
@@ -716,7 +716,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean supportsDataManipulationTransactionsOnly() throws SQLException {
-		return false;
+		return true;
 	}
 
 	@Override public boolean dataDefinitionCausesTransactionCommit() throws SQLException {
@@ -727,50 +727,53 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 		return false;
 	}
 
+	private ResultSet emptyResultSet() {
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+	}
 	@Override public ResultSet getProcedureColumns(String catalog, String schemaPattern, String procedureNamePattern, String columnNamePattern)
 			throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getColumnPrivileges(String catalog, String schema, String table, String columnNamePattern) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getBestRowIdentifier(String catalog, String schema, String table, int scope, boolean nullable) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getVersionColumns(String catalog, String schema, String table) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getPrimaryKeys(String catalog, String schema, String table) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getImportedKeys(String catalog, String schema, String table) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getExportedKeys(String catalog, String schema, String table) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getCrossReference(String parentCatalog, String parentSchema, String parentTable, String foreignCatalog, String foreignSchema,
 			String foreignTable) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getTypeInfo() throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getIndexInfo(String catalog, String schema, String table, boolean unique, boolean approximate) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public boolean supportsResultSetType(int type) throws SQLException {
@@ -782,15 +785,15 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean ownUpdatesAreVisible(int type) throws SQLException {
-		return false;
+		return type == ResultSet.TYPE_FORWARD_ONLY;
 	}
 
 	@Override public boolean ownDeletesAreVisible(int type) throws SQLException {
-		return false;
+		return type == ResultSet.TYPE_FORWARD_ONLY;
 	}
 
 	@Override public boolean ownInsertsAreVisible(int type) throws SQLException {
-		return false;
+		return type == ResultSet.TYPE_FORWARD_ONLY;
 	}
 
 	@Override public boolean othersUpdatesAreVisible(int type) throws SQLException {
@@ -818,11 +821,11 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public boolean supportsBatchUpdates() throws SQLException {
-		return false;
+		return true;
 	}
 
 	@Override public ResultSet getUDTs(String catalog, String schemaPattern, String typeNamePattern, int[] types) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public boolean supportsSavepoints() throws SQLException {
@@ -842,15 +845,15 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getAttributes(String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public boolean supportsResultSetHoldability(int holdability) throws SQLException {
@@ -858,11 +861,11 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public int getResultSetHoldability() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ResultSet.CLOSE_CURSORS_AT_COMMIT;
 	}
 
 	@Override public int getSQLStateType() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return -1;
 	}
 
 	@Override public boolean locatorsUpdateCopy() throws SQLException {
@@ -874,15 +877,15 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public RowIdLifetime getRowIdLifetime() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return DatabaseMetaData.ROWID_UNSUPPORTED;
 	}
 
 	@Override public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public boolean supportsStoredFunctionsUsingCallSyntax() throws SQLException {
-		return false;
+		return true;
 	}
 
 	@Override public boolean autoCommitFailureClosesAllResultSets() throws SQLException {
@@ -890,20 +893,20 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public ResultSet getClientInfoProperties() throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getFunctionColumns(String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern)
 			throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public ResultSet getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) throws SQLException {
-		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
+		return emptyResultSet();
 	}
 
 	@Override public boolean generatedKeyAlwaysReturned() throws SQLException {

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDatabaseMetaDataTest.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDatabaseMetaDataTest.java
@@ -146,7 +146,7 @@ public class Neo4jDatabaseMetaDataTest {
 
 	@Test public void storesMixedCaseQuotedIdentifiersShouldBeReturnFalse() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-		assertFalse(databaseMetaData.storesMixedCaseQuotedIdentifiers());
+		assertTrue(databaseMetaData.storesMixedCaseQuotedIdentifiers());
 	}
 
 	@Test public void supportsMixedCaseIdentifiersShouldBeReturnTrue() throws SQLException {
@@ -156,7 +156,7 @@ public class Neo4jDatabaseMetaDataTest {
 
 	@Test public void supportsMixedCaseQuotedIdentifiersShouldBeReturnFalse() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-		assertFalse(databaseMetaData.supportsMixedCaseQuotedIdentifiers());
+		assertTrue(databaseMetaData.supportsMixedCaseQuotedIdentifiers());
 	}
 
 	@Test public void supportsResultSetType_TYPE_FORWARD_ONLY_true() throws SQLException {
@@ -230,13 +230,13 @@ public class Neo4jDatabaseMetaDataTest {
 	@Test
 	public void supportsColumnAliasing() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-		assertFalse(databaseMetaData.supportsColumnAliasing());
+		assertTrue(databaseMetaData.supportsColumnAliasing());
 	}
 
 	@Test
 	public void nullPlusNonNullIsNull() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-		assertFalse(databaseMetaData.nullPlusNonNullIsNull());
+		assertTrue(databaseMetaData.nullPlusNonNullIsNull());
 	}
 
 	@Test
@@ -254,7 +254,7 @@ public class Neo4jDatabaseMetaDataTest {
 	@Test
 	public void supportsExpressionsInOrderBy() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-		assertFalse(databaseMetaData.supportsExpressionsInOrderBy());
+		assertTrue(databaseMetaData.supportsExpressionsInOrderBy());
 	}
 
 	@Test
@@ -362,7 +362,7 @@ public class Neo4jDatabaseMetaDataTest {
 	@Test
 	public void getProcedureTerm() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-		assertEquals("", databaseMetaData.getProcedureTerm());
+		assertEquals("procedure", databaseMetaData.getProcedureTerm());
 	}
 
 	@Test
@@ -416,13 +416,13 @@ public class Neo4jDatabaseMetaDataTest {
 	@Test
 	public void supportsUnion() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-		assertFalse(databaseMetaData.supportsUnion());
+		assertTrue(databaseMetaData.supportsUnion());
 	}
 
 	@Test
 	public void supportsUnionAll() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-		assertFalse(databaseMetaData.supportsUnionAll());
+		assertTrue(databaseMetaData.supportsUnionAll());
 	}
 
 	@Test
@@ -470,7 +470,7 @@ public class Neo4jDatabaseMetaDataTest {
 	@Test
 	public void supportsDataManipulationTransactionsOnly() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-		assertFalse(databaseMetaData.supportsDataManipulationTransactionsOnly());
+		assertTrue(databaseMetaData.supportsDataManipulationTransactionsOnly());
 	}
 
 	@Test
@@ -548,7 +548,7 @@ public class Neo4jDatabaseMetaDataTest {
 	@Test
 	public void supportsBatchUpdates() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-		assertFalse(databaseMetaData.supportsBatchUpdates());
+		assertTrue(databaseMetaData.supportsBatchUpdates());
 	}
 
 	@Test
@@ -596,7 +596,7 @@ public class Neo4jDatabaseMetaDataTest {
 	@Test
 	public void supportsStoredFunctionsUsingCallSyntax() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-		assertFalse(databaseMetaData.supportsStoredFunctionsUsingCallSyntax());
+		assertTrue(databaseMetaData.supportsStoredFunctionsUsingCallSyntax());
 	}
 
 	@Test

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDatabaseMetaDataTest.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDatabaseMetaDataTest.java
@@ -28,9 +28,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
+import static org.mockito.Mockito.*;
 
 /**
  * @author AgileLARUS
@@ -39,6 +37,7 @@ import static org.mockito.Mockito.withSettings;
 public class Neo4jDatabaseMetaDataTest {
 
 	@Rule public ExpectedException expectedEx = ExpectedException.none();
+
 
 	/*------------------------------*/
 	/*         isWrapperFor         */
@@ -198,4 +197,519 @@ public class Neo4jDatabaseMetaDataTest {
 		assertEquals("TABLE_CAT",schemas.getMetaData().getColumnName(1));
 	}
 
+	@Test
+	public void usesLocalFiles() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.usesLocalFiles());
+	}
+
+	@Test
+	public void usesLocalFilePerTable() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.usesLocalFilePerTable());
+	}
+
+	@Test
+	public void getSystemFunctions() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertEquals("", databaseMetaData.getSystemFunctions());
+	}
+
+	@Test
+	public void supportsAlterTableWithAddColumn() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsAlterTableWithAddColumn());
+	}
+
+	@Test
+	public void supportsAlterTableWithDropColumn() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsAlterTableWithDropColumn());
+	}
+
+	@Test
+	public void supportsColumnAliasing() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsColumnAliasing());
+	}
+
+	@Test
+	public void nullPlusNonNullIsNull() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.nullPlusNonNullIsNull());
+	}
+
+	@Test
+	public void supportsTableCorrelationNames() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsTableCorrelationNames());
+	}
+
+	@Test
+	public void supportsDifferentTableCorrelationNames() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsDifferentTableCorrelationNames());
+	}
+
+	@Test
+	public void supportsExpressionsInOrderBy() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsExpressionsInOrderBy());
+	}
+
+	@Test
+	public void supportsOrderByUnrelated() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsOrderByUnrelated());
+	}
+
+	@Test
+	public void supportsGroupBy() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsGroupBy());
+	}
+
+	@Test
+	public void supportsGroupByUnrelated() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsGroupByUnrelated());
+	}
+
+	@Test
+	public void supportsGroupByBeyondSelect() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsGroupByBeyondSelect());
+	}
+
+	@Test
+	public void supportsLikeEscapeClause() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsLikeEscapeClause());
+	}
+
+	@Test
+	public void supportsMultipleTransactions() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsMultipleTransactions());
+	}
+
+	@Test
+	public void supportsNonNullableColumns() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsNonNullableColumns());
+	}
+
+	@Test
+	public void supportsMinimumSQLGrammar() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsMinimumSQLGrammar());
+	}
+
+	@Test
+	public void supportsCoreSQLGrammar() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsCoreSQLGrammar());
+	}
+
+	@Test
+	public void supportsExtendedSQLGrammar() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsExtendedSQLGrammar());
+	}
+
+	@Test
+	public void supportsANSI92EntryLevelSQL() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsANSI92EntryLevelSQL());
+	}
+
+	@Test
+	public void supportsANSI92IntermediateSQL() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsANSI92IntermediateSQL());
+	}
+
+	@Test
+	public void supportsANSI92FullSQL() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsANSI92FullSQL());
+	}
+
+	@Test
+	public void supportsIntegrityEnhancementFacility() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsIntegrityEnhancementFacility());
+	}
+
+	@Test
+	public void supportsOuterJoins() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsOuterJoins());
+	}
+
+	@Test
+	public void supportsFullOuterJoins() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsFullOuterJoins());
+	}
+
+	@Test
+	public void supportsLimitedOuterJoins() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsLimitedOuterJoins());
+	}
+
+	@Test
+	public void getProcedureTerm() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertEquals("", databaseMetaData.getProcedureTerm());
+	}
+
+	@Test
+	public void supportsPositionedDelete() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsPositionedDelete());
+	}
+
+	@Test
+	public void supportsStoredProcedures() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsStoredProcedures());
+	}
+
+	@Test
+	public void supportsPositionedUpdate() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsPositionedUpdate());
+	}
+
+	@Test
+	public void supportsSubqueriesInComparisons() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsSubqueriesInComparisons());
+	}
+
+	@Test
+	public void supportsSubqueriesInExists() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsSubqueriesInExists());
+	}
+
+	@Test
+	public void supportsSubqueriesInIns() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsSubqueriesInIns());
+	}
+
+	@Test
+	public void supportsSubqueriesInQuantifieds() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsSubqueriesInQuantifieds());
+	}
+
+	@Test
+	public void supportsCorrelatedSubqueries() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsCorrelatedSubqueries());
+	}
+
+	@Test
+	public void supportsUnion() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsUnion());
+	}
+
+	@Test
+	public void supportsUnionAll() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsUnionAll());
+	}
+
+	@Test
+	public void supportsOpenCursorsAcrossCommit() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsOpenCursorsAcrossCommit());
+	}
+
+	@Test
+	public void supportsOpenCursorsAcrossRollback() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsOpenCursorsAcrossRollback());
+	}
+
+	@Test
+	public void supportsOpenStatementsAcrossCommit() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsOpenStatementsAcrossCommit());
+	}
+
+	@Test
+	public void supportsOpenStatementsAcrossRollback() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsOpenStatementsAcrossRollback());
+	}
+
+	@Test
+	public void doesMaxRowSizeIncludeBlobs() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.doesMaxRowSizeIncludeBlobs());
+	}
+
+	@Test
+	public void supportsTransactionIsolationLevel() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsTransactionIsolationLevel(0));
+	}
+
+	@Test
+	public void supportsDataDefinitionAndDataManipulationTransactions() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsDataDefinitionAndDataManipulationTransactions());
+	}
+
+	@Test
+	public void supportsDataManipulationTransactionsOnly() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsDataManipulationTransactionsOnly());
+	}
+
+	@Test
+	public void dataDefinitionCausesTransactionCommit() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.dataDefinitionCausesTransactionCommit());
+	}
+
+	@Test
+	public void dataDefinitionIgnoredInTransactions() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.dataDefinitionIgnoredInTransactions());
+	}
+
+	@Test
+	public void supportsResultSetConcurrency() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsResultSetConcurrency(0, 0));
+	}
+
+	@Test
+	public void ownUpdatesAreVisible() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.ownUpdatesAreVisible(0));
+	}
+
+	@Test
+	public void ownDeletesAreVisible() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.ownDeletesAreVisible(0));
+	}
+
+	@Test
+	public void ownInsertsAreVisible() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.ownInsertsAreVisible(0));
+	}
+
+	@Test
+	public void othersUpdatesAreVisible() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.othersUpdatesAreVisible(0));
+	}
+
+	@Test
+	public void othersDeletesAreVisible() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.othersDeletesAreVisible(0));
+	}
+
+	@Test
+	public void othersInsertsAreVisible() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.othersInsertsAreVisible(0));
+	}
+
+	@Test
+	public void updatesAreDetected() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.updatesAreDetected(0));
+	}
+
+	@Test
+	public void deletesAreDetected() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.deletesAreDetected(0));
+	}
+
+	@Test
+	public void insertsAreDetected() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.insertsAreDetected(0));
+	}
+
+	@Test
+	public void supportsBatchUpdates() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsBatchUpdates());
+	}
+
+	@Test
+	public void supportsSavepoints() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsSavepoints());
+	}
+
+	@Test
+	public void supportsNamedParameters() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsNamedParameters());
+	}
+
+	@Test
+	public void supportsMultipleOpenResults() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsMultipleOpenResults());
+	}
+
+	@Test
+	public void supportsGetGeneratedKeys() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsGetGeneratedKeys());
+	}
+
+	@Test
+	public void supportsResultSetHoldability() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsResultSetHoldability(0));
+	}
+
+	@Test
+	public void locatorsUpdateCopy() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.locatorsUpdateCopy());
+	}
+
+	@Test
+	public void supportsStatementPooling() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsStatementPooling());
+	}
+
+	@Test
+	public void supportsStoredFunctionsUsingCallSyntax() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.supportsStoredFunctionsUsingCallSyntax());
+	}
+
+	@Test
+	public void autoCommitFailureClosesAllResultSets() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.autoCommitFailureClosesAllResultSets());
+	}
+
+	@Test
+	public void generatedKeyAlwaysReturned() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.generatedKeyAlwaysReturned());
+	}
+
+	@Test
+	public void getProcedureColumns() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getProcedureColumns("", "", "", "").next());
+	}
+
+	@Test
+	public void getColumnPrivileges() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getColumnPrivileges("", "", "", "").next());
+	}
+
+	@Test
+	public void getTablePrivileges() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getTablePrivileges("", "", "").next());
+	}
+
+	@Test
+	public void getBestRowIdentifier() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getBestRowIdentifier("", "", "", 0, false).next());
+	}
+
+	@Test
+	public void getVersionColumns() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getVersionColumns("", "", "").next());
+	}
+
+	@Test
+	public void getPrimaryKeys() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getPrimaryKeys("", "", "").next());
+	}
+
+	@Test
+	public void getImportedKeys() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getImportedKeys("", "", "").next());
+	}
+
+	@Test
+	public void getExportedKeys() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getExportedKeys("", "", "").next());
+	}
+
+	@Test
+	public void getCrossReference() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getCrossReference("", "", "", "", "", "").next());
+	}
+
+	@Test
+	public void getIndexInfo() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getIndexInfo("", "", "", false,false).next());
+	}
+
+	@Test
+	public void getUDTs() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getUDTs("", "", "", new int[0]).next());
+	}
+
+	@Test
+	public void getSuperTypes() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getSuperTypes("", "", "").next());
+	}
+
+	@Test
+	public void getSuperTables() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getSuperTables("", "", "").next());
+	}
+
+	@Test
+	public void getAttributes() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getAttributes("", "", "", "").next());
+	}
+
+	@Test
+	public void getSchemas() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getSchemas().next());
+	}
+
+	@Test
+	public void getFunctionColumns() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getFunctionColumns("", "", "", "").next());
+	}
+
+	@Test
+	public void getPseudoColumns() throws SQLException {
+		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+		assertFalse(databaseMetaData.getPseudoColumns("", "", "", "").next());
+	}
 }


### PR DESCRIPTION
Provided an implementation for methods that throw an `UnsupportedOperationException`. In case of the return type is:

- `boolean`: the return value is set to `false`
- `ResultSet`: the return value is an empty `ResultSet`
- `others`: left them as is