### PR TITLE
fixes #194: Neo4jDatabaseMetaData#getIndexInfo should return the indexes of the label

### DIFF
--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
@@ -771,7 +771,39 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public ResultSet getIndexInfo(String catalog, String schema, String table, boolean unique, boolean approximate) throws SQLException {
-		return emptyResultSet();
+		List<String> filters = new ArrayList<>();
+		boolean hasTable = table != null && !table.trim().isEmpty();
+		if (hasTable) {
+			filters.add("label = ?");
+		}
+		if (unique) {
+			filters.add("type = 'node_unique_property'");
+		}
+		StringBuilder queryBuilder = new StringBuilder();
+		queryBuilder.append("CALL db.indexes() YIELD description, label, properties, state, type\n");
+		if (!filters.isEmpty()) {
+			queryBuilder.append("WHERE " + String.join(" AND ", filters) + "\n");
+		}
+		queryBuilder.append("WITH description, label, properties, state, type\n");
+		queryBuilder.append("UNWIND range(0, size(properties) - 1) AS index\n");
+		queryBuilder.append("RETURN null AS TABLE_CAT,\n");
+		queryBuilder.append("null AS TABLE_SCHEM,\n");
+		queryBuilder.append("label AS TABLE_NAME,\n");
+		queryBuilder.append("type <> 'node_unique_property' AS NON_UNIQUE,\n");
+		queryBuilder.append("description AS INDEX_QUALIFIER,\n");
+		queryBuilder.append("description AS INDEX_NAME,\n");
+		queryBuilder.append(DatabaseMetaData.tableIndexOther + " AS TYPE,\n");
+		queryBuilder.append("index + 1 AS ORDINAL_POSITION,\n");
+		queryBuilder.append("properties[index] AS COLUMN_NAME,\n");
+		queryBuilder.append("null AS ASC_OR_DESC,\n");
+		queryBuilder.append("null AS CARDINALITY,\n");
+		queryBuilder.append("null AS PAGES,\n");
+		queryBuilder.append("null AS FILTER_CONDITION");
+		PreparedStatement ps = this.connection.prepareStatement(queryBuilder.toString());
+		if (hasTable) {
+			ps.setString(1, table);
+		}
+		return ps.executeQuery();
 	}
 
 	@Override public boolean supportsResultSetType(int type) throws SQLException {

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDatabaseMetaDataTest.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDatabaseMetaDataTest.java
@@ -666,12 +666,6 @@ public class Neo4jDatabaseMetaDataTest {
 	}
 
 	@Test
-	public void getIndexInfo() throws SQLException {
-		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-		assertFalse(databaseMetaData.getIndexInfo("", "", "", false,false).next());
-	}
-
-	@Test
 	public void getUDTs() throws SQLException {
 		Neo4jDatabaseMetaData databaseMetaData = mock(Neo4jDatabaseMetaData.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
 		assertFalse(databaseMetaData.getUDTs("", "", "", new int[0]).next());


### PR DESCRIPTION
Implemented the `Neo4jDatabaseMetaData#getIndexInfo` method that returns information about the indexes of the label