### PR TITLE
Issue 197: Remove unsupported operation exeception from driver, resultset, statement and connection

### DIFF
--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jCallableStatement.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jCallableStatement.java
@@ -30,7 +30,7 @@ import java.sql.SQLException;
  * @author AgileLARUS
  * @since 3.0.0
  */
-class BoltNeo4jCallableStatement extends Neo4jCallableStatement {
+abstract class BoltNeo4jCallableStatement extends Neo4jCallableStatement { // TODO not used
 	/**
 	 * Default constructor with connection and statement.
 	 *

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatement.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatement.java
@@ -187,4 +187,10 @@ public class BoltNeo4jPreparedStatement extends Neo4jPreparedStatement implement
 	public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
 		setTemporal(parameterIndex, x.getTime(),cal.getTimeZone().toZoneId(), (zdt)-> zdt.toOffsetDateTime().toOffsetTime());
 	}
+
+	@Override
+	public void setArray(int parameterIndex, Array x) throws SQLException {
+		checkClosed();
+		insertParameter(parameterIndex, x.getArray());
+	}
 }

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementIT.java
@@ -26,9 +26,13 @@ import org.junit.Test;
 import org.neo4j.graphdb.Result;
 import org.neo4j.jdbc.bolt.data.StatementData;
 import org.neo4j.jdbc.bolt.utils.JdbcConnectionTestUtils;
+import org.neo4j.jdbc.impl.ListArray;
 
 import java.sql.*;
+import java.util.Arrays;
+import java.util.Map;
 
+import static java.sql.Types.INTEGER;
 import static org.junit.Assert.*;
 
 /**
@@ -289,6 +293,22 @@ public class BoltNeo4jPreparedStatementIT {
 		assertEquals(-1, statement.getUpdateCount());
 
 		statement.close();
+	}
+
+	@Test public void shouldInsertArrayType() throws SQLException {
+		PreparedStatement statement = connection.prepareStatement("CREATE (:TestArrayType {name:?, props:?})");
+		statement.setString(1, "Andrea Santurbano");
+		statement.setArray(2, new ListArray(Arrays.asList(1L,2L,4L), INTEGER));
+		assertEquals(1, statement.executeUpdate());
+		statement.close();
+
+		Statement search = connection.createStatement();
+		ResultSet rs = search.executeQuery("MATCH (n:TestArrayType) return n");
+		assertTrue(rs.next());
+		Map<String, Object> map = (Map<String, Object>) rs.getObject("n");
+		assertEquals("Andrea Santurbano", map.get("name"));
+		assertEquals(Arrays.asList(1L,2L,4L), map.get("props"));
+		search.close();
 	}
 }
 

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementTest.java
@@ -34,6 +34,7 @@ import org.neo4j.jdbc.Neo4jStatement;
 import org.neo4j.jdbc.bolt.data.StatementData;
 import org.neo4j.jdbc.bolt.impl.BoltNeo4jConnectionImpl;
 import org.neo4j.jdbc.bolt.utils.Mocker;
+import org.neo4j.jdbc.impl.ListArray;
 import org.neo4j.jdbc.utils.PreparedStatementBuilder;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -980,5 +981,16 @@ public class BoltNeo4jPreparedStatementTest {
 		stmt.close();
 
 		stmt.getConnection();
+	}
+
+	/*------------------------------*/
+	/*           setArray           */
+	/*------------------------------*/
+
+	@Test public void setArrayShouldInsertTheCorrectArray() throws SQLException {
+		ListArray array = new ListArray(Arrays.asList(1L,2L,4L), INTEGER);
+		this.preparedStatementOneParam.setArray(1, array);
+		HashMap<String, Object> value = Whitebox.getInternalState(this.preparedStatementOneParam, "parameters");
+		assertArrayEquals(new Long[]{1L,2L,4L}, (Long[]) value.get("1"));
 	}
 }

--- a/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/HttpNeo4jConnection.java
+++ b/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/HttpNeo4jConnection.java
@@ -28,6 +28,7 @@ import org.neo4j.jdbc.utils.ExceptionBuilder;
 import org.neo4j.jdbc.utils.Neo4jJdbcRuntimeException;
 import org.neo4j.jdbc.utils.TimeLimitedCodeBlock;
 
+import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -127,18 +128,6 @@ public class HttpNeo4jConnection extends Neo4jConnectionImpl implements Loggable
 		checkClosed();
 		checkAutoCommit();
 		executor.rollback();
-	}
-
-	/*-------------------------*/
-	/*       Holdability       */
-	/*-------------------------*/
-
-	@Override public void setHoldability(int holdability) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
-
-	@Override public int getHoldability() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
 	/*------------------------------*/

--- a/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/HttpNeo4jPreparedStatement.java
+++ b/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/HttpNeo4jPreparedStatement.java
@@ -130,24 +130,6 @@ public class HttpNeo4jPreparedStatement extends Neo4jPreparedStatement implement
 		return result;
 	}
 
-	/*-------------------*/
-	/*   setParameter    */
-	/*-------------------*/
-
-	protected void setTemporal(int parameterIndex, long epoch, ZoneId zone, Function<ZonedDateTime, Temporal> extractTemporal) throws SQLException {
-		checkClosed();
-		checkParamsNumber(parameterIndex);
-
-		ZonedDateTime zdt = Instant.ofEpochMilli(epoch).atZone(zone);
-
-		insertParameter(parameterIndex, extractTemporal.apply(zdt));
-	}
-
-	@Override
-	public void setDate(int parameterIndex, Date x) throws SQLException {
-		setTemporal(parameterIndex, x.getTime(), ZoneId.systemDefault(), (zdt)-> zdt.toLocalDate());
-	}
-
 	@Override
 	public void setArray(int parameterIndex, Array x) throws SQLException {
 		checkClosed();

--- a/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/HttpNeo4jConnectionIT.java
+++ b/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/HttpNeo4jConnectionIT.java
@@ -172,16 +172,6 @@ public class HttpNeo4jConnectionIT extends Neo4jHttpITUtil {
 		reader.close();
 	}
 
-	@Test public void holdabilityShouldFail() throws SQLException {
-		expectedEx.expect(UnsupportedOperationException.class);
-		expectedEx.expectMessage("Method setHoldability in class org.neo4j.jdbc.http.HttpNeo4jConnection is not yet implemented.");
-
-		// Write something
-		Connection writer = DriverManager.getConnection(getJDBCUrl());
-		writer.setHoldability(1);
-		writer.close();
-	}
-
 	@Test public void isValidShouldWork() throws SQLException {
 		Connection writer = DriverManager.getConnection(getJDBCUrl());
 		assertTrue(writer.isValid(1));

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDatabaseMetaData.java
@@ -642,7 +642,7 @@ public abstract class Neo4jDatabaseMetaData implements java.sql.DatabaseMetaData
 	}
 
 	@Override public int getMaxColumnsInGroupBy() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return 0;
 	}
 
 	@Override public int getMaxColumnsInIndex() throws SQLException {

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jParameterMetaData.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jParameterMetaData.java
@@ -29,24 +29,29 @@ import java.sql.SQLException;
  */
 public abstract class Neo4jParameterMetaData implements java.sql.ParameterMetaData {
 
-	@Override public int getParameterCount() throws SQLException {
+	@Override
+	public int getParameterCount() throws SQLException {
 		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
-	@Override public int isNullable(int param) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+	@Override
+	public int isNullable(int param) throws SQLException {
+		return parameterNullable;
 	}
 
-	@Override public boolean isSigned(int param) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+	@Override
+	public boolean isSigned(int param) throws SQLException {
+		return false;
 	}
 
-	@Override public int getPrecision(int param) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+	@Override
+	public int getPrecision(int column) throws SQLException {
+		return 0;
 	}
 
-	@Override public int getScale(int param) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+	@Override
+	public int getScale(int column) throws SQLException {
+		return 0;
 	}
 
 	@Override public int getParameterType(int param) throws SQLException {
@@ -57,19 +62,23 @@ public abstract class Neo4jParameterMetaData implements java.sql.ParameterMetaDa
 		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
-	@Override public String getParameterClassName(int param) throws SQLException {
+	@Override
+	public String getParameterClassName(int param) throws SQLException {
 		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
-	@Override public int getParameterMode(int param) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+	@Override
+	public int getParameterMode(int param) throws SQLException {
+		return parameterModeUnknown;
 	}
 
-	@Override public <T> T unwrap(Class<T> iface) throws SQLException {
+	@Override
+	public <T> T unwrap(Class<T> iface) throws SQLException {
 		return Wrapper.unwrap(iface, this);
 	}
 
-	@Override public boolean isWrapperFor(Class<?> iface) throws SQLException {
+	@Override
+	public boolean isWrapperFor(Class<?> iface) throws SQLException {
 		return Wrapper.isWrapperFor(iface, this.getClass());
 	}
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jPreparedStatement.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jPreparedStatement.java
@@ -310,10 +310,6 @@ public abstract class Neo4jPreparedStatement extends Neo4jStatement implements P
 		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
-	@Override public void setArray(int parameterIndex, java.sql.Array x) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
-
 	@Override public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
 		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
@@ -327,7 +323,7 @@ public abstract class Neo4jPreparedStatement extends Neo4jStatement implements P
 	}
 
 	@Override public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		setNull(parameterIndex, sqlType); // simply store a null
 	}
 
 	@Override public void setURL(int parameterIndex, URL x) throws SQLException {
@@ -408,10 +404,6 @@ public abstract class Neo4jPreparedStatement extends Neo4jStatement implements P
 
 	@Override public void setNClob(int parameterIndex, Reader reader) throws SQLException {
 		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
-
-	@Override public void addBatch(String sql) throws SQLException {
-		throw new SQLException("Method addBatch(String sql) cannot be called on PreparedStatement");
 	}
 
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jResultSetMetaData.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jResultSetMetaData.java
@@ -181,11 +181,11 @@ public abstract class Neo4jResultSetMetaData implements java.sql.ResultSetMetaDa
 	/*---------------------------------*/
 
 	@Override public boolean isWritable(int column) throws SQLException {
-		return true; // TODO add a check for the <id> field
+		return false;
 	}
 
 	@Override public boolean isDefinitelyWritable(int column) throws SQLException {
-		return true; // TODO add a check for the <id> field
+		return false;
 	}
 
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jResultSetMetaData.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jResultSetMetaData.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.jdbc;
 
-import org.neo4j.jdbc.utils.ExceptionBuilder;
-
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -183,11 +181,11 @@ public abstract class Neo4jResultSetMetaData implements java.sql.ResultSetMetaDa
 	/*---------------------------------*/
 
 	@Override public boolean isWritable(int column) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return true; // TODO add a check for the <id> field
 	}
 
 	@Override public boolean isDefinitelyWritable(int column) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return true; // TODO add a check for the <id> field
 	}
 
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
@@ -274,7 +274,7 @@ public abstract class Neo4jStatement implements Statement, Loggable {
 	}
 
 	@Override public int getMaxFieldSize() throws SQLException {
-		return -1;
+		return 0;
 	}
 
 	@Override public void setMaxFieldSize(int max) throws SQLException {} // do nothing
@@ -290,7 +290,7 @@ public abstract class Neo4jStatement implements Statement, Loggable {
 	}
 
 	@Override public int getFetchSize() throws SQLException {
-		return -1;
+		return 0;
 	}
 
 	@Override public boolean getMoreResults(int current) throws SQLException {
@@ -310,9 +310,13 @@ public abstract class Neo4jStatement implements Statement, Loggable {
 		return false;
 	}
 
-	@Override public void closeOnCompletion() throws SQLException {}
+	@Override public void closeOnCompletion() throws SQLException {
+		this.checkClosed();
+		// do nothing
+	}
 
 	@Override public boolean isCloseOnCompletion() throws SQLException {
+		this.checkClosed();
 		return false;
 	}
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
@@ -19,12 +19,15 @@
  */
 package org.neo4j.jdbc;
 
+import org.neo4j.jdbc.impl.ListNeo4jResultSet;
 import org.neo4j.jdbc.utils.ExceptionBuilder;
 
+import javax.xml.transform.Result;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -271,63 +274,46 @@ public abstract class Neo4jStatement implements Statement, Loggable {
 	}
 
 	@Override public int getMaxFieldSize() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return -1;
 	}
 
-	@Override public void setMaxFieldSize(int max) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void setMaxFieldSize(int max) throws SQLException {} // do nothing
 
-	@Override public void setEscapeProcessing(boolean enable) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void setEscapeProcessing(boolean enable) throws SQLException {} // do nothing
 
-	@Override public void setCursorName(String name) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void setCursorName(String name) throws SQLException {} // do nothing
 
-	@Override public void setFetchDirection(int direction) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void setFetchDirection(int direction) throws SQLException {}
 
 	@Override public int getFetchDirection() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return ResultSet.FETCH_FORWARD;
 	}
 
 	@Override public int getFetchSize() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return -1;
 	}
 
 	@Override public boolean getMoreResults(int current) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return getMoreResults();
 	}
 
 	@Override public ResultSet getGeneratedKeys() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		// TODO should at least return the <id>?
+		return ListNeo4jResultSet.newInstance(false, Collections.<List<Object>>emptyList(), Collections.<String>emptyList());
 	}
 
-	@Override public void cancel() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void cancel() throws SQLException {} // do nothing
 
-	@Override public void setPoolable(boolean poolable) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void setPoolable(boolean poolable) throws SQLException {} // do nothing
 
 	@Override public boolean isPoolable() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
-	@Override public int[] executeBatch() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
-
-	@Override public void closeOnCompletion() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void closeOnCompletion() throws SQLException {}
 
 	@Override public boolean isCloseOnCompletion() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return false;
 	}
 
 	@Override public boolean hasDebug() {

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/impl/ListArray.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/impl/ListArray.java
@@ -23,8 +23,12 @@ import org.neo4j.jdbc.Neo4jArray;
 
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author AgileLARUS
@@ -39,6 +43,34 @@ public class ListArray extends Neo4jArray {
 
 	public ListArray(List list, int type) {
 		this.list = list;
+		this.type = type;
+	}
+
+	public ListArray(String typeName, Object[] elements) throws SQLException {
+		int type;
+		switch (typeName) {
+			case "VARCHAR":
+				type = Types.VARCHAR;
+				break;
+			case "INTEGER":
+				type = Types.INTEGER;
+				break;
+			case "BOOLEAN":
+				type = Types.BOOLEAN;
+				break;
+			case "DOUBLE":
+				type = Types.DOUBLE;
+				break;
+			case "JAVA_OBJECT":
+				type = Types.JAVA_OBJECT;
+				break;
+			default:
+				throw new SQLException(String.format(TYPE_NOT_SUPPORTED, this.type));
+		}
+		this.list = new ArrayList();
+		for (Object obj : elements) {
+			this.list.add(obj);
+		}
 		this.type = type;
 	}
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/impl/ListArray.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/impl/ListArray.java
@@ -67,10 +67,7 @@ public class ListArray extends Neo4jArray {
 			default:
 				throw new SQLException(String.format(TYPE_NOT_SUPPORTED, this.type));
 		}
-		this.list = new ArrayList();
-		for (Object obj : elements) {
-			this.list.add(obj);
-		}
+		this.list = Arrays.asList(elements);
 		this.type = type;
 	}
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/impl/Neo4jConnectionImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/impl/Neo4jConnectionImpl.java
@@ -375,29 +375,12 @@ public abstract class Neo4jConnectionImpl implements Neo4jConnection {
 	/*       Not implemented yet       */
 	/*---------------------------------*/
 
-	@Override
-	public CallableStatement prepareCall(String sql) throws SQLException {
-		return null;
+	@Override public java.sql.CallableStatement prepareCall(String sql) throws SQLException {
+		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
-	@Override
-	public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
-		return null;
-	}
-
-	@Override
-	public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
-		return null;
-	}
-
-	@Override
-	public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
-		return null;
-	}
-
-	@Override
-	public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
-		return null;
+	@Override public java.sql.CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
 	@Override public Map<String, Class<?>> getTypeMap() throws SQLException {
@@ -407,31 +390,47 @@ public abstract class Neo4jConnectionImpl implements Neo4jConnection {
 	@Override public void setTypeMap(Map<String, Class<?>> map) throws SQLException {} // do nothing
 
 	@Override public Savepoint setSavepoint() throws SQLException {
-		return null;
+		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
 	@Override public Savepoint setSavepoint(String name) throws SQLException {
-		return null;
+		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
-	@Override public void rollback(Savepoint savepoint) throws SQLException {} // do nothing
+	@Override public void rollback(Savepoint savepoint) throws SQLException {
+		throw ExceptionBuilder.buildUnsupportedOperationException();
+	}
 
-	@Override public void releaseSavepoint(Savepoint savepoint) throws SQLException {} // do nothing
+	@Override public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+		throw ExceptionBuilder.buildUnsupportedOperationException();
+	}
+
+	@Override public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+		throw ExceptionBuilder.buildUnsupportedOperationException();
+	}
+
+	@Override public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+		throw ExceptionBuilder.buildUnsupportedOperationException();
+	}
+
+	@Override public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+		throw ExceptionBuilder.buildUnsupportedOperationException();
+	}
 
 	@Override public Clob createClob() throws SQLException {
-		return null;
+		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
 	@Override public Blob createBlob() throws SQLException {
-		return null;
+		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
 	@Override public NClob createNClob() throws SQLException {
-		return null;
+		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
 	@Override public SQLXML createSQLXML() throws SQLException {
-		return null;
+		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
 	@Override public void setClientInfo(String name, String value) throws SQLClientInfoException {
@@ -460,17 +459,21 @@ public abstract class Neo4jConnectionImpl implements Neo4jConnection {
 	}
 
 	@Override public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
-		return null;
+		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
 	@Override public void setSchema(String schema) throws SQLException {} // do nothing
 
-	@Override public void abort(Executor executor) throws SQLException {} // do nothing
+	@Override public void abort(Executor executor) throws SQLException {
+		throw ExceptionBuilder.buildUnsupportedOperationException();
+	}
 
-	@Override public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {} // do nothing
+	@Override public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+		throw ExceptionBuilder.buildUnsupportedOperationException();
+	}
 
 	@Override public int getNetworkTimeout() throws SQLException {
-		return -1;
+		throw ExceptionBuilder.buildUnsupportedOperationException();
 	}
 
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/impl/Neo4jConnectionImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/impl/Neo4jConnectionImpl.java
@@ -26,6 +26,7 @@ import org.neo4j.jdbc.utils.ExceptionBuilder;
 
 import java.sql.*;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
@@ -374,64 +375,63 @@ public abstract class Neo4jConnectionImpl implements Neo4jConnection {
 	/*       Not implemented yet       */
 	/*---------------------------------*/
 
-	@Override public java.sql.CallableStatement prepareCall(String sql) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+	@Override
+	public CallableStatement prepareCall(String sql) throws SQLException {
+		return null;
 	}
 
-	@Override public java.sql.CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+	@Override
+	public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+		return null;
+	}
+
+	@Override
+	public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+		return null;
+	}
+
+	@Override
+	public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+		return null;
+	}
+
+	@Override
+	public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+		return null;
 	}
 
 	@Override public Map<String, Class<?>> getTypeMap() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return Collections.emptyMap();
 	}
 
-	@Override public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void setTypeMap(Map<String, Class<?>> map) throws SQLException {} // do nothing
 
 	@Override public Savepoint setSavepoint() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return null;
 	}
 
 	@Override public Savepoint setSavepoint(String name) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return null;
 	}
 
-	@Override public void rollback(Savepoint savepoint) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void rollback(Savepoint savepoint) throws SQLException {} // do nothing
 
-	@Override public void releaseSavepoint(Savepoint savepoint) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
-
-	@Override public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
-
-	@Override public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
-
-	@Override public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void releaseSavepoint(Savepoint savepoint) throws SQLException {} // do nothing
 
 	@Override public Clob createClob() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return null;
 	}
 
 	@Override public Blob createBlob() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return null;
 	}
 
 	@Override public NClob createNClob() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return null;
 	}
 
 	@Override public SQLXML createSQLXML() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return null;
 	}
 
 	@Override public void setClientInfo(String name, String value) throws SQLClientInfoException {
@@ -456,27 +456,21 @@ public abstract class Neo4jConnectionImpl implements Neo4jConnection {
 	}
 
 	@Override public Neo4jArray createArrayOf(String typeName, Object[] elements) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return new ListArray(typeName, elements);
 	}
 
 	@Override public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return null;
 	}
 
-	@Override public void setSchema(String schema) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void setSchema(String schema) throws SQLException {} // do nothing
 
-	@Override public void abort(Executor executor) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void abort(Executor executor) throws SQLException {} // do nothing
 
-	@Override public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
-	}
+	@Override public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {} // do nothing
 
 	@Override public int getNetworkTimeout() throws SQLException {
-		throw ExceptionBuilder.buildUnsupportedOperationException();
+		return -1;
 	}
 
 }

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jConnectionTest.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jConnectionTest.java
@@ -25,7 +25,10 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 import org.neo4j.jdbc.impl.Neo4jConnectionImpl;
 
+import java.sql.Array;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -79,5 +82,34 @@ public class Neo4jConnectionTest {
 		Neo4jConnection connection = mock(Neo4jConnectionImpl.class, Mockito.CALLS_REAL_METHODS);
 
 		connection.unwrap(Neo4jStatement.class);
+	}
+
+	@Test public void createArrayOfShouldThrowException() throws SQLException {
+		Neo4jConnection connection = mock(Neo4jConnectionImpl.class, Mockito.CALLS_REAL_METHODS);
+
+		Object[] booleans = {true, false, false, true};
+		Array booleansArr = connection.createArrayOf("BOOLEAN", booleans);
+		assertArrayEquals(booleans, (Object[]) booleansArr.getArray());
+
+		Object[] strings = {"foo", "false", "bar", "1"};
+		Array stringsArr = connection.createArrayOf("VARCHAR", strings);
+		assertArrayEquals(strings, (Object[]) stringsArr.getArray());
+		assertArrayEquals(booleans, (Object[]) booleansArr.getArray());
+
+		Object[] integers = {1L, 100L, Long.MAX_VALUE, Long.MIN_VALUE};
+		Array integersArr = connection.createArrayOf("INTEGER", integers);
+		assertArrayEquals(integers, (Object[]) integersArr.getArray());
+
+		Object[] doubles = {1D, 100D, Double.MAX_VALUE, Double.MIN_VALUE};
+		Array doublesArr = connection.createArrayOf("DOUBLE", doubles);
+		assertArrayEquals(doubles, (Object[]) doublesArr.getArray());
+
+		Map<String, Object> first = new HashMap<>();
+		first.put("first", 1L);
+		Map<String, Object> second = new HashMap<>();
+		second.put("second", 2L);
+		Object[] maps = {first, second};
+		Array mapsArr = connection.createArrayOf("JAVA_OBJECT", maps);
+		assertArrayEquals(maps, (Object[]) mapsArr.getArray());
 	}
 }


### PR DESCRIPTION
Fixes #197 

List of provided changes:
- removed the `UnsupportedOperationException` where possible
- added support to the `setArray` method to `Bolt/HttpNeo4jPreparedStatement`
- added support to `createArrayOf` method of `Neo4jConnectionImpl`