### PR TITLE
fixes #213: jdbc driver lacks ability to pass multiple bookmarks to initial session

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 jdk:

--- a/neo4j-jdbc-bolt/pom.xml
+++ b/neo4j-jdbc-bolt/pom.xml
@@ -50,5 +50,16 @@
             <artifactId>jmh-generator-annprocess</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>neo4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/TestcontainersCausalCluster.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/TestcontainersCausalCluster.java
@@ -1,0 +1,218 @@
+package org.neo4j;
+
+import org.jetbrains.annotations.NotNull;
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+public class TestcontainersCausalCluster {
+    private static final Logger logger = LoggerFactory.getLogger(TestcontainersCausalCluster.class);
+    private static final int DEFAULT_BOLT_PORT = 7687;
+
+    public enum ClusterInstanceType {CORE, READ_REPLICA}
+
+    private static Stream<String> iterateMembers(int numOfMembers, ClusterInstanceType instanceType) {
+        final IntFunction<String> generateInstanceName = i -> String.format("neo4j-%s-%d", instanceType.toString(), i);
+
+        return IntStream.rangeClosed(1, numOfMembers).mapToObj(generateInstanceName);
+    }
+
+    public static TestcontainersCausalCluster create(int numberOfCoreMembers, int numberOfReadReplica, Duration timeout, Map<String, Object> neo4jConfig) {
+        if (numberOfCoreMembers < 3) {
+            throw new IllegalArgumentException("numberOfCoreMembers must be >= 3");
+        }
+        if (numberOfReadReplica < 0) {
+            throw new IllegalArgumentException("numberOfReadReplica must be >= 0");
+        }
+
+        // Setup a naming strategy and the initial discovery members
+        final String initialDiscoveryMembers = iterateMembers(numberOfCoreMembers, ClusterInstanceType.CORE)
+                .map(n -> String.format("%s:5000", n))
+                .collect(joining(","));
+
+        // Prepare one shared network for those containers
+        Network network = Network.newNetwork();
+
+        // Prepare proxys as sidecars
+        Map<String, GenericContainer> sidecars = createSidecars(numberOfCoreMembers, network, ClusterInstanceType.CORE);
+        sidecars.putAll(createSidecars(numberOfReadReplica, network, ClusterInstanceType.READ_REPLICA));
+
+        // Start the sidecars so that the exposed ports are available
+        sidecars.values().forEach(GenericContainer::start);
+
+        // Build the core/read_replica
+        List<Neo4jContainer> members = getClusterMembers(numberOfCoreMembers, ClusterInstanceType.CORE, sidecars, network, initialDiscoveryMembers, neo4jConfig, timeout);
+        members.addAll(getClusterMembers(numberOfReadReplica, ClusterInstanceType.READ_REPLICA, sidecars, network, initialDiscoveryMembers, neo4jConfig, timeout));
+
+        // Start all of them in parallel
+        final CountDownLatch latch = new CountDownLatch(numberOfCoreMembers);
+        members.forEach(instance -> CompletableFuture.runAsync(() -> {
+            instance.start();
+            latch.countDown();
+        }));
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        return new TestcontainersCausalCluster(members, sidecars.values().stream().collect(toList()));
+    }
+
+    @NotNull
+    private static List<Neo4jContainer> getClusterMembers(int numberOfCoreMembers,
+                                                                   ClusterInstanceType instanceType,
+                                                                   Map<String, GenericContainer> sidecars,
+                                                                   Network network,
+                                                                   String initialDiscoveryMembers,
+                                                                   Map<String, Object> neo4jConfig,
+                                                                   Duration timeout) {
+        // Currently needed as a whole new waiting strategy due to a bug in test containers
+        WaitStrategy waitForBolt = new LogMessageWaitStrategy()
+                .withRegEx(String.format(".*Bolt enabled on 0\\.0\\.0\\.0:%d\\.\n", DEFAULT_BOLT_PORT))
+                .withStartupTimeout(timeout);
+        Function<GenericContainer, String> getProxyUrl = instance ->
+                String.format("%s:%d", instance.getContainerIpAddress(), instance.getMappedPort(DEFAULT_BOLT_PORT));
+        return iterateMembers(numberOfCoreMembers, instanceType)
+                .map(name -> getNeo4jContainer(waitForBolt, network, initialDiscoveryMembers, sidecars, getProxyUrl, instanceType, neo4jConfig, name))
+                .collect(toList());
+    }
+
+    @NotNull
+    private static Map<String, GenericContainer> createSidecars(int numOfMembers, Network network, ClusterInstanceType instanceType) {
+        return iterateMembers(numOfMembers, instanceType)
+                .collect(toMap(
+                        Function.identity(),
+                        name -> new GenericContainer("alpine/socat")
+                                .withNetwork(network)
+                                .withLabel("memberType", instanceType.toString())
+                                // Expose the default bolt port on the sidecar
+                                .withExposedPorts(DEFAULT_BOLT_PORT)
+                                // And redirect that port to the corresponding Neo4j instance
+                                .withCommand(String
+                                        .format("tcp-listen:%d,fork,reuseaddr tcp-connect:%s:%1$d", DEFAULT_BOLT_PORT, name))
+                ));
+    }
+
+    private static Neo4jContainer getNeo4jContainer(WaitStrategy waitForBolt,
+                                                                      Network network,
+                                                                      String initialDiscoveryMembers,
+                                                                      Map<String, GenericContainer> sidecars,
+                                                                      Function<GenericContainer, String> getProxyUrl,
+                                                                      ClusterInstanceType instanceType,
+                                                                      Map<String, Object> neo4jConfig,
+                                                                      String name) {
+        Neo4jContainer container = (Neo4jContainer) new Neo4jContainer("neo4j:3.5-enterprise")
+                .withNeo4jConfig("dbms.mode", instanceType.toString())
+                .withNeo4jConfig("dbms.connectors.default_listen_address", "0.0.0.0")
+                .withNeo4jConfig("dbms.connectors.default_advertised_address", name)
+                .withNeo4jConfig("dbms.connector.bolt.advertised_address", getProxyUrl.apply(sidecars.get(name)))
+                .withNeo4jConfig("causal_clustering.initial_discovery_members", initialDiscoveryMembers)
+                .withAdminPassword("jdbc")
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withLabel("memberType", instanceType.toString())
+                .withNetwork(network)
+                .withNetworkAliases(name)
+//                .withLogConsumer(new Slf4jLogConsumer(logger))
+                .waitingFor(waitForBolt);
+        neo4jConfig.forEach((conf, value) -> container.withNeo4jConfig(conf, String.valueOf(value)));
+        return container;
+    }
+
+    private final List<Neo4jContainer> clusterMembers;
+    private final List<GenericContainer> sidecars;
+
+    private Driver driver;
+    private Session session;
+
+    public TestcontainersCausalCluster(List<Neo4jContainer> clusterMembers,
+                                       List<GenericContainer> sidecars) {
+        this.clusterMembers = clusterMembers;
+        this.sidecars = sidecars;
+        this.driver = GraphDatabase.driver(getURI(), AuthTokens.basic("neo4j", "jdbc"));
+        this.session = driver.session();
+    }
+
+    public Driver getDriver() {
+        return driver;
+    }
+
+    public Session getSession() {
+        return session;
+    }
+
+    public URI getURI() {
+        return this.sidecars.stream().findAny()
+                .map(instance -> String.format("bolt+routing://%s:%d", instance.getContainerIpAddress(),
+                        instance.getMappedPort(DEFAULT_BOLT_PORT)))
+                .map(uri -> {
+                    try {
+                        return new URI(uri);
+                    } catch (URISyntaxException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .orElseThrow(() -> new IllegalStateException("No sidecar as entrypoint into the cluster available."));
+    }
+
+    public URI getURIByType(ClusterInstanceType instanceType) {
+        return this.sidecars.stream()
+                .filter(instance -> instance.getLabels().getOrDefault("memberType", "").equals(instanceType.toString()))
+                .findAny()
+                .map(instance -> String.format("bolt+routing://%s:%d", instance.getContainerIpAddress(),
+                        instance.getMappedPort(DEFAULT_BOLT_PORT)))
+                .map(uri -> {
+                    try {
+                        return new URI(uri);
+                    } catch (URISyntaxException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .orElseThrow(() -> new IllegalStateException("No sidecar as entrypoint into the cluster available."));
+    }
+
+    public URI getAllMembersURI() {
+        try {
+            return new URI("bolt+routing://" + this.sidecars.stream()
+                    .map(instance -> String.format("%s:%d", instance.getContainerIpAddress(),
+                            instance.getMappedPort(DEFAULT_BOLT_PORT)))
+                    .collect(Collectors.joining(",")));
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void close() {
+        getSession().close();
+        getDriver().close();
+        sidecars.forEach(GenericContainer::stop);
+        clusterMembers.forEach(Neo4jContainer::stop);
+    }
+}
+

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jConnectionTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jConnectionTest.java
@@ -107,7 +107,7 @@ public class BoltNeo4jConnectionTest {
 		Session session = mock(Session.class);
 		when(session.isOpen()).thenReturn(true).thenReturn(false);
 		org.neo4j.driver.v1.Driver driver = mock(org.neo4j.driver.v1.Driver.class);
-		when(driver.session(any(AccessMode.class), anyString())).thenReturn(session);
+		when(driver.session(any(AccessMode.class), anySet())).thenReturn(session);
 		Connection connection = new BoltNeo4jConnectionImpl(driver, new Properties(), "");
 		connection.close();
 		verify(session, times(1)).close();
@@ -117,12 +117,23 @@ public class BoltNeo4jConnectionTest {
 	@Test public void closeShouldNotThrowExceptionWhenClosingAClosedConnection() throws SQLException {
 		Session session = mockSessionClosed();
         org.neo4j.driver.v1.Driver driver = mock(org.neo4j.driver.v1.Driver.class);
-		when(driver.session(any(AccessMode.class), anyString())).thenReturn(session);
+		when(driver.session(any(AccessMode.class), anySet())).thenReturn(session);
 		Connection connection = new BoltNeo4jConnectionImpl(driver, new Properties(), "");
 		connection.close();
 		verify(session, never()).close();
 		assertTrue(connection.isClosed());
 	}
+
+    @Test public void shouldPassTheBookmarks() throws SQLException {
+        Session session = mock(Session.class);
+        when(session.isOpen()).thenReturn(true).thenReturn(false);
+        org.neo4j.driver.v1.Driver driver = mock(org.neo4j.driver.v1.Driver.class);
+        when(driver.session(any(AccessMode.class), anySet())).thenReturn(session);
+        Connection connection = new BoltNeo4jConnectionImpl(driver, new Properties(), "");
+        connection.close();
+        verify(session, times(1)).close();
+        assertTrue(connection.isClosed());
+    }
 
 	/*
 	@Ignore

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/utils/Mocker.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/utils/Mocker.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anySet;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
@@ -50,28 +51,28 @@ public class Mocker {
 	public static Driver mockDriverOpen() {
         Session session = mockSessionOpen();
 		Driver driver = mock(Driver.class);
-		when(driver.session(any(AccessMode.class), anyString())).thenReturn(session);
+		when(driver.session(any(AccessMode.class), anySet())).thenReturn(session);
 		return driver;
 	}
 
 	public static Driver mockDriverClosed() {
         Session session = mockSessionClosed();
         Driver driver = mock(Driver.class);
-        when(driver.session(any(AccessMode.class), anyString())).thenReturn(session);
+        when(driver.session(any(AccessMode.class), anySet())).thenReturn(session);
 		return driver;
 	}
 
 	public static Driver mockDriverOpenSlow() {
         Session session = mockSessionOpenSlow();
 		Driver driver = mock(Driver.class);
-        when(driver.session(any(AccessMode.class), anyString())).thenReturn(session);
+        when(driver.session(any(AccessMode.class), anySet())).thenReturn(session);
 		return driver;
 	}
 
 	public static Driver mockDriverException() {
         Session session = mockSessionException();
         Driver driver = mock(Driver.class);
-        when(driver.session(any(AccessMode.class), anyString())).thenReturn(session);
+        when(driver.session(any(AccessMode.class), anySet())).thenReturn(session);
 		return driver;
 	}
 

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/boltrouting/BoltRoutingIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/boltrouting/BoltRoutingIT.java
@@ -20,22 +20,48 @@ package org.neo4j.jdbc.boltrouting;
 
 import org.junit.*;
 import org.junit.rules.ExpectedException;
+import org.neo4j.TestcontainersCausalCluster;
 
 import java.sql.*;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assume.assumeNotNull;
 
 /**
  * @author AgileLARUS
  * @since 3.3.1
  */
-public class BoltRoutingPT {
+public class BoltRoutingIT {
+    private static final String NEO4J_USER = "neo4j";
+    private static final String NEO4J_PASSWORD = "jdbc";
 
-    private String connectionUrl = "jdbc:neo4j:bolt+routing://localhost:17681?noSsl&debug=true&routing:policy=EU&routing:servers=localhost:17682;localhost:17683;localhost:17684;localhost:17685;localhost:17686;localhost:17687";
-    private String connectionUrl2 = "jdbc:neo4j:bolt+routing://localhost:17681,localhost:17682,localhost:17683,localhost:17684,localhost:17685,localhost:17686,localhost:17687?noSsl&debug=true&routing:policy=EU";
+//    private String connectionUrl = "jdbc:neo4j:bolt+routing://localhost:17681?noSsl&debug=true&routing:policy=EU&routing:servers=localhost:17682;localhost:17683;localhost:17684;localhost:17685;localhost:17686;localhost:17687";
+//    private String connectionUrl2 = "jdbc:neo4j:bolt+routing://localhost:17681,localhost:17682,localhost:17683,localhost:17684,localhost:17685,localhost:17686,localhost:17687?noSsl&debug=true&routing:policy=EU";
+
+    private static TestcontainersCausalCluster cluster;
+
+    @BeforeClass
+    public static void beforeClass() {
+        try {
+            cluster = TestcontainersCausalCluster.create(3, 1, Duration.ofMinutes(4), Collections.emptyMap());
+            assumeNotNull(cluster);
+        } catch (Exception ignored) {}
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        if (cluster != null) {
+            cluster.close();
+        }
+    }
 
     @Rule public ExpectedException expectedEx = ExpectedException.none();
 
     @After public void tearDown() throws Exception {
-        try  (Connection connection = DriverManager.getConnection(connectionUrl, "neo4j", "larus")) {
+        try  (Connection connection = DriverManager.getConnection("jdbc:neo4j:" + cluster.getURI().toString(), NEO4J_USER, NEO4J_PASSWORD)) {
             connection.setAutoCommit(false);
             try (Statement statement = connection.createStatement()) {
                 statement.execute("match (t) detach delete t");
@@ -47,7 +73,7 @@ public class BoltRoutingPT {
     //@Ignore
     @Test public void shouldAccessReadReplicaNodes() throws SQLException {
 
-        try  (Connection connection = DriverManager.getConnection(connectionUrl, "neo4j", "larus")) {
+        try  (Connection connection = DriverManager.getConnection("jdbc:neo4j:" + cluster.getURI().toString(), NEO4J_USER, NEO4J_PASSWORD)) {
             connection.setReadOnly(true);
             try (Statement statement = connection.createStatement()) {
                 try (ResultSet resultSet = statement.executeQuery("match (t:BoltRoutingTest) return count(t) as tot")) {
@@ -61,7 +87,7 @@ public class BoltRoutingPT {
 
     @Test public void shouldAccessReadReplicaNodes2() throws SQLException {
 
-        try  (Connection connection = DriverManager.getConnection(connectionUrl2, "neo4j", "larus")) {
+        try  (Connection connection = DriverManager.getConnection("jdbc:neo4j:" + cluster.getAllMembersURI().toString(), NEO4J_USER, NEO4J_PASSWORD)) {
             connection.setReadOnly(true);
             try (Statement statement = connection.createStatement()) {
                 try (ResultSet resultSet = statement.executeQuery("match (t:BoltRoutingTest) return count(t) as tot")) {
@@ -78,7 +104,7 @@ public class BoltRoutingPT {
 
         expectedEx.expect(SQLException.class);
 
-        try  (Connection connection = DriverManager.getConnection(connectionUrl, "neo4j", "larus")) {
+        try  (Connection connection = DriverManager.getConnection("jdbc:neo4j:" + cluster.getURI().toString(), NEO4J_USER, NEO4J_PASSWORD)) {
             connection.setReadOnly(true);
 
             try (Statement statement = connection.createStatement()) {
@@ -92,7 +118,7 @@ public class BoltRoutingPT {
     //@Ignore
     @Test public void shouldUseBookmarkToReadYourOwnWrites() throws SQLException {
 
-        try  (Connection connection = DriverManager.getConnection(connectionUrl, "neo4j", "larus")) {
+        try  (Connection connection = DriverManager.getConnection("jdbc:neo4j:" + cluster.getURI().toString(), NEO4J_USER, NEO4J_PASSWORD)) {
 
             connection.setAutoCommit(false);
 
@@ -115,6 +141,44 @@ public class BoltRoutingPT {
                 }
             }
             connection.commit();
+        }
+    }
+
+    //@Ignore
+    @Test public void shouldPassTheBookMark() throws SQLException {
+        List<String> bookmarks = new ArrayList<>();
+        bookmarks.add(insertAndGetBookmark());
+        bookmarks.add(insertAndGetBookmark());
+
+        String bookmarksAsString = String.join(",", bookmarks);
+        try  (Connection connection = DriverManager.getConnection("jdbc:neo4j:" + cluster.getURI().toString(), NEO4J_USER, NEO4J_PASSWORD)) {
+
+            connection.setClientInfo(BoltRoutingNeo4jDriver.BOOKMARK, bookmarksAsString);
+            connection.setReadOnly(true);
+
+            try (Statement statement = connection.createStatement()) {
+                try (ResultSet resultSet = statement.executeQuery("match (t:BoltRoutingTest) return count(t) as tot")) {
+                    if (resultSet.next()) {
+                        long tot = resultSet.getLong("tot");
+                        Assert.assertEquals(2L, tot);
+                    }
+                }
+            }
+        }
+    }
+
+    private String insertAndGetBookmark() throws SQLException {
+        try (Connection connection = DriverManager.getConnection("jdbc:neo4j:" + cluster.getURI().toString(), NEO4J_USER, NEO4J_PASSWORD)) {
+            connection.setAutoCommit(false);
+
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("create (:BoltRoutingTest { protocol: 'BOLT+ROUTING' })");
+            }
+            connection.commit();
+
+            final String bookmark = connection.getClientInfo(BoltRoutingNeo4jDriver.BOOKMARK);
+            Assert.assertNotNull(bookmark);
+            return bookmark;
         }
     }
 }

--- a/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/driver/CypherExecutor.java
+++ b/neo4j-jdbc-http/src/main/java/org/neo4j/jdbc/http/driver/CypherExecutor.java
@@ -21,32 +21,44 @@ package org.neo4j.jdbc.http.driver;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.http.*;
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.AuthState;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.*;
-import org.apache.http.client.protocol.ClientContext;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.*;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
-import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HttpContext;
-import sun.misc.BASE64Encoder;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * Execute cypher queries.

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
 		<neo4j.version>3.4.1</neo4j.version>
 		<httpclient.version>4.5.3</httpclient.version>
 		<jackson.version>2.9.2</jackson.version>
+		<testcontainers.version>1.12.3</testcontainers.version>
 
 		<!-- Plugin version -->
 		<maven.plugin.compiler>3.6.1</maven.plugin.compiler>
@@ -179,6 +180,18 @@
 				<groupId>org.openjdk.jmh</groupId>
 				<artifactId>jmh-generator-annprocess</artifactId>
 				<version>${jmh.version}</version>
+			</dependency>
+
+			<!-- Deps for Testcontainers -->
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>testcontainers</artifactId>
+				<version>${testcontainers.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>neo4j</artifactId>
+				<version>${testcontainers.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
List of provided changes:
- [x] Added the support for multiple bookmarks separated by a comma;
- [x] Added Testcontainers in order to spin up a Causal Cluster and test the change;