### PR TITLE
fixes #236: Session Handling

### DIFF
--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaData.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaData.java
@@ -69,9 +69,7 @@ public class BoltNeo4jDatabaseMetaData extends Neo4jDatabaseMetaData {
 			} catch (Exception e) {
 				LOGGER.log(Level.SEVERE, e.getMessage(), e);
 			}finally{
-				if (session != null && session.isOpen()) {
-					session.close();
-				}
+				BoltNeo4jUtils.closeSafely(session, LOGGER);
 			}
 		}
 	}

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaData.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jDatabaseMetaData.java
@@ -69,7 +69,9 @@ public class BoltNeo4jDatabaseMetaData extends Neo4jDatabaseMetaData {
 			} catch (Exception e) {
 				LOGGER.log(Level.SEVERE, e.getMessage(), e);
 			}finally{
-				connection.closeSession(session);
+				if (session != null && session.isOpen()) {
+					session.close();
+				}
 			}
 		}
 	}

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jUtils.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jUtils.java
@@ -1,5 +1,6 @@
 package org.neo4j.jdbc.bolt;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.summary.SummaryCounters;
@@ -8,6 +9,7 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.logging.Logger;
 
 /**
  * A set of common functions for bolt connector
@@ -77,6 +79,21 @@ public class BoltNeo4jUtils {
                                           Map<String, Object> params) {
         Transaction transaction = connection.getTransaction();
         return transaction.run(statement, params);
+    }
+
+    public static void closeSafely(AutoCloseable closeable, Logger logger) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (Exception e) {
+            if (logger == null) {
+                return;
+            }
+            logger.warning("Exception while trying to close an AutoCloseable, because of the following exception: " +
+                    ExceptionUtils.getStackTrace(e));
+        }
     }
 
 }

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jConnectionTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jConnectionTest.java
@@ -518,23 +518,32 @@ public class BoltNeo4jConnectionTest {
 
 		openConnection.setAutoCommit(false);
 		openConnection.createStatement();
-		verify(openConnection.getSession(), times(1)).beginTransaction();
+		final Session session = openConnection.getSession();
+		verify(session, times(1)).beginTransaction();
 
 		openConnection.setAutoCommit(false);
 		openConnection.createStatement();
-		verify(openConnection.getSession(), times(1)).beginTransaction();
+		final Session session1 = openConnection.getSession();
+		verify(session1, times(1)).beginTransaction();
+		assertEquals(session, session1);
 
 		openConnection.setAutoCommit(true);
 		openConnection.createStatement();
-		verify(openConnection.getSession(), times(2)).beginTransaction();
+		final Session session2 = openConnection.getSession();
+		verify(session2, times(1)).beginTransaction();
+		assertNotEquals(session1, session2);
 
 		openConnection.setAutoCommit(true);
 		openConnection.createStatement();
-		verify(openConnection.getSession(), times(3)).beginTransaction();
+		final Session session3 = openConnection.getSession();
+		verify(session3, times(1)).beginTransaction();
+		assertNotEquals(session2, session3);
 
 		openConnection.setAutoCommit(false);
 		openConnection.createStatement();
-		verify(openConnection.getSession(), times(3)).beginTransaction();
+		final Session session4 = openConnection.getSession();
+		verify(session4, times(1)).beginTransaction();
+		assertNotEquals(session3, session4);
 	}
 
 	/*------------------------------*/

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jConnectionTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jConnectionTest.java
@@ -109,7 +109,7 @@ public class BoltNeo4jConnectionTest {
 	/*------------------------------*/
 	@Test public void closeShouldCloseConnection() throws SQLException {
 		Session session = mock(Session.class);
-		when(session.isOpen()).thenReturn(true).thenReturn(false);
+		when(session.isOpen()).thenReturn(true).thenReturn(true).thenReturn(false);
 		org.neo4j.driver.Driver driver = mock(org.neo4j.driver.Driver.class);
 		when(driver.session(any(SessionConfig.class))).thenReturn(session);
 		Connection connection = new BoltNeo4jConnectionImpl(driver, new Properties(), "");
@@ -525,25 +525,25 @@ public class BoltNeo4jConnectionTest {
 		openConnection.createStatement();
 		final Session session1 = openConnection.getSession();
 		verify(session1, times(1)).beginTransaction();
-		assertEquals(session, session1);
+		assertSame(session, session1);
 
 		openConnection.setAutoCommit(true);
 		openConnection.createStatement();
 		final Session session2 = openConnection.getSession();
 		verify(session2, times(1)).beginTransaction();
-		assertNotEquals(session1, session2);
+		assertNotSame(session1, session2);
 
 		openConnection.setAutoCommit(true);
 		openConnection.createStatement();
 		final Session session3 = openConnection.getSession();
 		verify(session3, times(1)).beginTransaction();
-		assertNotEquals(session2, session3);
+		assertNotSame(session2, session3);
 
 		openConnection.setAutoCommit(false);
 		openConnection.createStatement();
 		final Session session4 = openConnection.getSession();
 		verify(session4, times(1)).beginTransaction();
-		assertNotEquals(session3, session4);
+		assertNotSame(session3, session4);
 	}
 
 	/*------------------------------*/

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jStatementTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jStatementTest.java
@@ -36,6 +36,7 @@ import org.neo4j.jdbc.bolt.data.StatementData;
 import org.neo4j.jdbc.bolt.impl.BoltNeo4jConnectionImpl;
 import org.neo4j.jdbc.bolt.utils.Mocker;
 import org.neo4j.jdbc.utils.Neo4jInvocationHandler;
+import org.neo4j.test.ReflectionUtil;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -573,5 +574,17 @@ public class BoltNeo4jStatementTest {
 		stmt.close();
 
 		stmt.getConnection();
+	}
+
+	@Test public void shouldCreateABrandNewSession() throws Exception {
+		Properties props = new Properties();
+		Connection connection = new BoltNeo4jConnectionImpl(mockDriverOpen(), props, "");
+		PreparedStatement statement = connection.prepareStatement(StatementData.STATEMENT_MATCH_ALL);
+		Session session = ReflectionUtil.getPrivateField(connection, "session", Session.class);
+		statement.executeQuery();
+		PreparedStatement otherStatement = connection.prepareStatement(StatementData.STATEMENT_MATCH_ALL);
+		Session otherSession = ReflectionUtil.getPrivateField(connection, "session", Session.class);
+		otherStatement.executeQuery();
+		assertNotEquals(session, otherSession);
 	}
 }

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jStatementTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jStatementTest.java
@@ -585,6 +585,6 @@ public class BoltNeo4jStatementTest {
 		PreparedStatement otherStatement = connection.prepareStatement(StatementData.STATEMENT_MATCH_ALL);
 		Session otherSession = ReflectionUtil.getPrivateField(connection, "session", Session.class);
 		otherStatement.executeQuery();
-		assertNotEquals(session, otherSession);
+		assertNotSame(session, otherSession);
 	}
 }

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/utils/Mocker.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/utils/Mocker.java
@@ -102,7 +102,7 @@ public class Mocker {
 		when(session.isOpen()).thenReturn(true);
 		Transaction transaction = mock(Transaction.class);
 		when(session.beginTransaction()).thenReturn(transaction);
-		when(session.run(anyString())).thenAnswer(new Answer<ResultSet>() {
+		when(transaction.run(anyString())).thenAnswer(new Answer<ResultSet>() {
 			@Override public ResultSet answer(InvocationOnMock invocation) {
 				try {
 					TimeUnit.SECONDS.sleep(5);
@@ -119,7 +119,7 @@ public class Mocker {
 		when(session.isOpen()).thenReturn(true);
 		Transaction transaction = mock(Transaction.class);
 		when(session.beginTransaction()).thenReturn(transaction);
-		when(session.run(anyString())).thenThrow(new RuntimeException("RuntimeException THROWN"));
+		when(transaction.run(anyString())).thenThrow(new RuntimeException("RuntimeException THROWN"));
 		return session;
 	}
 

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/utils/Mocker.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/utils/Mocker.java
@@ -52,8 +52,15 @@ public class Mocker {
 
 	public static Driver mockDriverOpen() {
         Session session = mockSessionOpen();
+        Session session1 = mockSessionOpen();
+        Session session2 = mockSessionOpen();
+        Session session3 = mockSessionOpen();
+        Session session4 = mockSessionOpen();
+        Session session5 = mockSessionOpen();
 		Driver driver = mock(Driver.class);
-		when(driver.session(any(SessionConfig.class))).thenReturn(session);
+		when(driver.session(any(SessionConfig.class))).thenReturn(session, session1,
+				session2, session3,
+				session4, session5);
 		return driver;
 	}
 


### PR DESCRIPTION
Fixed the issue leveraged by #236, now we manage the session creation in these two ways:

* if auto-commit true for each statement we:
  * create session and transaction
  * run the single statement
  * on commit we close transaction and session
* if auto-commit false:
  * on the first statement we create session and transaction
  * run the statements with the same transaction
  * on commit we close transaction and session

This is the first implementation but we can do it better in future by moving the transaction lifecycle management to the Statements instead of having it in the Connection, ensuring better isolation between statements.