### PR TITLE
added autocommit via configuration parameter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -149,6 +149,7 @@ try (Connection con = DriverManager.getConnection("jdbc:neo4j:bolt://localhost",
 |max.transaction.retry.time |Any Long | The retry time for a transaction transient error
 |database |String |The database name, if not specified connects to the default instance
 |readonly |true/false |If specified creates a fixed read only connection, any further modification via the `Connection#setReadOnly` method will have no effect
+|autocommit |true/false |If specified sets the autocommit property as initial value, you can still change the autocommit value by using `Connection#setAutoCommit` method, but it will have effect only for newly created transactions
 |usebookmarks |true/false |If specified disables the bookmarks
 |===
 

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/impl/BoltNeo4jConnectionImpl.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/impl/BoltNeo4jConnectionImpl.java
@@ -80,6 +80,7 @@ public class BoltNeo4jConnectionImpl extends Neo4jConnectionImpl implements Bolt
 	public BoltNeo4jConnectionImpl(Driver driver, Properties properties, String url) {
 		super(properties, url, BoltNeo4jResultSet.DEFAULT_HOLDABILITY);
 		this.readOnly = Boolean.parseBoolean(getProperties().getProperty("readonly"));
+		this.autoCommit = Boolean.parseBoolean(getProperties().getProperty("autocommit", "true"));
 		this.useBookmarks = Boolean.parseBoolean(getProperties().getProperty("usebookmarks", "true"));
 		this.driver = driver;
 		this.initSession();

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jConnectionIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jConnectionIT.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.jdbc.bolt;
 
+import junit.framework.TestCase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,6 +37,7 @@ import org.neo4j.harness.junit.rule.Neo4jRule;
 import org.neo4j.jdbc.bolt.data.StatementData;
 import org.neo4j.jdbc.bolt.impl.BoltNeo4jDriverImpl;
 import org.neo4j.jdbc.bolt.utils.JdbcConnectionTestUtils;
+import org.powermock.api.mockito.PowerMockito;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -299,6 +301,14 @@ public class BoltNeo4jConnectionIT {
 					assertEquals(1, resultSet.getLong(1));
 				}
 			}
+		}
+	}
+	@Test public void shouldManageAutocommitParameter() throws SQLException, URISyntaxException {
+		try (Connection connection = JdbcConnectionTestUtils.getConnection(neo4j)) {
+			assertTrue("default is true", connection.getAutoCommit());
+		}
+		try (Connection connection = JdbcConnectionTestUtils.getConnection(neo4j, "&autocommit=false")) {
+			assertFalse("we defined false but it is not", connection.getAutoCommit());
 		}
 	}
 


### PR DESCRIPTION
Now the user can pass `autocommit` as. configuration parameter, i.e. `jdbc:neo4j:bolt://127.0.0.1:63206/?autocommit=false`