### PR TITLE
fixes #270: Manage Statement#getMoreResults properly

### DIFF
--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatementIT.java
@@ -316,5 +316,18 @@ public class BoltNeo4jPreparedStatementIT {
 		assertEquals(Arrays.asList(1L,2L,4L), map.get("props"));
 		search.close();
 	}
+
+	@Test public void testMoreResultInvokedTwice() throws SQLException {
+		neo4j.defaultDatabaseService().executeTransactionally(StatementData.STATEMENT_CREATE_TWO_PROPERTIES);
+		PreparedStatement statement = connection.prepareStatement(StatementData.STATEMENT_MATCH_ALL_STRING_PARAMETRIC);
+		statement.setString(1, "test");
+		statement.execute();
+
+		assertTrue(statement.getMoreResults());
+
+		assertFalse(statement.getMoreResults());
+
+		statement.close();
+	}
 }
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
@@ -162,7 +162,15 @@ public abstract class Neo4jStatement implements Statement, Loggable {
 	 */
 	@Override public boolean getMoreResults() throws SQLException {
 		this.checkClosed();
-		return this.currentResultSet != null;
+		if (this.currentResultSet == null) {
+			return false;
+		}
+		boolean isOpen = false;
+		if (!this.currentResultSet.isClosed()) {
+			isOpen = true;
+			this.currentResultSet.close();
+		}
+		return isOpen;
 	}
 
 	/**


### PR DESCRIPTION
Manage Statement#getMoreResults properly

* first call of getMoreResults returns true since the result is a RS, and this RS will then be closed
* second call of getMoreResults returns false since there is no current RS anymore (OR we check RS is closed)