### PR TITLE
fixes #272: Improve RETURN clause detection

### DIFF
--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jConnection.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jConnection.java
@@ -48,4 +48,11 @@ public interface BoltNeo4jConnection extends Connection {
 	void doCommit() throws SQLException;
 	void doRollback() throws SQLException;
 
+	/**
+	 * Build an internal neo4j session, without saving reference (stateless)
+	 * Close using {@link #close()} for driver management
+	 * @return
+	 */
+	Session newNeo4jSession();
+
 }

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatement.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jPreparedStatement.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 
 import static java.util.Arrays.copyOf;
 import static org.neo4j.jdbc.utils.BoltNeo4jUtils.executeInTx;
+import static org.neo4j.jdbc.utils.BoltNeo4jUtils.hasResultSet;
 
 /**
  * @author AgileLARUS
@@ -79,7 +80,7 @@ public class BoltNeo4jPreparedStatement extends Neo4jPreparedStatement implement
 
 	@Override public boolean execute() throws SQLException {
 		return executeInternal((result) -> {
-			boolean hasResultSet = hasResultSet();
+			boolean hasResultSet = hasResultSet((BoltNeo4jConnection) this.connection, this.statement);
 			if (hasResultSet) {
 				this.currentResultSet = BoltNeo4jResultSet.newInstance(this.hasDebug(), this, result, this.resultSetParams);
 				this.currentUpdateCount = -1;
@@ -95,10 +96,6 @@ public class BoltNeo4jPreparedStatement extends Neo4jPreparedStatement implement
 	private <T> T executeInternal(Function<Result, T> body) throws SQLException {
 		this.checkClosed();
 		return executeInTx((BoltNeo4jConnection) this.connection, this.statement, this.parameters, body);
-	}
-
-	private boolean hasResultSet() {
-		return this.statement != null && this.statement.toLowerCase().contains("return");
 	}
 
 	@Override public Neo4jParameterMetaData getParameterMetaData() throws SQLException {

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSet.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jResultSet.java
@@ -22,6 +22,7 @@ package org.neo4j.jdbc.bolt;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.value.DateTimeValue;
@@ -290,6 +291,10 @@ public class BoltNeo4jResultSet extends Neo4jResultSet {
 	}
 
 	private Value fetchValueFromLabel(String label) throws SQLException {
+		if (this.current == null) {
+			this.wasNull = true;
+			return Values.NULL;
+		}
 		Value value;
 		if (this.current.containsKey(label)) {
 			//Requested value is not flattened

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jStatement.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/BoltNeo4jStatement.java
@@ -36,6 +36,7 @@ import java.util.function.Function;
 
 import static java.util.Arrays.copyOf;
 import static org.neo4j.jdbc.utils.BoltNeo4jUtils.executeInTx;
+import static org.neo4j.jdbc.utils.BoltNeo4jUtils.hasResultSet;
 
 /**
  * @author AgileLARUS
@@ -80,10 +81,9 @@ public class BoltNeo4jStatement extends Neo4jStatement {
 	}
 
 	@Override public boolean execute(String sql) throws SQLException {
+		boolean hasResultSet = hasResultSet((BoltNeo4jConnection) connection, sql);
 		return executeInternal(sql, (result) -> {
-			boolean hasResultSet = false;
 			if (result != null) {
-				hasResultSet = hasResultSet(sql);
 				if (hasResultSet) {
 					this.currentResultSet = BoltNeo4jResultSet.newInstance(this.hasDebug(), this, result, this.resultSetParams);
 					this.currentUpdateCount = -1;
@@ -101,10 +101,6 @@ public class BoltNeo4jStatement extends Neo4jStatement {
 								  Function<Result, T> body) throws SQLException {
 		this.checkClosed();
 		return executeInTx((BoltNeo4jConnection) this.connection, statement, body);
-	}
-
-	private boolean hasResultSet(String sql) {
-		return sql != null && sql.toLowerCase().contains("return ");
 	}
 
 	/*-------------------*/

--- a/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/impl/BoltNeo4jConnectionImpl.java
+++ b/neo4j-jdbc-bolt/src/main/java/org/neo4j/jdbc/bolt/impl/BoltNeo4jConnectionImpl.java
@@ -117,6 +117,7 @@ public class BoltNeo4jConnectionImpl extends Neo4jConnectionImpl implements Bolt
 	 * Close using {@link #close()} for driver management
 	 * @return
 	 */
+	@Override
 	public Session newNeo4jSession() {
 		try {
 			final SessionConfig.Builder config = SessionConfig.builder()

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jStatementIT.java
@@ -305,4 +305,80 @@ public class BoltNeo4jStatementIT {
 		statement.close();
 	}
 
+	@Test public void testCallProcedure() throws SQLException {
+		connection.setAutoCommit(true);
+
+		try (Statement statement = connection.createStatement()) {
+			statement.execute("CALL db.schema.visualization");
+
+			ResultSet resultSet = statement.getResultSet();
+			resultSet.next();
+			Array arrayNodes = resultSet.getArray("nodes");
+			Object[] nodesArray = (Object[]) arrayNodes.getArray();
+			assertEquals(0, nodesArray.length);
+			Array arrayRels = resultSet.getArray("relationships");
+			Object[] relsArray = (Object[]) arrayRels.getArray();
+			assertEquals(0, relsArray.length);
+		}
+	}
+
+	@Test public void testSimpleReturn() throws SQLException {
+		connection.setAutoCommit(true);
+
+		try (Statement statement = connection.createStatement()) {
+			statement.execute("RETURN 1 AS id");
+
+			ResultSet resultSet = statement.getResultSet();
+			resultSet.next();
+			final long id = resultSet.getLong("id");
+			assertEquals(1L, id);
+		}
+	}
+
+	@Test public void testUnwindNope() throws SQLException {
+		connection.setAutoCommit(true);
+
+		try (Statement statement = connection.createStatement()) {
+			final boolean execute = statement.execute("UNWIND [] AS nope RETURN nope");
+			assertTrue(execute);
+
+			ResultSet resultSet = statement.getResultSet();
+			resultSet.next();
+			final Object nope = resultSet.getObject("nope");
+			assertNull(nope);
+		}
+	}
+
+	@Test public void testCreate() throws SQLException {
+		connection.setAutoCommit(true);
+
+		try (Statement statement = connection.createStatement()) {
+			final boolean execute = statement.execute("CREATE (n:NodeTestToDelete)");
+			assertFalse(execute);
+			assertNull(statement.getResultSet());
+		}
+		neo4j.defaultDatabaseService().executeTransactionally("MATCH (n:NodeTestToDelete) DELETE n");
+	}
+
+	@Test public void testExplain() throws SQLException {
+		connection.setAutoCommit(true);
+
+		try (Statement statement = connection.createStatement()) {
+			final boolean execute = statement.execute("EXPLAIN CREATE (n:NodeTestToDelete)");
+			assertFalse(execute);
+			assertNull(statement.getResultSet());
+		}
+	}
+
+	@Test public void testProfile() throws SQLException {
+		connection.setAutoCommit(true);
+
+		try (Statement statement = connection.createStatement()) {
+			final boolean execute = statement.execute("PROFILE CREATE (n:NodeTestToDelete)");
+			assertFalse(execute);
+			assertNull(statement.getResultSet());
+		}
+		neo4j.defaultDatabaseService().executeTransactionally("MATCH (n:NodeTestToDelete) DELETE n");
+	}
+
 }

--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jStatementTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/BoltNeo4jStatementTest.java
@@ -26,15 +26,19 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
+import org.neo4j.driver.summary.Plan;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.summary.SummaryCounters;
 import org.neo4j.jdbc.Neo4jStatement;
 import org.neo4j.jdbc.bolt.data.StatementData;
 import org.neo4j.jdbc.bolt.impl.BoltNeo4jConnectionImpl;
 import org.neo4j.jdbc.bolt.utils.Mocker;
+import org.neo4j.jdbc.utils.BoltNeo4jUtils;
 import org.neo4j.jdbc.utils.Neo4jInvocationHandler;
 import org.neo4j.test.ReflectionUtil;
 import org.powermock.api.mockito.PowerMockito;
@@ -62,7 +66,7 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
  * @since 3.0.0
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ BoltNeo4jStatement.class, BoltNeo4jResultSet.class, Session.class })
+@PrepareForTest({ BoltNeo4jStatement.class, BoltNeo4jResultSet.class, Session.class, BoltNeo4jUtils.class })
 
 public class BoltNeo4jStatementTest {
 
@@ -286,8 +290,10 @@ public class BoltNeo4jStatementTest {
 	@Test public void executeShouldRunQuery() throws SQLException {
 		Result mockResult = mock(Result.class);
 
+		final BoltNeo4jConnectionImpl mockedConnection = mockConnectionOpenWithTransactionThatReturns(mockResult);
+		mockStatic(BoltNeo4jUtils.class, invocationOnMock -> invocationOnMock.getMethod().getName().equals("hasResult"));
 		Statement statement = BoltNeo4jStatement
-				.newInstance(false, mockConnectionOpenWithTransactionThatReturns(mockResult), ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY,
+				.newInstance(false, mockedConnection, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY,
 						ResultSet.HOLD_CURSORS_OVER_COMMIT);
 		statement.execute(StatementData.STATEMENT_MATCH_ALL);
 	}


### PR DESCRIPTION
Improve RETURN clause detection by analysing the Plan looking for an `EmptyResult`