### PR TITLE
Shutdown executor.

### DIFF
--- a/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/cache/BoltDriverCacheTest.java
+++ b/neo4j-jdbc-bolt/src/test/java/org/neo4j/jdbc/bolt/cache/BoltDriverCacheTest.java
@@ -69,6 +69,7 @@ public class BoltDriverCacheTest {
         for (Future<Driver> getDriverFuture : executor.invokeAll(getDriver)) {
             drivers.put(getDriverFuture.get(), 1);
         }
+        executor.shutdown();
 
         assumeTrue(overlaps.get() > 0); // This might get flaky...
         assertEquals(1, drivers.size());


### PR DESCRIPTION
This prevents thread exhaustion during tests (probably only applicable when re-running things until failure, but nevertheless).