### PR TITLE
Update Java driver to include Netty fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<mockito.version>3.12.4</mockito.version>
 		<junit.version>4.13.2</junit.version>
 		<jmh.version>1.19</jmh.version>
-		<neo4j.java.driver.version>4.3.1</neo4j.java.driver.version>
+		<neo4j.java.driver.version>4.3.4</neo4j.java.driver.version>
 		<neo4j.version>4.3.0</neo4j.version>
 		<httpclient.version>4.5.13</httpclient.version>
 		<jackson.version>2.11.0</jackson.version>


### PR DESCRIPTION
The recent Java driver configures Netty so that it spawns deamon
threads for its event lopos and therefore does not block
application when they shut down. This is especially useful for
CLI applications using the JDBC driver.

See https://github.com/neo4j/neo4j-java-driver/pull/918 for more
context.