### PR TITLE
fixes #291: Vulnerabilities in dependency commons-beanutils:commons-beanutils 1.9.3

### DIFF
--- a/neo4j-jdbc-http/pom.xml
+++ b/neo4j-jdbc-http/pom.xml
@@ -58,7 +58,8 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>4.0</version>
+            <version>5.5.2</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/test/Neo4jHttpUnitTestUtil.java
+++ b/neo4j-jdbc-http/src/test/java/org/neo4j/jdbc/http/test/Neo4jHttpUnitTestUtil.java
@@ -21,7 +21,9 @@ package org.neo4j.jdbc.http.test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -60,7 +62,12 @@ public class Neo4jHttpUnitTestUtil {
 		List<String[]> queriesCsv = new ArrayList<>();
 
 		File csv = new File(getClass().getClassLoader().getResource(filename).getFile());
-		CSVReader reader = new CSVReader(new FileReader(csv), ';', '"');
+		CSVReader reader = new CSVReaderBuilder(new FileReader(csv))
+				.withCSVParser(new CSVParserBuilder()
+						.withQuoteChar('"')
+						.withSeparator(';')
+						.build())
+				.build();
 		List<String[]> entries = reader.readAll();
 		entries.remove(0); // remove headers
 


### PR DESCRIPTION
OpenCSV has a transitive dep to BeanUtils 1.9.3:

- [ ] Updated OpenCSV to the last version that contains BeanUtils 1.9.4
- [ ] Changed `scope` to `test` 