### PR TITLE
refactor: Extract all metadata queries used into a separate resource.

### DIFF
--- a/neo4j-jdbc/src/main/resources/META-INF/native-image/org.neo4j/neo4j-jdbc/resources-config.json
+++ b/neo4j-jdbc/src/main/resources/META-INF/native-image/org.neo4j/neo4j-jdbc/resources-config.json
@@ -2,6 +2,9 @@
   "resources": [
     {
       "pattern": "META-INF/MANIFEST\\.MF"
+    },
+    {
+      "pattern": "queries/.*\\.properties"
     }
   ]
 }

--- a/neo4j-jdbc/src/main/resources/queries/DatabaseMetadata.properties
+++ b/neo4j-jdbc/src/main/resources/queries/DatabaseMetadata.properties
@@ -1,0 +1,151 @@
+#
+# Copyright (c) 2023-2024 "Neo4j,"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+getDatabaseProductName=CALL dbms.components() YIELD name, versions, edition \
+UNWIND versions AS version RETURN name, edition, version
+getDatabaseProductVersion=CALL dbms.components() YIELD versions \
+UNWIND versions AS version RETURN version
+getProcedures=SHOW PROCEDURES YIELD name AS PROCEDURE_NAME, description AS REMARKS \
+ORDER BY PROCEDURE_NAME \
+WHERE name = $name OR $name IS NULL \
+RETURN \
+NULL AS PROCEDURE_CAT, \
+"public" AS PROCEDURE_SCHEM, \
+PROCEDURE_NAME, \
+NULL AS reserved_1, \
+NULL AS reserved_2, \
+NULL AS reserved_3, \
+REMARKS, \
+$procedureType AS PROCEDURE_TYPE, \
+PROCEDURE_NAME as SPECIFIC_NAME
+getProcedureColumns=UNWIND $results AS result \
+WITH result, range(0, size(result.argumentDescriptions) - 1) AS ordinal_positions \
+UNWIND ordinal_positions AS ORDINAL_POSITION \
+WITH result, ORDINAL_POSITION \
+WHERE result.argumentDescriptions[ORDINAL_POSITION].name = $columnNamePattern OR $columnNamePattern IS NULL OR $columnNamePattern = '%' \
+RETURN \
+NULL AS PROCEDURE_CAT, \
+"public" AS PROCEDURE_SCHEM, \
+result.name AS PROCEDURE_NAME, \
+result.argumentDescriptions[ORDINAL_POSITION].name AS COLUMN_NAME, \
+$columnType AS COLUMN_TYPE, \
+NULL AS DATA_TYPE, \
+NULL AS TYPE_NAME, \
+NULL AS PRECISION, \
+NULL AS LENGTH, \
+NULL AS SCALE, \
+NULL AS RADIX, \
+$nullable AS NULLABLE, \
+result.argumentDescriptions[ORDINAL_POSITION].description AS REMARKS, \
+NULL AS COLUMN_DEF, \
+NULL AS SQL_DATA_TYPE, \
+NULL AS SQL_DATETIME_SUB, \
+NULL AS CHAR_OCTET_LENGTH, \
+ORDINAL_POSITION + 1 AS ORDINAL_POSITION, \
+'' AS IS_NULLABLE, \
+result.name AS SPECIFIC_NAME
+getTables=CALL db.labels() YIELD label AS TABLE_NAME \
+WHERE ($name IS NULL OR TABLE_NAME =~ $name) AND EXISTS {MATCH (n) WHERE TABLE_NAME IN labels(n)} \
+RETURN \
+"" as TABLE_CAT, \
+"public" AS TABLE_SCHEM, \
+TABLE_NAME, \
+"TABLE" as TABLE_TYPE, \
+NULL as REMARKS, \
+NULL AS TYPE_CAT, \
+NULL AS TYPE_SCHEM, \
+NULL AS TYPE_NAME, \
+NULL AS SELF_REFERENCES_COL_NAME, \
+NULL AS REF_GENERATION
+getColumns=CALL db.schema.nodeTypeProperties() \
+YIELD nodeLabels, propertyName, propertyTypes \
+WITH * \
+WHERE ($name IS NULL OR $name = '%' OR ANY (label IN nodeLabels WHERE label =~ $name)) \
+AND ($column_name IS NULL OR propertyName =~ $column_name) \
+RETURN *
+getColumns.nullability=SHOW CONSTRAINTS YIELD * \
+WHERE type IN ['NODE_KEY', 'NODE_PROPERTY_EXISTENCE'] \
+AND $propertyName IN properties \
+AND ANY (x IN $nodeLabels WHERE x IN labelsOrTypes) \
+RETURN count(*) > 0
+getIndexInfo=SHOW INDEXES YIELD name, type, labelsOrTypes, properties, owningConstraint, entityType \
+ORDER BY name \
+WHERE ($name IS NULL OR $name = '%' OR $name IN labelsOrTypes) \
+AND size(labelsOrTypes) = 1 \
+AND entityType = 'NODE' \
+AND type <> 'LOOKUP' \
+AND (NOT $unique OR owningConstraint IS NOT NULL)
+getIndexInfo.flattening=UNWIND $results AS result \
+WITH result, range(0, size(result.properties) - 1) AS ordinal_positions \
+UNWIND ordinal_positions AS ORDINAL_POSITION \
+WITH result, ORDINAL_POSITION \
+RETURN \
+NULL AS TABLE_CAT, \
+"public" AS TABLE_SCHEM, \
+result.tableName AS TABLE_NAME, \
+result.owningConstraint IS NULL AS NON_UNIQUE, \
+result.name AS INDEX_QUALIFIER, \
+result.name AS INDEX_NAME, \
+$type AS TYPE, \
+CASE WHEN result.properties[ORDINAL_POSITION] IS NULL THEN NULL ELSE ORDINAL_POSITION + 1 END AS ORDINAL_POSITION, \
+result.properties[ORDINAL_POSITION] AS COLUMN_NAME, \
+'A' AS ASC_OR_DESC, \
+NULL AS CARDINALITY, \
+NULL AS PAGES, \
+NULL AS FILTER_CONDITION
+getFunctions=SHOW FUNCTIONS YIELD name AS FUNCTION_NAME, description AS REMARKS \
+ORDER BY FUNCTION_NAME \
+WHERE name = $name OR $name IS NULL \
+RETURN NULL AS FUNCTION_CAT, \
+"public" AS FUNCTION_SCHEM, \
+FUNCTION_NAME, \
+REMARKS, \
+$functionType AS FUNCTION_TYPE, \
+FUNCTION_NAME AS SPECIFIC_NAME
+getFunctionColumns=UNWIND $results AS result \
+WITH result, range(0, size(result.argumentDescriptions) - 1) AS ordinal_positions \
+UNWIND ordinal_positions AS ORDINAL_POSITION \
+WITH result, ORDINAL_POSITION \
+WHERE result.argumentDescriptions[ORDINAL_POSITION].name = $columnNamePattern OR $columnNamePattern IS NULL OR $columnNamePattern = '%' \
+RETURN \
+NULL AS FUNCTION_CAT, \
+"public" AS FUNCTION_SCHEM, \
+result.name AS FUNCTION_NAME, \
+result.argumentDescriptions[ORDINAL_POSITION].name AS COLUMN_NAME, \
+$columnType AS COLUMN_TYPE, \
+NULL AS DATA_TYPE, \
+NULL AS TYPE_NAME, \
+NULL AS PRECISION, \
+NULL AS LENGTH, \
+NULL AS SCALE, \
+NULL AS RADIX, \
+$nullable AS NULLABLE, \
+result.argumentDescriptions[ORDINAL_POSITION].description AS REMARKS, \
+NULL AS CHAR_OCTET_LENGTH, \
+ORDINAL_POSITION + 1 AS ORDINAL_POSITION, \
+'' AS IS_NULLABLE, \
+result.name AS SPECIFIC_NAME
+getArgumentDescriptions=SHOW %s YIELD name, description, argumentDescription \
+ORDER BY name \
+WHERE (name = $name OR $name IS NULL OR $name = '%%')
+allProceduresAreCallable=SHOW PROCEDURE EXECUTABLE YIELD name AS PROCEDURE_NAME
+getUserName=SHOW CURRENT USER YIELD user
+getMaxConnections=SHOW SETTINGS YIELD * \
+WHERE name =~ 'server.bolt.thread_pool_max_size' \
+RETURN toInteger(value)


### PR DESCRIPTION
Thus we avoid the (nice) JDK 17 string literals and (ugly) String concatenations.
In addition it could open up the possibility to have several variants of those, for past and future Neo4j versions.

Properties format has been chosen because it's one of the easiest to read without dependencies.
XML would be another option, but that would actually but more weight in on GraalVM native image or the module path.

Adding libraries for JSON or YAML is not worth the additional weight for this.
