### PR TITLE
fix: Return the maximum precision for INTEGER and FLOAT properties.

### DIFF
--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/DatabaseMetadataIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/DatabaseMetadataIT.java
@@ -1012,6 +1012,27 @@ class DatabaseMetadataIT extends IntegrationTestBase {
 	}
 
 	@Test
+	void precisionShallBeAvailableForSomeNumericProperties() throws SQLException {
+		try (var statement = this.connection.createStatement()) {
+			statement.execute("CREATE (n:Wurstsalat {d: 42.23, i: 21, s: 'asd'})");
+			var meta = this.connection.getMetaData().getColumns(null, null, "Wurstsalat", null);
+			while (meta.next()) {
+				var columnName = meta.getString("COLUMN_NAME");
+				var precision = meta.getInt("COLUMN_SIZE");
+				if ("d".equals(columnName)) {
+					assertThat(precision).isEqualTo(15);
+				}
+				else if ("i".equals(columnName)) {
+					assertThat(precision).isEqualTo(19);
+				}
+				else {
+					assertThat(precision).isZero();
+				}
+			}
+		}
+	}
+
+	@Test
 	void getIndexInfoWithIndex() throws Exception {
 		String indexName = "bar_uuid";
 		try (var statement = this.connection.createStatement()) {

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ResultSetMetaDataImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ResultSetMetaDataImpl.java
@@ -117,8 +117,8 @@ public class ResultSetMetaDataImpl implements ResultSetMetaData {
 	}
 
 	@Override
-	public int getPrecision(int column) {
-		return 0;
+	public int getPrecision(int column) throws SQLException {
+		return DatabaseMetadataImpl.getMaxPrecision(this.getColumnType(column));
 	}
 
 	@Override


### PR DESCRIPTION
For Cypher INTEGER it’s always 19 (Long.MAX_VALUE length), for FLOAT it is complicated: A float with all digits to the left of the comma will have a max precision of 15. Neo4j / Cypher does not have a proper fixed point float.

Closes #254.
