### PR TITLE
feat: add more authentication schemes

### DIFF
--- a/docs/src/main/asciidoc/modules/ROOT/pages/configuration.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/pages/configuration.adoc
@@ -89,7 +89,7 @@ The driver accepts the following configuration arguments, either properties or a
 |`String`
 a|The authentication scheme to use. *NOT RECOMMENDED* as URL query parameter for security reasons. Currently supported values are:
 
-* `basic` for basic authentication.
+* `basic` (default) for basic authentication.
 * `none` for no authentication. The properties `user`, `password` and `authRealm` have no effect.
 * `bearer` for bearer authentication (SSO). `password` should be set to the bearer token; `user` and `authRealm` have no effect.
 * `kerberos` for kerberos authentication. Requires `password` to be set to the kerberos ticket; `user` and `authRealm` have no effect.

--- a/docs/src/main/asciidoc/modules/ROOT/pages/configuration.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/pages/configuration.adoc
@@ -72,22 +72,22 @@ The driver accepts the following configuration arguments, either properties or a
 
 |`user`
 |`String`
-|The username (principal) to use for authentication. *NOT RECOMMENDED* for security reasons.
+|The username (principal) to use for authentication. *NOT RECOMMENDED* as URL query parameter for security reasons.
 |`neo4j`
 
 |`password`
 |`String`
-|The password (credentials) to use for authentication. *NOT RECOMMENDED* for security reasons.
+|The password (credentials) to use for authentication. *NOT RECOMMENDED* as URL query parameter for security reasons.
 |`password`
 
 |`authRealm`
 |`String`
-|The realm to use for authentication. *NOT RECOMMENDED* for security reasons.
+|The realm to use for authentication. *NOT RECOMMENDED* as URL query parameter for security reasons.
 |`null`
 
 |`authScheme`
 |`String`
-a|The authentication scheme to use. *NOT RECOMMENDED* for security reasons. Currently supported values are:
+a|The authentication scheme to use. *NOT RECOMMENDED* as URL query parameter for security reasons. Currently supported values are:
 
 * `basic` for basic authentication.
 * `none` for no authentication. The properties `user`, `password` and `authRealm` have no effect.

--- a/docs/src/main/asciidoc/modules/ROOT/pages/configuration.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/pages/configuration.adoc
@@ -80,6 +80,21 @@ The driver accepts the following configuration arguments, either properties or a
 |The password (credentials) to use for authentication. *NOT RECOMMENDED* for security reasons.
 |`password`
 
+|`authRealm`
+|`String`
+|The realm to use for authentication. *NOT RECOMMENDED* for security reasons.
+|`null`
+
+|`authScheme`
+|`String`
+a|The authentication scheme to use. *NOT RECOMMENDED* for security reasons. Currently supported values are:
+
+* `basic` for basic authentication.
+* `none` for no authentication. The properties `user`, `password` and `authRealm` have no effect.
+* `bearer` for bearer authentication (SSO). `password` should be set to the bearer token; `user` and `authRealm` have no effect.
+* `kerberos` for kerberos authentication. Requires `password` to be set to the kerberos ticket; `user` and `authRealm` have no effect.
+|`basic`
+
 |===
 
 == Getting a driver or a connection instance

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -777,6 +777,19 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 		return factories.stream().map(factory -> factory.create(config)).sorted(TranslatorComparator.INSTANCE).toList();
 	}
 
+	private static AuthScheme authScheme(String scheme) throws IllegalArgumentException {
+		if (scheme == null || scheme.isBlank()) {
+			return AuthScheme.BASIC;
+		}
+
+		try {
+			return AuthScheme.valueOf(scheme.toUpperCase(Locale.ROOT));
+		}
+		catch (IllegalArgumentException ignored) {
+			throw new IllegalArgumentException(String.format("%s is not a valid option for authScheme", scheme));
+		}
+	}
+
 	enum SSLMode {
 
 		DISABLE("disable"), REQUIRE("require"), VERIFY_FULL("verify-full");
@@ -820,19 +833,6 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 			return this.name;
 		}
 
-	}
-
-	private static AuthScheme authScheme(String scheme) throws IllegalArgumentException {
-		if (scheme == null || scheme.isBlank()) {
-			return AuthScheme.BASIC;
-		}
-
-		try {
-			return AuthScheme.valueOf(scheme.toUpperCase(Locale.ROOT));
-		}
-		catch (IllegalArgumentException ignored) {
-			throw new IllegalArgumentException(String.format("%s is not a valid option for authScheme", scheme));
-		}
 	}
 
 	/**

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDriverUrlParsingTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDriverUrlParsingTests.java
@@ -409,8 +409,8 @@ class Neo4jDriverUrlParsingTests {
 		props.put("authScheme", "foobar");
 
 		assertThatThrownBy(() -> driver.getPropertyInfo("jdbc:neo4j://host:1234", props))
-			.isInstanceOf(SQLException.class)
-			.hasMessageContaining("Unknown auth scheme: foobar");
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("foobar is not a valid option for authScheme");
 	}
 
 	private static Stream<Arguments> jdbcURLProvider() {


### PR DESCRIPTION
Add support for more auth schemes
 * `none` existed before, but was inferred from lacking user and password. Now needs to be configure explicitly.
 * `basic` as before
 * `bearer` for SSO tokens
 * `kerberos` for Kerberos tickets.

Fully custom auth schemes are currently not supported.

Closes: #579