### PR TITLE
feat: Add support for locally kept client info.

### DIFF
--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ConnectionImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ConnectionImplTests.java
@@ -366,7 +366,7 @@ class ConnectionImplTests {
 	@Test
 	void shouldClearWarnings() throws SQLException {
 		var connection = makeConnection(mock(BoltConnection.class));
-		connection.setClientInfo("a", "b");
+		connection.setClientInfo("", "b");
 		assertThat((Object) connection.getWarnings()).isNotNull();
 
 		connection.clearWarnings();


### PR DESCRIPTION
This just holds the three standard client info properties for now and makes a bunch of warnings in some tooling go away.

See 
![image](https://github.com/neo4j/neo4j-jdbc/assets/526383/925216b5-202d-4099-8abe-e5e9621bba5e)

![image](https://github.com/neo4j/neo4j-jdbc/assets/526383/b9298c02-73ec-43ac-84ee-92256361a6e2)

