### PR TITLE
Remove author revision and EAP attribute

### DIFF
--- a/docs/src/main/asciidoc/antora.yml
+++ b/docs/src/main/asciidoc/antora.yml
@@ -37,9 +37,6 @@ asciidoc:
     artifact-id-full-bundle: ${mainArtifactId}-full-bundle
     artifact-id-text2cypher-bundle: ${mainArtifactId}-text2cypher-bundle
     version: ${project.version}
-    revdate: ${revdate}
-    revnumber: ${project.version} ${git.commit.id.abbrev}
-    revremark: For EAP
     doctype: article
     title-page:
     lang: en

--- a/docs/src/main/asciidoc/modules/ROOT/pages/index.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/pages/index.adoc
@@ -1,8 +1,4 @@
 = Neo4j JDBC Driver
-Michael Simons <michael.simons@neo4j.com>
-:revdate: ${revdate}
-:revnumber: ${project.version} ${git.commit.id.abbrev}
-:revremark: For EAP
 :doctype: article
 :title-page:
 :lang: en


### PR DESCRIPTION
The `revremark` no long applies, and we don't typically use the revision or author line in Neo4j docs.