### PR TITLE
feat: Clean up mixed SQL/Cypher queries generated by Spark. [translator]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         run: >
           ./mvnw --no-transfer-progress
           -P$USE_SONAR -Dsonar.projectKey=neo4j-jdbc -Dsonar.projectName='neo4j-jdbc'
-          -am -pl neo4j-jdbc -pl neo4j-jdbc-bom -pl bundles/neo4j-jdbc-bundle -pl bundles/neo4j-jdbc-full-bundle          
+          -am -pl neo4j-jdbc -pl neo4j-jdbc-bom -pl bundles/neo4j-jdbc-bundle -pl bundles/neo4j-jdbc-full-bundle -pl neo4j-jdbc-translator/sparkcleaner
           clean install
 
   integration_tests:

--- a/neo4j-jdbc-bom/pom.xml
+++ b/neo4j-jdbc-bom/pom.xml
@@ -58,6 +58,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.neo4j</groupId>
+				<artifactId>neo4j-jdbc-translator-sparkcleaner</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.neo4j</groupId>
 				<artifactId>neo4j-jdbc-translator-spi</artifactId>
 				<version>${project.version}</version>
 			</dependency>

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
@@ -58,6 +58,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-jdbc-translator-sparkcleaner</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<scope>test</scope>

--- a/neo4j-jdbc-it/neo4j-jdbc-it-mp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-mp/pom.xml
@@ -48,6 +48,11 @@
 			<artifactId>neo4j-jdbc-translator-impl</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-jdbc-translator-sparkcleaner</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
@@ -58,10 +58,7 @@ import org.jooq.SortField;
 import org.jooq.Table;
 import org.jooq.TableField;
 import org.jooq.conf.ParamType;
-import org.jooq.conf.ParseUnknownFunctions;
-import org.jooq.conf.ParseWithMetaLookups;
 import org.jooq.impl.DSL;
-import org.jooq.impl.DefaultConfiguration;
 import org.jooq.impl.ParserException;
 import org.jooq.impl.QOM;
 import org.jooq.impl.QOM.TableAlias;
@@ -181,14 +178,7 @@ final class SqlToCypher implements Translator {
 	@SuppressWarnings("ResultOfMethodCallIgnored")
 	private DSLContext createDSLContext() {
 
-		var settings = new DefaultConfiguration().settings()
-			.withParseNameCase(this.config.getParseNameCase())
-			.withRenderNameCase(this.config.getRenderNameCase())
-			.withParseWithMetaLookups(ParseWithMetaLookups.IGNORE_ON_FAILURE)
-			.withDiagnosticsLogging(true)
-			.withParseUnknownFunctions(ParseUnknownFunctions.IGNORE)
-			.withParseDialect(this.config.getSqlDialect());
-
+		var settings = this.config.asSettings();
 		Optional.ofNullable(this.config.getParseNamedParamPrefix())
 			.filter(Predicate.not(String::isBlank))
 			.map(String::trim)

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypherConfig.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypherConfig.java
@@ -30,7 +30,11 @@ import java.util.stream.Collectors;
 
 import org.jooq.SQLDialect;
 import org.jooq.conf.ParseNameCase;
+import org.jooq.conf.ParseUnknownFunctions;
+import org.jooq.conf.ParseWithMetaLookups;
 import org.jooq.conf.RenderNameCase;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DefaultConfiguration;
 import org.neo4j.jdbc.translator.spi.Translator;
 
 /**
@@ -347,6 +351,20 @@ public final class SqlToCypherConfig {
 	 */
 	public Integer getPrecedence() {
 		return this.precedence;
+	}
+
+	public Settings asSettings() {
+		return asSettings(ParseWithMetaLookups.IGNORE_ON_FAILURE);
+	}
+
+	public Settings asSettings(ParseWithMetaLookups withMetaLookups) {
+		return new DefaultConfiguration().settings()
+			.withParseNameCase(getParseNameCase())
+			.withRenderNameCase(getRenderNameCase())
+			.withParseWithMetaLookups(withMetaLookups)
+			.withDiagnosticsLogging(isJooqDiagnosticLogging())
+			.withParseUnknownFunctions(ParseUnknownFunctions.IGNORE)
+			.withParseDialect(getSqlDialect());
 	}
 
 	/**

--- a/neo4j-jdbc-translator/pom.xml
+++ b/neo4j-jdbc-translator/pom.xml
@@ -36,6 +36,7 @@
 	<modules>
 		<module>spi</module>
 		<module>impl</module>
+		<module>sparkcleaner</module>
 		<module>text2cypher</module>
 	</modules>
 

--- a/neo4j-jdbc-translator/sparkcleaner/pom.xml
+++ b/neo4j-jdbc-translator/sparkcleaner/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2025 "Neo4j,"
+    Neo4j Sweden AB [https://neo4j.com]
+
+    This file is part of Neo4j.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.neo4j</groupId>
+		<artifactId>neo4j-jdbc-translator</artifactId>
+		<version>6.1.2-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>neo4j-jdbc-translator-sparkcleaner</artifactId>
+
+	<packaging>jar</packaging>
+	<name>Neo4j JDBC Driver (Spark preparing Translator)</name>
+	<description>A specialized translator unwrapping Spark subqueries</description>
+
+	<properties>
+		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.neo4j</groupId>
+			<artifactId>cypher-v5-antlr-parser</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-jdbc-translator-spi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<!-- First shade the things we won't definitely not have as dependency -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<phase>package</phase>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>org.neo4j:cypher-antlr-common</include>
+									<include>org.neo4j:cypher-v5-antlr-parser</include>
+									<include>org.antlr:antlr4-runtime</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>org.antlr</pattern>
+									<shadedPattern>org.neo4j.jdbc.translator.sparkcleaner.internal.shaded.antlr</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.neo4j.cypher.internal.parser</pattern>
+									<shadedPattern>org.neo4j.jdbc.translator.sparkcleaner.internal.shaded.parser.common</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.neo4j.cypher.internal.parser.v5</pattern>
+									<shadedPattern>org.neo4j.jdbc.translator.sparkcleaner.internal.shaded.parser.v5</shadedPattern>
+								</relocation>
+							</relocations>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+							</transformers>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>LICENSE.txt</exclude>
+										<exclude>META-INF/LICENSE*.txt</exclude>
+										<exclude>META-INF/MANIFEST.MF</exclude>
+										<exclude>META-INF/NOTICE.txt</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<!-- Than add the module info -->
+				<groupId>org.moditect</groupId>
+				<artifactId>moditect-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-module-infos</id>
+						<goals>
+							<goal>add-module-info</goal>
+						</goals>
+						<phase>package</phase>
+						<configuration>
+							<overwriteExistingFiles>true</overwriteExistingFiles>
+							<module>
+								<moduleInfoSource>module org.neo4j.jdbc.translator.sparkcleaner {
+										provides org.neo4j.jdbc.translator.spi.TranslatorFactory with org.neo4j.jdbc.translator.sparkcleaner.SparkSubqueryCleaningTranslatorFactory;
+										requires org.neo4j.jdbc.translator.spi;
+									}</moduleInfoSource>
+							</module>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/neo4j-jdbc-translator/sparkcleaner/src/main/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslator.java
+++ b/neo4j-jdbc-translator/sparkcleaner/src/main/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.translator.sparkcleaner;
+
+import java.sql.DatabaseMetaData;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.neo4j.cypher.internal.parser.v5.Cypher5Lexer;
+import org.neo4j.cypher.internal.parser.v5.Cypher5Parser;
+import org.neo4j.jdbc.translator.spi.Translator;
+
+/**
+ * This translator will search for the occurrence of {@literal SPARK_GEN_SUBQ_} in a query
+ * before passing it on towards to the next translator. If such a literal is found, a
+ * check if it might be a spark subquery containing cypher instead of SQL is performed.
+ * The check is performed by parsing it with jOOQ as well.
+ *
+ * @author Michael J. Simons
+ * @since 6.2.0
+ */
+final class SparkSubqueryCleaningTranslator implements Translator {
+
+	private static final Pattern SUBQUERY_PATTERN = Pattern
+		.compile("(?ims)SELECT\\s+\\*\\s+FROM\\s+\\((.*?)\\)\\s+SPARK_GEN_SUBQ_0.*");
+
+	private final int precedence;
+
+	SparkSubqueryCleaningTranslator(int precedence) {
+		this.precedence = precedence;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.precedence;
+	}
+
+	@Override
+	public String translate(String statement, DatabaseMetaData optionalDatabaseMetaData) {
+		if (!mightBeASparkQuery(statement)) {
+			return null;
+		}
+
+		var extractedSubquery = extractSubquery(statement);
+		return extractedSubquery.filter(this::canParseAsCypher).map(v -> """
+				/*+ NEO4J FORCE_CYPHER */
+				CALL {%s} RETURN * LIMIT 1
+				""".formatted(v).strip()).orElse(null);
+	}
+
+	static boolean mightBeASparkQuery(String statement) {
+		return statement != null && statement.toUpperCase(Locale.ROOT).contains("SPARK_GEN_SUBQ");
+	}
+
+	static Optional<String> extractSubquery(String statement) {
+		var matcher = SUBQUERY_PATTERN.matcher(statement);
+		if (!matcher.matches()) {
+			return Optional.empty();
+		}
+		return Optional.of(matcher.group(1).trim());
+	}
+
+	boolean canParseAsCypher(String statement) {
+
+		var tokens = new CommonTokenStream(new Cypher5Lexer(CharStreams.fromString(statement)));
+		var parser = new Cypher5Parser(tokens);
+		parser.getErrorListeners().clear();
+		var statements = parser.statements();
+		return statements.getChildCount() != 0 && parser.isMatchedEOF() && parser.getNumberOfSyntaxErrors() == 0;
+	}
+
+}

--- a/neo4j-jdbc-translator/sparkcleaner/src/main/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslator.java
+++ b/neo4j-jdbc-translator/sparkcleaner/src/main/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslator.java
@@ -39,7 +39,7 @@ import org.neo4j.jdbc.translator.spi.Translator;
  * The check is performed by parsing it with jOOQ as well.
  *
  * @author Michael J. Simons
- * @since 6.2.0
+ * @since 6.1.2
  */
 final class SparkSubqueryCleaningTranslator implements Translator {
 

--- a/neo4j-jdbc-translator/sparkcleaner/src/main/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslator.java
+++ b/neo4j-jdbc-translator/sparkcleaner/src/main/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslator.java
@@ -90,7 +90,6 @@ final class SparkSubqueryCleaningTranslator implements Translator {
 		var parser = new Cypher5Parser(tokens);
 		parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
 		parser.setErrorHandler(new BailErrorStrategy());
-		Cypher5Parser.StatementsContext statements;
 		try {
 			parser.statements();
 		}

--- a/neo4j-jdbc-translator/sparkcleaner/src/main/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslatorFactory.java
+++ b/neo4j-jdbc-translator/sparkcleaner/src/main/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslatorFactory.java
@@ -29,7 +29,7 @@ import org.neo4j.jdbc.translator.spi.TranslatorFactory;
  * Creates a {@link SparkSubqueryCleaningTranslator}.
  *
  * @author Michael J. Simons
- * @since 6.2.0
+ * @since 6.1.2
  */
 public final class SparkSubqueryCleaningTranslatorFactory implements TranslatorFactory {
 

--- a/neo4j-jdbc-translator/sparkcleaner/src/main/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslatorFactory.java
+++ b/neo4j-jdbc-translator/sparkcleaner/src/main/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslatorFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.translator.sparkcleaner;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.neo4j.jdbc.translator.spi.Translator;
+import org.neo4j.jdbc.translator.spi.TranslatorFactory;
+
+/**
+ * Creates a {@link SparkSubqueryCleaningTranslator}.
+ *
+ * @author Michael J. Simons
+ * @since 6.2.0
+ */
+public final class SparkSubqueryCleaningTranslatorFactory implements TranslatorFactory {
+
+	@Override
+	public Translator create(Map<String, ?> config) {
+
+		var precedence = Optional.ofNullable(config)
+			.stream()
+			.flatMap(c -> c.entrySet().stream())
+			.filter(e -> e.getKey().equalsIgnoreCase("s2c.precedence"))
+			.map(Map.Entry::getValue)
+			.map(v -> {
+				if (v instanceof Integer i) {
+					return i;
+				}
+				else if (v instanceof String s) {
+					return Integer.parseInt(s);
+				}
+				else {
+					return null;
+				}
+			})
+			.filter(Objects::nonNull)
+			.map(v -> v - 1)
+			.findFirst()
+			.orElse(Translator.LOWEST_PRECEDENCE - 5);
+		return new SparkSubqueryCleaningTranslator(precedence);
+	}
+
+}

--- a/neo4j-jdbc-translator/sparkcleaner/src/main/java/org/neo4j/jdbc/translator/sparkcleaner/package-info.java
+++ b/neo4j-jdbc-translator/sparkcleaner/src/main/java/org/neo4j/jdbc/translator/sparkcleaner/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Translator to be chained with the default translator implementation. It is able to
+ * detect Cypher in a subquery and wrap it into a similar <code>CALL IN {}</code> block.
+ */
+package org.neo4j.jdbc.translator.sparkcleaner;

--- a/neo4j-jdbc-translator/sparkcleaner/src/main/resources/META-INF/services/org.neo4j.jdbc.translator.spi.TranslatorFactory
+++ b/neo4j-jdbc-translator/sparkcleaner/src/main/resources/META-INF/services/org.neo4j.jdbc.translator.spi.TranslatorFactory
@@ -1,0 +1,1 @@
+org.neo4j.jdbc.translator.sparkcleaner.SparkSubqueryCleaningTranslatorFactory

--- a/neo4j-jdbc-translator/sparkcleaner/src/test/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslatorFactoryTests.java
+++ b/neo4j-jdbc-translator/sparkcleaner/src/test/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslatorFactoryTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.translator.sparkcleaner;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SparkSubqueryCleaningTranslatorFactoryTests {
+
+	private static final int DEFAULT_ORDER = Integer.MAX_VALUE - 5;
+
+	@Test
+	void shouldCreateTranslatorWithoutConfig() {
+		assertThat(new SparkSubqueryCleaningTranslatorFactory().create(null).getOrder()).isEqualTo(DEFAULT_ORDER);
+	}
+
+	@Test
+	void shouldCreateTranslatorWithEmptyConfig() {
+		assertThat(new SparkSubqueryCleaningTranslatorFactory().create(Map.of()).getOrder()).isEqualTo(DEFAULT_ORDER);
+	}
+
+	@Test
+	void shouldCreateTranslator() {
+		assertThat(new SparkSubqueryCleaningTranslatorFactory().create(Map.of("s2c.precedence", 10)).getOrder())
+			.isEqualTo(9);
+	}
+
+}

--- a/neo4j-jdbc-translator/sparkcleaner/src/test/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslatorTests.java
+++ b/neo4j-jdbc-translator/sparkcleaner/src/test/java/org/neo4j/jdbc/translator/sparkcleaner/SparkSubqueryCleaningTranslatorTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.translator.sparkcleaner;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SparkSubqueryCleaningTranslatorTests {
+
+	static final int RANDOM_PRECEDENCE = 4711;
+
+	@ParameterizedTest
+	@CsvSource(textBlock = """
+			n/a,false
+			SELECT * FROM dingens,false
+			SELECT * FROM SPARK_GEN_SUBQ,true
+			MATCH (n) RETURN n,false,
+			,false
+			SELECT * FROM (MATCH (n) RETURN n) SPARK_GEN_SUBQ_0 WHERE 1=0, true
+			""", nullValues = "n/a")
+	void shouldDetectPossibleSparkSubqueries(String statement, boolean expectation) {
+		assertThat(SparkSubqueryCleaningTranslator.mightBeASparkQuery(statement)).isEqualTo(expectation);
+	}
+
+	static Stream<Arguments> shouldBeAbleToExtractSubquery() {
+		return Stream.of(Arguments.of("""
+				SELECT * FROM (
+				MATCH (m:Movie)<-[:ACTED_IN]-(p:Person)
+				RETURN m.title AS title, collect(p.name) AS actors
+				ORDER BY m.title
+				) SPARK_GEN_SUBQ_0 WHERE 1=0
+				""", """
+				MATCH (m:Movie)<-[:ACTED_IN]-(p:Person)
+				RETURN m.title AS title, collect(p.name) AS actors
+				ORDER BY m.title
+				"""),
+				Arguments.of(
+						"""
+								SELECT * FROM (
+								MATCH (m:Movie)<-[:ACTED_IN]-(p:Person) RETURN m.title AS title, collect(p.name) AS actors ORDER BY m.title
+								) SPARK_GEN_SUBQ_0 WHERE 1=0
+								""",
+						"""
+								MATCH (m:Movie)<-[:ACTED_IN]-(p:Person) RETURN m.title AS title, collect(p.name) AS actors ORDER BY m.title
+								"""),
+				Arguments.of("""
+						SELECT * FROM (
+							SELECT * FROM (RETURN 1) SPARK_GEN_SUBQ_1
+						) SPARK_GEN_SUBQ_0 WHERE 1=0
+						""", """
+						SELECT * FROM (RETURN 1) SPARK_GEN_SUBQ_1
+						"""), Arguments.of("""
+						SELECT * FROM (
+							SELECT * FROM (RETURN 1) SPARK_GEN_SUBQ_1
+						)
+						""", null), Arguments.of("SELECT * FROM Movie", null));
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void shouldBeAbleToExtractSubquery(String statement, String expectedSubquery) {
+		var extracted = SparkSubqueryCleaningTranslator.extractSubquery(statement);
+		if (expectedSubquery != null) {
+			assertThat(extracted).hasValue(expectedSubquery.trim());
+		}
+		else {
+			assertThat(extracted).isEmpty();
+		}
+	}
+
+	static Stream<Arguments> shouldDetectParsableCypher() {
+		return Stream.of(Arguments.of(
+				"MATCH (m:Movie)<-[:ACTED_IN]-(p:Person) RETURN m.title AS title, collect(p.name) AS actors ORDER BY m.title",
+				true), Arguments.of("INSERT INTO Movie(title, year) VALUES (?, ?)", false),
+				Arguments.of("SELECT * FROM Movie", false), Arguments.of("RETURN 1", true));
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void shouldDetectParsableCypher(String statement, boolean expectation) {
+
+		var translator = new SparkSubqueryCleaningTranslator(RANDOM_PRECEDENCE);
+		assertThat(translator.canParseAsCypher(statement)).isEqualTo(expectation);
+	}
+
+	@Test
+	void shouldWrap() {
+		var translator = new SparkSubqueryCleaningTranslator(RANDOM_PRECEDENCE);
+
+		var query = """
+				SELECT * FROM (
+				MATCH (m:Movie)<-[:ACTED_IN]-(p:Person)
+				RETURN m.title AS title, collect(p.name) AS actors
+				ORDER BY m.title
+				) SPARK_GEN_SUBQ_0 WHERE 1=0
+				""";
+
+		assertThat(translator.translate(query)).isEqualTo("""
+				/*+ NEO4J FORCE_CYPHER */
+				CALL {MATCH (m:Movie)<-[:ACTED_IN]-(p:Person)
+				RETURN m.title AS title, collect(p.name) AS actors
+				ORDER BY m.title} RETURN * LIMIT 1
+				""".strip());
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
 		<checkstyle.version>10.21.1</checkstyle.version>
 		<covered-ratio-complexity>0.05</covered-ratio-complexity>
 		<covered-ratio-instructions>0.05</covered-ratio-instructions>
+		<cypher-v5-antlr-parser.version>5.26.1</cypher-v5-antlr-parser.version>
 		<docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>
 		<dotenv-java.version>3.1.0</dotenv-java.version>
 		<duplicate-finder-maven-plugin.version>2.0.1</duplicate-finder-maven-plugin.version>
@@ -180,7 +181,7 @@
 		<neo4j-cypher-dsl.version>2024.4.0</neo4j-cypher-dsl.version>
 		<neo4j-jdbc.previous.version>6.1.1</neo4j-jdbc.previous.version>
 		<neo4j.image>neo4j:${neo4j.version}</neo4j.image>
-		<neo4j.version>5.23.0</neo4j.version>
+		<neo4j.version>5.26.0</neo4j.version>
 		<netty.version>4.1.116.Final</netty.version>
 		<openapi-generator-maven-plugin.version>7.10.0</openapi-generator-maven-plugin.version>
 		<opencsv.version>5.10</opencsv.version>
@@ -283,6 +284,11 @@
 				<groupId>org.jooq</groupId>
 				<artifactId>jooq</artifactId>
 				<version>${jooq.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.neo4j</groupId>
+				<artifactId>cypher-v5-antlr-parser</artifactId>
+				<version>${cypher-v5-antlr-parser.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>


### PR DESCRIPTION
This adds a new translator implementation, that by default is always running before the default implementation. It will check if a query looks like something that Spark did.

If this is the case, the idea is to check whether the inner query is a already a cypher query. If that’s the case, no further translation will be attempted.