### PR TITLE
fix(test): Disable reflection based test in native image.

### DIFF
--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/AbstractDatabaseMetadata.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/AbstractDatabaseMetadata.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -1379,6 +1380,7 @@ abstract class AbstractDatabaseMetadata extends IntegrationTestBase {
 	abstract boolean apocShouldBeAvailable();
 
 	@Test
+	@DisabledInNativeImage
 	void apocDetectionShouldWork() throws SQLException {
 
 		var databaseMetadata = this.connection.getMetaData();


### PR DESCRIPTION
APOC detection itself does not require reflection, only the test.
The test however did run already twice by that time and will not be impacted by native image, so it's safe to skip it here instead of adding meta data for GraalVM.
