### PR TITLE
refactor(metadata): Improve transaction handling in metadata.

### DIFF
--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -222,7 +222,11 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 
 	private static final String URL_REGEX = "^jdbc:neo4j(?:\\+(?<transport>s(?:sc)?)?)?://(?<host>[^:/?]+):?(?<port>\\d+)?/?(?<database>[^?]+)?\\??(?<urlParams>\\S+)?$";
 
-	private static final Pattern URL_PATTERN = Pattern.compile(URL_REGEX);
+	/**
+	 * The URL pattern that this driver supports.
+	 * @since 6.2.0
+	 */
+	public static final Pattern URL_PATTERN = Pattern.compile(URL_REGEX);
 
 	private static final BoltProtocolVersion MIN_BOLT_VERSION = new BoltProtocolVersion(5, 1);
 

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/DatabaseMetadataImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/DatabaseMetadataImplTests.java
@@ -276,8 +276,14 @@ class DatabaseMetadataImplTests {
 	}
 
 	static DatabaseMetadataImpl newDatabaseMetadata() {
-		var connection = Mockito.mock(Connection.class);
-		return new DatabaseMetadataImpl(connection, (s) -> mock(Neo4jTransaction.class), false, 1000);
+		var connection = Mockito.mock(ConnectionImpl.class);
+		try {
+			given(connection.getTransaction(any())).willReturn(mock(Neo4jTransaction.class));
+		}
+		catch (SQLException ex) {
+			throw new RuntimeException(ex);
+		}
+		return new DatabaseMetadataImpl(connection, false, 1000);
 	}
 
 }

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/DatabaseMetadataKeyValidatingTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/DatabaseMetadataKeyValidatingTests.java
@@ -18,22 +18,28 @@
  */
 package org.neo4j.jdbc;
 
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.concurrent.ExecutionException;
 
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 class DatabaseMetadataKeyValidatingTests {
 
 	static DatabaseMetadataImpl newDatabaseMetadata() throws SQLException {
-		var connection = mock(Connection.class);
+		var connection = mock(ConnectionImpl.class);
 		given(connection.getCatalog()).willReturn("someCatalog");
-		return new DatabaseMetadataImpl(connection, (s) -> mock(Neo4jTransaction.class), false, 1000);
+		try {
+			given(connection.getTransaction(any())).willReturn(mock(Neo4jTransaction.class));
+		}
+		catch (SQLException ex) {
+			throw new RuntimeException(ex);
+		}
+		return new DatabaseMetadataImpl(connection, false, 1000);
 	}
 
 	@Test


### PR DESCRIPTION
Decoupling the connection and the transaction in the metadata just to circumvent the auto commit check is brittle and errorprone, as tests with Flyway have shown.

We must however still be able to rollback by default, as commands like `SHOW USER` cannot run in the same transactions like normal queries due to restrictions in Neo4j.

So it is best to use the actual existing JDBC auto commit machinery for the purpose.