### PR TITLE
Update license-maven-plugin to include full path to license.tpl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
 					<configuration>
 						<licenseSets>
 							<licenseSet>
-								<header>etc/license.tpl</header>
+								<header>${maven.multiModuleProjectDirectory}/etc/license.tpl</header>
 								<properties>
 									<year>2025</year>
 								</properties>


### PR DESCRIPTION
This fixes a build failure when running Maven build from a different directory with an explicit path to project POM.

Example:
```
/# mvn -f /neo4j-jdbc/pom.xml clean verify
```