### PR TITLE
Update exec-maven-plugin configuration to include full path

### DIFF
--- a/bundles/neo4j-jdbc-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-bundle/pom.xml
@@ -81,7 +81,7 @@
 						</goals>
 						<phase>generate-sources</phase>
 						<configuration>
-							<executable>bin/remove-shaded-dependencies-from-module-info.sh</executable>
+							<executable>${maven.multiModuleProjectDirectory}/bin/remove-shaded-dependencies-from-module-info.sh</executable>
 							<arguments>
 								<argument>${project.basedir}/../../neo4j-jdbc/src/main/java/module-info.java</argument>
 								<argument>${project.build.directory}/jpms/module-info.java</argument>

--- a/bundles/neo4j-jdbc-full-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-full-bundle/pom.xml
@@ -100,7 +100,7 @@
 						</goals>
 						<phase>generate-sources</phase>
 						<configuration>
-							<executable>bin/remove-shaded-dependencies-from-module-info.sh</executable>
+							<executable>${maven.multiModuleProjectDirectory}/bin/remove-shaded-dependencies-from-module-info.sh</executable>
 							<arguments>
 								<argument>${project.basedir}/../../neo4j-jdbc/src/main/java/module-info.java</argument>
 								<argument>${project.build.directory}/jpms/module-info.java</argument>


### PR DESCRIPTION
This fixes a build failure when running Maven build from a different directory with an explicit path to project POM.

Example:
```
/# mvn -f /neo4j-jdbc/pom.xml clean verify
```

Otherwise, it fails as it can't find the script.