### PR TITLE
test: Use `Neo4jContainer.getHost()` in ITs instead of `localhost`

### DIFF
--- a/neo4j-jdbc-it/hibernate-smoke-tests/src/test/java/org/neo4j/jdbc/it/hibernate/HibernateIT.java
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/src/test/java/org/neo4j/jdbc/it/hibernate/HibernateIT.java
@@ -51,7 +51,8 @@ class HibernateIT {
 		this.sessionFactory = new Configuration().addAnnotatedClass(Movie.class)
 			.setProperty(AvailableSettings.JAKARTA_JDBC_DRIVER, Neo4jDriver.class)
 			.setProperty(AvailableSettings.JAKARTA_JDBC_URL,
-					"jdbc:neo4j://localhost:" + this.neo4j.getMappedPort(7687) + "?enableSQLTranslation=true")
+					"jdbc:neo4j://" + this.neo4j.getHost() + ":" + this.neo4j.getMappedPort(7687)
+							+ "?enableSQLTranslation=true")
 			.setProperty(AvailableSettings.JAKARTA_JDBC_USER, "neo4j")
 			.setProperty(AvailableSettings.JAKARTA_JDBC_PASSWORD, this.neo4j.getAdminPassword())
 			.setProperty(AvailableSettings.SHOW_SQL, true)

--- a/neo4j-jdbc-it/quarkus-smoke-tests/src/test/java/org/neo4j/jdbc/it/quarkus/Neo4jTestResource.java
+++ b/neo4j-jdbc-it/quarkus-smoke-tests/src/test/java/org/neo4j/jdbc/it/quarkus/Neo4jTestResource.java
@@ -84,7 +84,8 @@ public final class Neo4jTestResource implements QuarkusTestResourceLifecycleMana
 		}
 
 		return Map.of("quarkus.datasource.jdbc.url",
-				"jdbc:neo4j://%s:%d?enableSQLTranslation=true".formatted("localhost", this.neo4j.getMappedPort(7687)),
+				"jdbc:neo4j://%s:%d?enableSQLTranslation=true".formatted(this.neo4j.getHost(),
+						this.neo4j.getMappedPort(7687)),
 				"quarkus.datasource.username", "neo4j", "quarkus.datasource.password", this.neo4j.getAdminPassword());
 	}
 


### PR DESCRIPTION
Using `Neo4jContainer.getHost()` instead of `localhost` is useful in cases when the Neo4j container is not available on `localhost`. For instance, when running integration tests in Docker container that start Neo4j instance in a separate one.