### PR TITLE
feat: Add events and metrics to the driver.

### DIFF
--- a/benchkit/pom.xml
+++ b/benchkit/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-benchkit</artifactId>
 

--- a/bundles/neo4j-jdbc-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/bundles/neo4j-jdbc-full-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-full-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/bundles/neo4j-jdbc-text2cypher-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-text2cypher-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-dist</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-docs</artifactId>

--- a/docs/src/main/asciidoc/modules/ROOT/pages/configuration.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/pages/configuration.adoc
@@ -325,3 +325,18 @@ quarkus.log.category."org.neo4j.jdbc.network.InboundMessageHandler".level=DEBUG
 === SQL Translations
 
 The SQL translators use the logger `org.neo4j.jdbc.translator`.
+
+== Metrics
+
+The Neo4j JDBC Driver will publish metrics via https://micrometer.io[Micrometer].
+If you put Micrometer on your classpath, no further configuration is necessary.
+This is for example automatically the case with https://docs.spring.io/spring-boot/reference/actuator/metrics.html[Spring Boot Actuator] or https://quarkus.io/guides/telemetry-micrometer[Micrometer for Quarkus].
+To make best use of this feature, you will additionally configure your https://docs.micrometer.io/micrometer/reference/implementations.html[monitoring system].
+
+The Neo4j JDBC Driver does publish the following metrics:
+
+`org.neo4j.jdbc.connections`:: a gauge representing the number of open connections, tagged with `url` to which the driver is connected
+`org.neo4j.jdbc.statements`:: a gauge representing the number of open connections, tagged with both  the `url` to which the statement is opened and the JDBC type of the statement (either `Statement`, `PreparedStatement` or `CallableStatement`
+)
+`org.neo4j.jdbc.queries`:: a composite meter containing the counts of successful and failed queries and a timer measuring the duration of queries
+`org.neo4j.jdbc.cached-translations`:: a gauge representing the number of cached SQL to cypher translations

--- a/docs/src/main/asciidoc/modules/ROOT/pages/configuration.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/pages/configuration.adoc
@@ -336,7 +336,7 @@ To make best use of this feature, you will additionally configure your https://d
 The Neo4j JDBC Driver does publish the following metrics:
 
 `org.neo4j.jdbc.connections`:: a gauge representing the number of open connections, tagged with `url` to which the driver is connected
-`org.neo4j.jdbc.statements`:: a gauge representing the number of open connections, tagged with both  the `url` to which the statement is opened and the JDBC type of the statement (either `Statement`, `PreparedStatement` or `CallableStatement`
+`org.neo4j.jdbc.statements`:: a gauge representing the number of open statements, tagged with both  the `url` to which the statement is opened and the JDBC type of the statement (either `Statement`, `PreparedStatement` or `CallableStatement`
 )
 `org.neo4j.jdbc.queries`:: a composite meter containing the counts of successful and failed queries and a timer measuring the duration of queries
 `org.neo4j.jdbc.cached-translations`:: a gauge representing the number of cached SQL to cypher translations

--- a/neo4j-jdbc-bom/pom.xml
+++ b/neo4j-jdbc-bom/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-bom</artifactId>

--- a/neo4j-jdbc-it/hibernate-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-hibernate-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/mybatis-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/mybatis-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-mybatis-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-cp</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/ConnectionIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/ConnectionIT.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class ConnectionIT extends IntegrationTestBase {
+class ConnectionIT extends IntegrationTestBase {
 
 	@Test
 	void shouldCheckTXStateBeforeCommit() throws SQLException {

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/IntegrationTestBase.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/IntegrationTestBase.java
@@ -75,7 +75,7 @@ abstract class IntegrationTestBase {
 
 	@BeforeEach
 	void clearDatabase() throws SQLException {
-		try (var stmt = this.getConnection().createStatement()) {
+		try (var connection = this.getConnection(); var stmt = connection.createStatement()) {
 			stmt.execute("""
 					MATCH (n)
 					CALL {

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/TranslationIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/TranslationIT.java
@@ -45,6 +45,7 @@ class TranslationIT extends IntegrationTestBase {
 		properties.put("password", this.neo4j.getAdminPassword());
 		properties.put("translatorFactory", "default");
 		properties.put("enableSQLTranslation", "true");
+		properties.put("cacheSQLTranslations", "true");
 
 		try (var con = driver.connect(url, properties);
 				var stmt = con.createStatement();

--- a/neo4j-jdbc-it/neo4j-jdbc-it-mp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-mp/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-mp</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-stub/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-stub/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-stub</artifactId>
 

--- a/neo4j-jdbc-it/pom.xml
+++ b/neo4j-jdbc-it/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it</artifactId>
 

--- a/neo4j-jdbc-it/quarkus-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/quarkus-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-quarkus-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/spring-boot-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/spring-boot-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-spring-boot-smoke-tests</artifactId>
 
@@ -48,6 +48,10 @@
 		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-jdbc-full-bundle</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/neo4j-jdbc-it/spring-boot-smoke-tests/src/main/java/org/neo4j/jdbc/it/sb/MovieRepository.java
+++ b/neo4j-jdbc-it/spring-boot-smoke-tests/src/main/java/org/neo4j/jdbc/it/sb/MovieRepository.java
@@ -39,7 +39,7 @@ public class MovieRepository {
 
 	@Transactional(readOnly = true)
 	public List<Movie> findAll() {
-		return this.jdbcTemplate.query("SELECT * FROM Movie m", (rs, rowNum) -> new Movie(rs.getString("title")));
+		return this.jdbcTemplate.query("SELECT title FROM Movie m", (rs, rowNum) -> new Movie(rs.getString("title")));
 	}
 
 	public int createOrUpdate(Movie movie) {

--- a/neo4j-jdbc-it/spring-boot-smoke-tests/src/main/resources/application.properties
+++ b/neo4j-jdbc-it/spring-boot-smoke-tests/src/main/resources/application.properties
@@ -27,3 +27,6 @@ logging.level.org.neo4j.jdbc.result-set=warn
 logging.level.org.neo4j.jdbc.network=warn
 logging.level.org.neo4j.jdbc.network.OutboundMessageHandler=debug
 logging.level.org.neo4j.jdbc.network.InboundMessageHandler=debug
+
+spring.datasource.hikari.maximum-pool-size=6
+management.endpoints.web.exposure.include=health,metrics

--- a/neo4j-jdbc-it/spring-boot-smoke-tests/src/test/java/org/neo4j/jdbc/it/sb/Neo4jTestConfig.java
+++ b/neo4j-jdbc-it/spring-boot-smoke-tests/src/test/java/org/neo4j/jdbc/it/sb/Neo4jTestConfig.java
@@ -72,8 +72,8 @@ class Neo4jTestConfig {
 
 		@Override
 		public String getJdbcUrl() {
-			return "jdbc:neo4j://%s:%d?enableSQLTranslation=true&s2c.precedence=20".formatted(this.getHost(),
-					this.getMappedPort(7687));
+			return "jdbc:neo4j://%s:%d?enableSQLTranslation=true&s2c.precedence=20&cacheSQLTranslations=true"
+				.formatted(this.getHost(), this.getMappedPort(7687));
 		}
 
 		@Override

--- a/neo4j-jdbc-test-results/pom.xml
+++ b/neo4j-jdbc-test-results/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-test-results</artifactId>

--- a/neo4j-jdbc-translator/impl/pom.xml
+++ b/neo4j-jdbc-translator/impl/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-impl</artifactId>

--- a/neo4j-jdbc-translator/pom.xml
+++ b/neo4j-jdbc-translator/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-translator</artifactId>
 

--- a/neo4j-jdbc-translator/sparkcleaner/pom.xml
+++ b/neo4j-jdbc-translator/sparkcleaner/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-sparkcleaner</artifactId>

--- a/neo4j-jdbc-translator/spi/pom.xml
+++ b/neo4j-jdbc-translator/spi/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-spi</artifactId>

--- a/neo4j-jdbc-translator/spi/src/main/java/org/neo4j/jdbc/translator/spi/Cache.java
+++ b/neo4j-jdbc-translator/spi/src/main/java/org/neo4j/jdbc/translator/spi/Cache.java
@@ -77,4 +77,13 @@ public interface Cache<K, V> {
 	 */
 	void flush();
 
+	/**
+	 * This is an unsupported operation by default, override this to indicate the size of
+	 * the cache.
+	 * @return the current size of the cache
+	 */
+	default int size() {
+		throw new UnsupportedOperationException();
+	}
+
 }

--- a/neo4j-jdbc-translator/text2cypher/pom.xml
+++ b/neo4j-jdbc-translator/text2cypher/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-text2cypher-translator</artifactId>

--- a/neo4j-jdbc/pom.xml
+++ b/neo4j-jdbc/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.2.2-SNAPSHOT</version>
+		<version>6.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc</artifactId>
@@ -54,6 +54,11 @@
 		<dependency>
 			<groupId>io.github.cdimascio</groupId>
 			<artifactId>dotenv-java</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-core</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.neo4j</groupId>

--- a/neo4j-jdbc/src/main/java/module-info.java
+++ b/neo4j-jdbc/src/main/java/module-info.java
@@ -22,6 +22,7 @@
 @SuppressWarnings({"requires-automatic"}) // Netty is an automatic module :(
 module org.neo4j.jdbc {
 	requires transitive java.sql;
+	requires static micrometer.core;
 
 	// start::shaded-dependencies
 	requires io.github.cdimascio.dotenv.java;
@@ -40,6 +41,7 @@ module org.neo4j.jdbc {
 	// requires jdk.unsupported;
 
 	exports org.neo4j.jdbc;
+	exports org.neo4j.jdbc.events;
 	exports org.neo4j.jdbc.values;
 
 	provides java.sql.Driver with org.neo4j.jdbc.Neo4jDriver;

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ConnectionImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ConnectionImpl.java
@@ -51,7 +51,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -155,7 +154,7 @@ final class ConnectionImpl implements Neo4jConnection {
 	 */
 	private final Consumer<Boolean> onClose;
 
-	private final Set<ConnectionListener> listeners = new CopyOnWriteArraySet<>();
+	private final Set<ConnectionListener> listeners = new HashSet<>();
 
 	ConnectionImpl(URI databaseUrl, Supplier<BoltConnection> boltConnectionSupplier,
 			Supplier<List<Translator>> translators, boolean enableSQLTranslation, boolean enableTranslationCaching,

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
@@ -338,7 +338,7 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 
 	@Override
 	public String getURL() throws SQLException {
-		return this.connection.unwrap(ConnectionImpl.class).getDatabaseURL().toString();
+		return this.connection.unwrap(Neo4jConnection.class).getDatabaseURL().toString();
 	}
 
 	@Override

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Events.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Events.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Some internal utilities around events.
+ *
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+final class Events {
+
+	private static final Logger LOGGER = Logger.getLogger("org.neo4j.jdbc.events");
+
+	static <T> void notify(Collection<T> listeners, Consumer<T> consumer) {
+		listeners.forEach(listener -> {
+			try {
+				consumer.accept(listener);
+			}
+			catch (Exception ex) {
+				LOGGER.log(Level.WARNING, ex,
+						() -> "Could not notify listener %s".formatted(listener.getClass().getCanonicalName()));
+			}
+		});
+	}
+
+	private Events() {
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/MetricsCollector.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/MetricsCollector.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.jdbc;
 
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -37,27 +38,21 @@ interface MetricsCollector extends DriverListener, ConnectionListener, Statement
 
 	/**
 	 * Tries to create a metrics collector based on the global Micrometer registry.
-	 * @return a metrics collector based on the global Micrometer instance or a noop
-	 * version.
+	 * @return a metrics collector based on the global Micrometer instance if available
 	 */
 	@SuppressWarnings("CastCanBeRemovedNarrowingVariableType")
-	static MetricsCollector tryGlobal() {
+	static Optional<MetricsCollector> tryGlobal() {
 		Object globalRegistry;
 		try {
 			globalRegistry = Metrics.globalRegistry;
 		}
 		catch (Throwable ex) {
 			Logger.getLogger("org.neo4j.jdbc").log(Level.INFO, "Metrics are not available");
-			return MetricsCollector.noop();
+			return Optional.empty();
 		}
 		// Avoid touching the class that actually is dependent on MeterRegistry as long as
 		// we didn't make sure it's there.
-		return MetricsCollectorImpl.of((MeterRegistry) globalRegistry);
-	}
-
-	static MetricsCollector noop() {
-		return new MetricsCollector() {
-		};
+		return Optional.of(MetricsCollectorImpl.of((MeterRegistry) globalRegistry));
 	}
 
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/MetricsCollector.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/MetricsCollector.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import org.neo4j.jdbc.events.ConnectionListener;
+import org.neo4j.jdbc.events.DriverListener;
+import org.neo4j.jdbc.events.StatementListener;
+
+/**
+ * Basic interface for a metrics collector.
+ *
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+interface MetricsCollector extends DriverListener, ConnectionListener, StatementListener {
+
+	/**
+	 * Tries to create a metrics collector based on the global Micrometer registry.
+	 * @return a metrics collector based on the global Micrometer instance or a noop
+	 * version.
+	 */
+	@SuppressWarnings("CastCanBeRemovedNarrowingVariableType")
+	static MetricsCollector tryGlobal() {
+		Object globalRegistry;
+		try {
+			globalRegistry = Metrics.globalRegistry;
+		}
+		catch (Throwable ex) {
+			Logger.getLogger("org.neo4j.jdbc").log(Level.INFO, "Metrics are not available");
+			return MetricsCollector.noop();
+		}
+		// Avoid touching the class that actually is dependent on MeterRegistry as long as
+		// we didn't make sure it's there.
+		return MetricsCollectorImpl.of((MeterRegistry) globalRegistry);
+	}
+
+	static MetricsCollector noop() {
+		return new MetricsCollector() {
+		};
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/MetricsCollectorImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/MetricsCollectorImpl.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.neo4j.jdbc.events.ConnectionClosedEvent;
+import org.neo4j.jdbc.events.ConnectionOpenedEvent;
+import org.neo4j.jdbc.events.ExecutionEndedEvent;
+import org.neo4j.jdbc.events.StatementClosedEvent;
+import org.neo4j.jdbc.events.StatementCreatedEvent;
+import org.neo4j.jdbc.events.TranslationCachedEvent;
+
+/**
+ * Collects various metrics per driver instance.
+ *
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+final class MetricsCollectorImpl implements MetricsCollector {
+
+	/**
+	 * The reason for this cache is that the global registry (and possibly others) are
+	 * indeed global. While you can get back the timers and counters from those, you don't
+	 * get the backing objects of gauges back. While one could theoretically find the
+	 * gauge, get the value and then recreate the gauge, this solution here is at that
+	 * point a lot more straight forward: Caching the collector per registry.
+	 */
+	private static final Map<MeterRegistry, MetricsCollector> INSTANCES = new ConcurrentHashMap<>();
+
+	static MetricsCollector of(MeterRegistry meterRegistry) {
+		return INSTANCES.computeIfAbsent(meterRegistry, MetricsCollectorImpl::new);
+	}
+
+	private final MeterRegistry meterRegistry;
+
+	private final Map<URI, AtomicInteger> openConnections = new ConcurrentHashMap<>();
+
+	private final Map<StatementKey, AtomicInteger> openStatements = new ConcurrentHashMap<>();
+
+	private final AtomicInteger cachedTranslations = new AtomicInteger();
+
+	private final Map<URI, QueryMetrics> queryMetrics = new ConcurrentHashMap<>();
+
+	private MetricsCollectorImpl(MeterRegistry meterRegistry) {
+
+		this.meterRegistry = meterRegistry;
+
+		var cachedTranslations = "org.neo4j.jdbc.cached-translations";
+		if (meterRegistry.find(cachedTranslations).gauge() == null) {
+			Gauge.builder(cachedTranslations, this.cachedTranslations::get).register(meterRegistry);
+		}
+	}
+
+	/**
+	 * Strips parameters away from the URL.
+	 * @param jdbcUrl the URL to clean
+	 * @return a parameter free URL
+	 */
+	static URI cleanURL(URI jdbcUrl) {
+		var hlp = URI.create(jdbcUrl.getSchemeSpecificPart());
+		try {
+			var port = hlp.getPort();
+			return new URI("jdbc",
+					"%s://%s:%d%s".formatted(hlp.getScheme(), hlp.getHost(), (port != -1) ? port : 7687, hlp.getPath()),
+					jdbcUrl.getFragment());
+		}
+		catch (URISyntaxException ex) {
+			throw new RuntimeException(ex);
+		}
+	}
+
+	@Override
+	public void connectionOpened(ConnectionOpenedEvent event) {
+		var counter = this.openConnections.computeIfAbsent(cleanURL(event.uri()), url -> {
+			var newCounter = new AtomicInteger();
+			Gauge.builder("org.neo4j.jdbc.connections", newCounter::get)
+				.description("The number of currently open connections")
+				.tags("url", url.toString())
+				.register(this.meterRegistry);
+			return newCounter;
+		});
+		counter.incrementAndGet();
+	}
+
+	@Override
+	public void connectionClosed(ConnectionClosedEvent event) {
+		var counter = this.openConnections.get(cleanURL(event.uri()));
+		if (counter != null) {
+			counter.decrementAndGet();
+		}
+	}
+
+	@Override
+	public void statementCreated(StatementCreatedEvent event) {
+		var counter = this.openStatements
+			.computeIfAbsent(new StatementKey(cleanURL(event.uri()), event.statementType()), key -> {
+				var newCounter = new AtomicInteger();
+				Gauge.builder("org.neo4j.jdbc.statements", newCounter::get)
+					.description("The number of currently open statements")
+					.tags("url", key.uri().toString(), "type", key.type().getSimpleName())
+					.register(this.meterRegistry);
+				return newCounter;
+			});
+		counter.incrementAndGet();
+	}
+
+	@Override
+	public void statementClosed(StatementClosedEvent event) {
+		var counter = this.openStatements.get(new StatementKey(cleanURL(event.uri()), event.statementType()));
+		if (counter != null) {
+			counter.decrementAndGet();
+		}
+	}
+
+	@Override
+	public void translationCached(TranslationCachedEvent event) {
+		this.cachedTranslations.set(event.cacheSize());
+	}
+
+	@Override
+	public void executionEnded(ExecutionEndedEvent event) {
+		var queryMetrics = this.queryMetrics.computeIfAbsent(cleanURL(event.uri()), url -> {
+			var queries = "org.neo4j.jdbc.queries";
+			var urlString = url.toString();
+			return new QueryMetrics(
+					Counter.builder(queries)
+						.description("The total number of successful queries run")
+						.tags("url", urlString, "state", "successful")
+						.register(this.meterRegistry),
+					Counter.builder(queries)
+						.description("The total number of queries that failed to run")
+						.tags("url", urlString, "state", "failed")
+						.register(this.meterRegistry),
+					Timer.builder(queries)
+						.description("Duration of the queries being run")
+						.tags("url", urlString)
+						.register(this.meterRegistry));
+		});
+		if (event.state() == ExecutionEndedEvent.State.SUCCESSFUL) {
+			queryMetrics.successfulQueries.increment();
+		}
+		else if (event.state() == ExecutionEndedEvent.State.FAILED) {
+			queryMetrics.failedQueries.increment();
+		}
+		queryMetrics.queryTimer.record(event.elapsedTime());
+	}
+
+	record QueryMetrics(Counter successfulQueries, Counter failedQueries, Timer queryTimer) {
+	}
+
+	public record StatementKey(URI uri, Class<? extends Statement> type) {
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jConnection.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jConnection.java
@@ -18,9 +18,12 @@
  */
 package org.neo4j.jdbc;
 
+import java.net.URI;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.concurrent.Executor;
+
+import org.neo4j.jdbc.events.ConnectionListener;
 
 /**
  * A Neo4j specific extension of {@link Connection}. It may be referred to for use with
@@ -86,5 +89,20 @@ public sealed interface Neo4jConnection extends Connection, Neo4jMetadataWriter 
 	 * @return the name of the database for this connection
 	 */
 	String getDatabaseName();
+
+	/**
+	 * Adds a listener to this connection that gets notified when statements are created
+	 * and closed.
+	 * @param connectionListener the listener to add, must not be {@literal null}
+	 * @since 6.3.0
+	 */
+	void addListener(ConnectionListener connectionListener);
+
+	/**
+	 * The database URL this connection is connected to.
+	 * @return the database URL this connection is connected to
+	 * @since 6.3.0
+	 */
+	URI getDatabaseURL();
 
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -69,6 +70,9 @@ import org.neo4j.bolt.connection.RoutingContext;
 import org.neo4j.bolt.connection.SecurityPlan;
 import org.neo4j.bolt.connection.SecurityPlans;
 import org.neo4j.bolt.connection.netty.NettyBoltConnectionProvider;
+import org.neo4j.jdbc.events.ConnectionClosedEvent;
+import org.neo4j.jdbc.events.ConnectionOpenedEvent;
+import org.neo4j.jdbc.events.DriverListener;
 import org.neo4j.jdbc.internal.bolt.BoltAdapters;
 import org.neo4j.jdbc.translator.spi.Translator;
 import org.neo4j.jdbc.translator.spi.TranslatorFactory;
@@ -246,14 +250,6 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 		}
 	}
 
-	private final BoltConnectionProvider boltConnectionProvider;
-
-	private volatile List<TranslatorFactory> sqlTranslatorFactories;
-
-	private final Map<DriverConfig, BookmarkManager> bookmarkManagers = new ConcurrentHashMap<>();
-
-	private final Map<String, Object> transactionMetadata = new ConcurrentHashMap<>();
-
 	/**
 	 * Lets you configure the driver from the environment, but always enable SQL to Cypher
 	 * translation.
@@ -323,6 +319,18 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 		return new BuilderImpl(false, Map.of()).fromEnv(directory, filename);
 	}
 
+	private final BoltConnectionProvider boltConnectionProvider;
+
+	private volatile List<TranslatorFactory> sqlTranslatorFactories;
+
+	private final Map<DriverConfig, BookmarkManager> bookmarkManagers = new ConcurrentHashMap<>();
+
+	private final Map<String, Object> transactionMetadata = new ConcurrentHashMap<>();
+
+	private final Set<DriverListener> listeners = new CopyOnWriteArraySet<>();
+
+	private final MetricsCollector metricsCollector;
+
 	/**
 	 * Creates a new instance of the {@link Neo4jDriver}. The instance is usable and is
 	 * able to provide connections. The public constructor is provided mainly for tooling
@@ -330,13 +338,16 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 	 * machinery for JDBC.
 	 */
 	public Neo4jDriver() {
-		this(new NettyBoltConnectionProvider(DEFAULT_EVENT_LOOP_GROUP, Clock.systemUTC(),
-				DefaultDomainNameResolver.getInstance(), null, BoltAdapters.newLoggingProvider(),
-				BoltAdapters.getValueFactory(), null));
+		this(null);
 	}
 
 	Neo4jDriver(BoltConnectionProvider boltConnectionProvider) {
-		this.boltConnectionProvider = boltConnectionProvider;
+		this.boltConnectionProvider = Objects.requireNonNullElseGet(boltConnectionProvider,
+				() -> new NettyBoltConnectionProvider(DEFAULT_EVENT_LOOP_GROUP, Clock.systemUTC(),
+						DefaultDomainNameResolver.getInstance(), null, BoltAdapters.newLoggingProvider(),
+						BoltAdapters.getValueFactory(), null));
+		this.metricsCollector = MetricsCollector.tryGlobal();
+		this.addListener(this.metricsCollector);
 	}
 
 	@Override
@@ -375,12 +386,22 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 		if (translatorFactory != null && !translatorFactory.isBlank()) {
 			translatorFactoriesSupplier = () -> getSqlTranslatorFactory(translatorFactory);
 		}
-		return new ConnectionImpl(driverConfig.toUrl(),
+
+		var targetUrl = driverConfig.toUrl();
+		var connection = new ConnectionImpl(targetUrl,
 				() -> establishBoltConnection(address, userAgent, connectTimeoutMillis, securityPlan, databaseName,
 						authToken),
 				getSqlTranslatorSupplier(enableSqlTranslation, driverConfig.rawConfig(), translatorFactoriesSupplier),
 				enableSqlTranslation, enableTranslationCaching, rewriteBatchedStatements, rewritePlaceholders,
-				bookmarkManager, this.transactionMetadata, driverConfig.relationshipSampleSize(), databaseName);
+				bookmarkManager, this.transactionMetadata, driverConfig.relationshipSampleSize(), databaseName,
+				this.metricsCollector, (aborted) -> {
+					var event = new ConnectionClosedEvent(targetUrl, aborted);
+					Events.notify(this.listeners, driverListener -> driverListener.connectionClosed(event));
+				});
+		connection.addListener(this.metricsCollector);
+		Events.notify(this.listeners,
+				driverListener -> driverListener.connectionOpened(new ConnectionOpenedEvent(targetUrl)));
+		return connection;
 	}
 
 	private BoltConnection establishBoltConnection(BoltServerAddress address, String userAgent,
@@ -757,6 +778,11 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 	}
 
 	@Override
+	public void addListener(DriverListener driverListener) {
+		this.listeners.add(Objects.requireNonNull(driverListener));
+	}
+
+	@Override
 	public Neo4jDriver withMetadata(Map<String, Object> metadata) {
 		if (metadata != null) {
 			this.transactionMetadata.putAll(metadata);
@@ -963,21 +989,11 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 			var sslProperties = this.sslProperties();
 			var result = new StringBuilder("jdbc:neo4j%s://%s:%s/%s?".formatted(sslProperties.protocolSuffix(),
 					this.host(), this.port(), this.database()));
-			append(result, PROPERTY_AUTH_SCHEME, this.authScheme()).append("&");
-			append(result, PROPERTY_USER, this.user()).append("&");
-			append(result, PROPERTY_AUTH_REALM, this.authRealm()).append("&");
-			append(result, PROPERTY_USER_AGENT, this.agent()).append("&");
-			append(result, PROPERTY_TIMEOUT, this.timeout()).append("&");
 			append(result, PROPERTY_SQL_TRANSLATION_ENABLED, this.enableSQLTranslation()).append("&");
 			append(result, PROPERTY_SQL_TRANSLATION_CACHING_ENABLED, this.enableTranslationCaching()).append("&");
 			append(result, PROPERTY_REWRITE_BATCHED_STATEMENTS, this.rewriteBatchedStatements()).append("&");
 			append(result, PROPERTY_REWRITE_PLACEHOLDERS, this.rewriteBatchedStatements()).append("&");
 			append(result, PROPERTY_USE_BOOKMARKS, this.useBookmarks()).append("&");
-			this.misc()
-				.entrySet()
-				.stream()
-				.sorted(Map.Entry.comparingByKey())
-				.forEach(e -> append(result, e.getKey(), e.getValue()).append("&"));
 			return URI.create(result.substring(0, result.length() - 1));
 		}
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -47,7 +48,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -328,7 +328,7 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 
 	private final Map<String, Object> transactionMetadata = new ConcurrentHashMap<>();
 
-	private final Set<DriverListener> listeners = new CopyOnWriteArraySet<>();
+	private final Set<DriverListener> listeners = new HashSet<>();
 
 	/**
 	 * Creates a new instance of the {@link Neo4jDriver}. The instance is usable and is

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriverExtensions.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriverExtensions.java
@@ -23,6 +23,8 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Properties;
 
+import org.neo4j.jdbc.events.DriverListener;
+
 /**
  * Neo4j specific extensions to a {@link Driver}.
  *
@@ -86,5 +88,13 @@ public sealed interface Neo4jDriverExtensions extends Driver, Neo4jMetadataWrite
 	 * @throws SQLException in all error cases
 	 */
 	void addBookmarks(String url, Properties info, Collection<Bookmark> bookmarks) throws SQLException;
+
+	/**
+	 * Adds a listener to this driver instance that gets notified when connections are
+	 * opened and closed.
+	 * @param driverListener the listener to add, must not be {@literal null}
+	 * @since 6.3.0
+	 */
+	void addListener(DriverListener driverListener);
 
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
@@ -20,6 +20,8 @@ package org.neo4j.jdbc;
 
 import java.sql.Statement;
 
+import org.neo4j.jdbc.events.StatementListener;
+
 /**
  * A Neo4j specific extension of a {@link java.sql.Statement}. It may be referred to for
  * use with {@link #unwrap(Class)} to access specific Neo4j functionality.
@@ -33,5 +35,13 @@ public sealed interface Neo4jStatement extends Statement, Neo4jMetadataWriter pe
 	 * The default (Bolt) fetch size that is used.
 	 */
 	int DEFAULT_FETCH_SIZE = 1000;
+
+	/**
+	 * Adds a listener to this statement that gets notified on starts and finish of
+	 * executions.
+	 * @param statementListener the listener to add, must not be {@literal null}
+	 * @since 6.3.0
+	 */
+	void addListener(StatementListener statementListener);
 
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/PreparedStatementImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/PreparedStatementImpl.java
@@ -39,6 +39,7 @@ import java.sql.RowId;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLXML;
+import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.ArrayDeque;
@@ -52,6 +53,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -92,8 +94,9 @@ sealed class PreparedStatementImpl extends StatementImpl implements Neo4jPrepare
 	}
 
 	PreparedStatementImpl(Connection connection, Neo4jTransactionSupplier transactionSupplier,
-			UnaryOperator<String> translator, Warnings localWarnings, boolean rewriteBatchedStatements, String sql) {
-		super(connection, transactionSupplier, translator, localWarnings);
+			UnaryOperator<String> translator, Warnings localWarnings, Consumer<Class<? extends Statement>> onClose,
+			boolean rewriteBatchedStatements, String sql) {
+		super(connection, transactionSupplier, translator, localWarnings, onClose);
 		this.rewriteBatchedStatements = rewriteBatchedStatements;
 		this.sql = sql;
 		this.poolable = true;

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/StatementImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/StatementImpl.java
@@ -35,13 +35,13 @@ import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -111,7 +111,7 @@ non-sealed class StatementImpl implements Neo4jStatement {
 
 	private final Consumer<Class<? extends Statement>> onClose;
 
-	private final Set<StatementListener> listeners = new CopyOnWriteArraySet<>();
+	private final Set<StatementListener> listeners = new HashSet<>();
 
 	StatementImpl(Connection connection, Neo4jTransactionSupplier transactionSupplier,
 			UnaryOperator<String> sqlProcessor, Warnings localWarnings, Consumer<Class<? extends Statement>> onClose) {

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/StatementImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/StatementImpl.java
@@ -313,6 +313,11 @@ non-sealed class StatementImpl implements Neo4jStatement {
 
 	private <T> T recordEvent(String statement, ExecutionMode executionType, SqlCallable<T> callable)
 			throws SQLException {
+
+		if (this.listeners.isEmpty()) {
+			return callable.call();
+		}
+
 		var id = statementId();
 		var s = System.nanoTime();
 		var databaseURL = this.connection.unwrap(Neo4jConnection.class).getDatabaseURL();

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/StatementImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/StatementImpl.java
@@ -25,17 +25,26 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.sql.CallableStatement;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.HexFormat;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -43,6 +52,10 @@ import java.util.regex.Pattern;
 
 import org.neo4j.cypherdsl.support.schema_name.SchemaNames;
 import org.neo4j.jdbc.Neo4jTransaction.ResultSummary;
+import org.neo4j.jdbc.events.ExecutionEndedEvent;
+import org.neo4j.jdbc.events.ExecutionMode;
+import org.neo4j.jdbc.events.ExecutionStartedEvent;
+import org.neo4j.jdbc.events.StatementListener;
 import org.neo4j.jdbc.values.Values;
 
 non-sealed class StatementImpl implements Neo4jStatement {
@@ -55,8 +68,14 @@ non-sealed class StatementImpl implements Neo4jStatement {
 
 	private static final Logger LOGGER = Logger.getLogger("org.neo4j.jdbc.statement");
 
+	private static final Map<String, AtomicLong> ID_GENERATORS = new ConcurrentHashMap<>();
+
 	static final int DEFAULT_BUFFER_SIZE_FOR_INCOMING_STREAMS = 4096;
 	static final Charset DEFAULT_ASCII_CHARSET_FOR_INCOMING_STREAM = StandardCharsets.ISO_8859_1;
+
+	private static final HexFormat HEX_FORMAT = HexFormat.of();
+
+	private static final Base64.Encoder ENCODER = Base64.getEncoder();
 
 	private final Connection connection;
 
@@ -90,12 +109,18 @@ non-sealed class StatementImpl implements Neo4jStatement {
 
 	private final Map<String, Object> transactionMetadata = new ConcurrentHashMap<>();
 
+	private final Consumer<Class<? extends Statement>> onClose;
+
+	private final Set<StatementListener> listeners = new CopyOnWriteArraySet<>();
+
 	StatementImpl(Connection connection, Neo4jTransactionSupplier transactionSupplier,
-			UnaryOperator<String> sqlProcessor, Warnings localWarnings) {
+			UnaryOperator<String> sqlProcessor, Warnings localWarnings, Consumer<Class<? extends Statement>> onClose) {
 		this.connection = Objects.requireNonNull(connection);
 		this.transactionSupplier = Objects.requireNonNull(transactionSupplier);
 		this.sqlProcessor = Objects.requireNonNullElseGet(sqlProcessor, UnaryOperator::identity);
 		this.warnings = Objects.requireNonNullElseGet(localWarnings, Warnings::new);
+		this.onClose = Objects.requireNonNullElse(onClose, (type) -> {
+		});
 	}
 
 	/**
@@ -106,6 +131,8 @@ non-sealed class StatementImpl implements Neo4jStatement {
 		this.transactionSupplier = null;
 		this.sqlProcessor = UnaryOperator.identity();
 		this.warnings = new Warnings();
+		this.onClose = (type) -> {
+		};
 	}
 
 	@Override
@@ -117,18 +144,19 @@ non-sealed class StatementImpl implements Neo4jStatement {
 			throws SQLException {
 		assertIsOpen();
 		closeResultSet();
-		this.updateCount = -1;
-		this.multipleResultsApi = false;
-		if (applyProcessor) {
-			sql = processSQL(sql);
-		}
-		var transaction = this.transactionSupplier.getTransaction(this.transactionMetadata);
-		var fetchSize = (this.maxRows > 0) ? Math.min(this.maxRows, this.fetchSize) : this.fetchSize;
-		var runAndPull = transaction.runAndPull(sql, getParameters(parameters), fetchSize, this.queryTimeout);
-		this.resultSet = new ResultSetImpl(this, transaction, runAndPull.runResponse(), runAndPull.pullResponse(),
-				this.fetchSize, this.maxRows, this.maxFieldSize);
-		this.resultSetAcquired.set(false);
-		return this.resultSet;
+		return recordEvent(sql, ExecutionMode.QUERY, () -> {
+			this.updateCount = -1;
+			this.multipleResultsApi = false;
+			var processedSQL = applyProcessor ? processSQL(sql) : sql;
+			var transaction = this.transactionSupplier.getTransaction(this.transactionMetadata);
+			var fetchSize = (this.maxRows > 0) ? Math.min(this.maxRows, this.fetchSize) : this.fetchSize;
+			var runAndPull = transaction.runAndPull(processedSQL, getParameters(parameters), fetchSize,
+					this.queryTimeout);
+			this.resultSet = new ResultSetImpl(this, transaction, runAndPull.runResponse(), runAndPull.pullResponse(),
+					this.fetchSize, this.maxRows, this.maxFieldSize);
+			this.resultSetAcquired.set(false);
+			return this.resultSet;
+		});
 	}
 
 	@Override
@@ -141,25 +169,26 @@ non-sealed class StatementImpl implements Neo4jStatement {
 			throws SQLException {
 		assertIsOpen();
 		closeResultSet();
-		this.updateCount = -1;
-		this.multipleResultsApi = false;
-		if (applyProcessor) {
-			sql = processSQL(sql);
-		}
-		var transaction = this.transactionSupplier.getTransaction(this.transactionMetadata);
-		return transaction.runAndDiscard(sql, getParameters(parameters), this.queryTimeout, transaction.isAutoCommit())
-			.resultSummary()
-			.map(ResultSummary::counters)
-			.map(c -> {
-				var rowCount = c.nodesCreated() + c.nodesDeleted() + c.relationshipsCreated()
-						+ c.relationshipsDeleted();
-				if (rowCount == 0 && c.containsUpdates()) {
-					var labelsAndProperties = c.labelsAdded() + c.labelsRemoved() + c.propertiesSet();
-					rowCount = (labelsAndProperties > 0) ? 1 : 0;
-				}
-				return rowCount;
-			})
-			.orElse(0);
+		return recordEvent(sql, ExecutionMode.UPDATE, () -> {
+			this.updateCount = -1;
+			this.multipleResultsApi = false;
+			var processedSQL = applyProcessor ? processSQL(sql) : sql;
+			var transaction = this.transactionSupplier.getTransaction(this.transactionMetadata);
+			return transaction
+				.runAndDiscard(processedSQL, getParameters(parameters), this.queryTimeout, transaction.isAutoCommit())
+				.resultSummary()
+				.map(ResultSummary::counters)
+				.map(c -> {
+					var rowCount = c.nodesCreated() + c.nodesDeleted() + c.relationshipsCreated()
+							+ c.relationshipsDeleted();
+					if (rowCount == 0 && c.containsUpdates()) {
+						var labelsAndProperties = c.labelsAdded() + c.labelsRemoved() + c.propertiesSet();
+						rowCount = (labelsAndProperties > 0) ? 1 : 0;
+					}
+					return rowCount;
+				})
+				.orElse(0);
+		});
 	}
 
 	@Override
@@ -170,6 +199,7 @@ non-sealed class StatementImpl implements Neo4jStatement {
 		}
 		closeResultSet();
 		this.closed = true;
+		this.onClose.accept(this.getType());
 	}
 
 	@Override
@@ -262,20 +292,52 @@ non-sealed class StatementImpl implements Neo4jStatement {
 	protected final boolean execute0(String sql, Map<String, Object> parameters) throws SQLException {
 		assertIsOpen();
 		closeResultSet();
-		this.updateCount = -1;
-		this.multipleResultsApi = true;
-		var processedSQL = processSQL(sql);
-		var transaction = this.transactionSupplier.getTransaction(this.transactionMetadata);
-		var fetchSize = (this.maxRows > 0) ? Math.min(this.maxRows, this.fetchSize) : this.fetchSize;
-		var runAndPull = transaction.runAndPull(processedSQL, getParameters(parameters), fetchSize, this.queryTimeout);
-		var pullResponse = runAndPull.pullResponse();
-		this.resultSet = new ResultSetImpl(this, transaction, runAndPull.runResponse(), pullResponse, this.fetchSize,
-				this.maxRows, this.maxFieldSize);
-		this.updateCount = pullResponse.resultSummary()
-			.map(summary -> summary.counters().totalCount())
-			.filter(count -> count > 0)
-			.orElse(-1);
-		return this.updateCount == -1;
+		return recordEvent(sql, ExecutionMode.PLAIN, () -> {
+			this.updateCount = -1;
+			this.multipleResultsApi = true;
+			var processedSQL = processSQL(sql);
+			var transaction = this.transactionSupplier.getTransaction(this.transactionMetadata);
+			var fetchSize = (this.maxRows > 0) ? Math.min(this.maxRows, this.fetchSize) : this.fetchSize;
+			var runAndPull = transaction.runAndPull(processedSQL, getParameters(parameters), fetchSize,
+					this.queryTimeout);
+			var pullResponse = runAndPull.pullResponse();
+			this.resultSet = new ResultSetImpl(this, transaction, runAndPull.runResponse(), pullResponse,
+					this.fetchSize, this.maxRows, this.maxFieldSize);
+			this.updateCount = pullResponse.resultSummary()
+				.map(summary -> summary.counters().totalCount())
+				.filter(count -> count > 0)
+				.orElse(-1);
+			return this.updateCount == -1;
+		});
+	}
+
+	private <T> T recordEvent(String statement, ExecutionMode executionType, SqlCallable<T> callable)
+			throws SQLException {
+		var id = statementId();
+		var s = System.nanoTime();
+		var databaseURL = this.connection.unwrap(Neo4jConnection.class).getDatabaseURL();
+		var startEvent = new ExecutionStartedEvent(id, databaseURL, statement, executionType);
+		Events.notify(this.listeners, listener -> listener.executionStarted(startEvent));
+
+		var state = ExecutionEndedEvent.State.FAILED;
+		try {
+			var result = callable.call();
+			state = ExecutionEndedEvent.State.SUCCESSFUL;
+			return result;
+		}
+		finally {
+			final long e = System.nanoTime();
+			var endEvent = new ExecutionEndedEvent(id, databaseURL, state, executionType, Duration.ofNanos(e - s));
+			Events.notify(this.listeners, listener -> listener.executionEnded(endEvent));
+		}
+	}
+
+	private String statementId() {
+		var type = getType().getSimpleName();
+		return type + "@"
+				+ HEX_FORMAT.formatHex(ENCODER.encode(Long
+					.toString(ID_GENERATORS.computeIfAbsent(type, ignored -> new AtomicLong(0)).getAndIncrement())
+					.getBytes(StandardCharsets.UTF_8)));
 	}
 
 	private static Map<String, Object> getParameters(Map<String, Object> parameters) throws SQLException {
@@ -566,6 +628,33 @@ non-sealed class StatementImpl implements Neo4jStatement {
 			this.transactionMetadata.putAll(metadata);
 		}
 		return this;
+	}
+
+	@Override
+	public void addListener(StatementListener statementListener) {
+		this.listeners.add(Objects.requireNonNull(statementListener));
+	}
+
+	Class<? extends Statement> getType() {
+		if (this instanceof CallableStatement) {
+			return CallableStatement.class;
+		}
+		else if (this instanceof PreparedStatement) {
+			return PreparedStatement.class;
+		}
+		return Statement.class;
+	}
+
+	@FunctionalInterface
+	interface SqlCallable<V> {
+
+		/**
+		 * Computes a result, or throws an exception if unable to do so.
+		 * @return computed result
+		 * @throws SQLException if unable to compute a result
+		 */
+		V call() throws SQLException;
+
 	}
 
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/ConnectionClosedEvent.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/ConnectionClosedEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.events;
+
+import java.net.URI;
+
+/**
+ * This event will be fired when a connection has been closed, either normally or aborted
+ * with the appropriate flag set to {@literal true}.
+ *
+ * @param uri the URL of the connection that was closed.
+ * @param aborted will be {@literal true} when the connection has been aborted.
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+public record ConnectionClosedEvent(URI uri, boolean aborted) {
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/ConnectionListener.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/ConnectionListener.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.events;
+
+/**
+ * Defines a listener on a {@link org.neo4j.jdbc.Neo4jConnection}.
+ *
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+public interface ConnectionListener {
+
+	/**
+	 * Will be called when a new statement is opened.
+	 * @param event the corresponding event
+	 */
+	default void statementCreated(StatementCreatedEvent event) {
+	}
+
+	/**
+	 * Will be called when a statement is closed.
+	 * @param event the corresponding event
+	 */
+	default void statementClosed(StatementClosedEvent event) {
+	}
+
+	/**
+	 * Will be called when a translation has been cached.
+	 * @param event the corresponding event
+	 */
+	default void translationCached(TranslationCachedEvent event) {
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/ConnectionOpenedEvent.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/ConnectionOpenedEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.events;
+
+import java.net.URI;
+
+/**
+ * Will be fired when a new connection has been opened.
+ *
+ * @param uri The URL of the Neo4j instance towards the connection has been opened too.
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+public record ConnectionOpenedEvent(URI uri) {
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/DriverListener.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/DriverListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.events;
+
+/**
+ * Defines a listener on relevant {@link org.neo4j.jdbc.Neo4jDriver} events.
+ *
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+public interface DriverListener {
+
+	/**
+	 * Will be called on any newly opened connection.
+	 * @param event the corresponding event
+	 */
+	default void connectionOpened(ConnectionOpenedEvent event) {
+	}
+
+	/**
+	 * Will be called when a connection is closed or aborted.
+	 * @param event the corresponding event
+	 */
+	default void connectionClosed(ConnectionClosedEvent event) {
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/ExecutionEndedEvent.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/ExecutionEndedEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.events;
+
+import java.net.URI;
+import java.time.Duration;
+
+/**
+ * Will be fired at the end of the execution of a {@link org.neo4j.jdbc.Neo4jStatement} or
+ * subtypes thereof.
+ *
+ * @param id a generated id to correlate this event to the corresponding
+ * {@link ExecutionStartedEvent start event}
+ * @param uri The URL of the Neo4j instance that was queried
+ * @param state information about the outcome of the execution (success or not)
+ * @param executionMode the mode of the execution (as defined by the JDBC spec)
+ * @param elapsedTime the elapsed time between sending the original statement to the
+ * database and the end of the first pull or discard. The elapsed time won't take the full
+ * materialization of any corresponding {@link java.sql.ResultSet} into account.
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+public record ExecutionEndedEvent(String id, URI uri, State state, ExecutionMode executionMode, Duration elapsedTime) {
+
+	/**
+	 * Possible state of a statement execution.
+	 */
+	public enum State {
+
+		/**
+		 * The statement was executed successfully.
+		 */
+		SUCCESSFUL,
+		/**
+		 * Execution failed.
+		 */
+		FAILED
+
+	}
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/ExecutionMode.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/ExecutionMode.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.events;
+
+/**
+ * The mode how a statement is executed (plain, without any immediate visible results or
+ * updates, as a query or as an update statement).
+ *
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+public enum ExecutionMode {
+
+	/**
+	 * Used with {@link java.sql.Statement#execute(String)} and overloads.
+	 */
+	PLAIN,
+	/**
+	 * Used with {@link java.sql.Statement#executeQuery(String)} and overloads.
+	 */
+	QUERY,
+	/**
+	 * Used with {@link java.sql.Statement#executeUpdate(String)} and overloads.
+	 */
+	UPDATE
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/ExecutionStartedEvent.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/ExecutionStartedEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.events;
+
+import java.net.URI;
+
+/**
+ * Will be fired before the execution of a statement happens.
+ *
+ * @param id a generated id to correlate this event to the corresponding
+ * {@link ExecutionEndedEvent end event}
+ * @param uri The URL of the Neo4j instance that was queried
+ * @param statement the statement to be executed. This will always the original statement
+ * passed to execute, not a potentially translated one.
+ * @param executionMode the mode of the execution
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+public record ExecutionStartedEvent(String id, URI uri, String statement, ExecutionMode executionMode) {
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/StatementClosedEvent.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/StatementClosedEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.events;
+
+import java.net.URI;
+import java.sql.Statement;
+
+/**
+ * Will be fired when a statement has been closed.
+ *
+ * @param uri the URL of the statement that was closed.
+ * @param statementType the actual type of the statement as defined in the JDBC spec.
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+public record StatementClosedEvent(URI uri, Class<? extends Statement> statementType) {
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/StatementCreatedEvent.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/StatementCreatedEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.events;
+
+import java.net.URI;
+import java.sql.Statement;
+
+/**
+ * This event will be fired when a statement has been created.
+ *
+ * @param uri The URL of the Neo4j instance towards the statement has been opened too.
+ * @param statementType the actual type of the statement as defined in the JDBC spec.
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+public record StatementCreatedEvent(URI uri, Class<? extends Statement> statementType) {
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/StatementListener.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/StatementListener.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.events;
+
+/**
+ * Defines a listener on a {@link org.neo4j.jdbc.Neo4jStatement} and subtypes.
+ *
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+public interface StatementListener {
+
+	/**
+	 * Will be called when the execution of a statement is about to start.
+	 * @param event the corresponding event
+	 */
+	default void executionStarted(ExecutionStartedEvent event) {
+	}
+
+	/**
+	 * Will be called when the execution of a statement has finished (after bolt run,
+	 * before any full materializing of a result set).
+	 * @param event the corresponding event
+	 */
+	default void executionEnded(ExecutionEndedEvent event) {
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/TranslationCachedEvent.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/TranslationCachedEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.events;
+
+/**
+ * This event will be fired when a translation has been cached.
+ *
+ * @param cacheSize the size of the cache
+ * @author Michael J. Simons
+ * @since 6.3.0
+ */
+public record TranslationCachedEvent(int cacheSize) {
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/package-info.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/events/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * A minimalistic event system for the Neo4j JDBC Driver.
+ */
+package org.neo4j.jdbc.events;

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/CallableStatementImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/CallableStatementImplTests.java
@@ -94,8 +94,8 @@ class CallableStatementImplTests {
 	@MethodSource
 	void shouldSetParameter(StatementMethodRunner parameterSettingRunner, Value expectedValue)
 			throws SQLException, MalformedURLException, IllegalAccessException {
-		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), false,
-				"RETURN $x");
+		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), null,
+				false, "RETURN $x");
 
 		parameterSettingRunner.run(this.statement);
 
@@ -190,8 +190,8 @@ class CallableStatementImplTests {
 	@ParameterizedTest
 	@MethodSource
 	void shouldThrowWhenClosed(StatementMethodRunner consumer) throws SQLException {
-		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), false,
-				TEST_STATEMENT);
+		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), null,
+				false, TEST_STATEMENT);
 		this.statement.close();
 		assertThat(this.statement.isClosed()).isTrue();
 		assertThatThrownBy(() -> consumer.run(this.statement)).isInstanceOf(SQLException.class);
@@ -289,8 +289,8 @@ class CallableStatementImplTests {
 	@ParameterizedTest
 	@MethodSource
 	void shouldThrowUnsupported(StatementMethodRunner consumer, Class<? extends SQLException> exceptionType) {
-		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), false,
-				TEST_STATEMENT);
+		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), null,
+				false, TEST_STATEMENT);
 		assertThatThrownBy(() -> consumer.run(this.statement)).isExactlyInstanceOf(exceptionType);
 	}
 
@@ -398,8 +398,8 @@ class CallableStatementImplTests {
 	@MethodSource("getUnwrapArgs")
 	void shouldUnwrap(Class<?> cls, boolean shouldUnwrap) throws SQLException {
 		// given
-		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), false,
-				TEST_STATEMENT);
+		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), null,
+				false, TEST_STATEMENT);
 
 		// when & then
 		if (shouldUnwrap) {
@@ -415,8 +415,8 @@ class CallableStatementImplTests {
 	@MethodSource("getUnwrapArgs")
 	void shouldHandleIsWrapperFor(Class<?> cls, boolean shouldUnwrap) {
 		// given
-		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), false,
-				TEST_STATEMENT);
+		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), null,
+				false, TEST_STATEMENT);
 
 		// when
 		var wrapperFor = this.statement.isWrapperFor(cls);
@@ -437,8 +437,8 @@ class CallableStatementImplTests {
 	@MethodSource("shouldNotAllowMixingParameterTypesArgs")
 	void shouldNotAllowMixingParameterTypes(StatementMethodRunner firstSetter, StatementMethodRunner secondSetter)
 			throws MalformedURLException, SQLException, IllegalAccessException {
-		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), false,
-				TEST_STATEMENT);
+		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), null,
+				false, TEST_STATEMENT);
 
 		try {
 			firstSetter.run(this.statement);

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ConnectionImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ConnectionImplTests.java
@@ -131,7 +131,8 @@ class ConnectionImplTests {
 		given(translator.translate(eq(sql), any(DatabaseMetaData.class))).willReturn(expectedNativeSql);
 		var connection = new ConnectionImpl(URI.create("jdbc:neo4j://localhost"), () -> mock(BoltConnection.class),
 				() -> List.of(translator), false, true, false, false, new VoidBookmarkManagerImpl(), Map.of(), 23,
-				"aBeautifulDatabase");
+				"aBeautifulDatabase", new MetricsCollector() {
+				}, null);
 
 		var nativeSQL = connection.nativeSQL(sql);
 		nativeSQL = connection.nativeSQL(sql);
@@ -761,7 +762,8 @@ class ConnectionImplTests {
 
 	ConnectionImpl makeConnection(BoltConnection boltConnection) {
 		return new ConnectionImpl(URI.create("jdbc:neo4j://localhost"), () -> boltConnection, List::of, false, false,
-				true, false, new VoidBookmarkManagerImpl(), Map.of(), 23, "aBeautifulDatabase");
+				true, false, new VoidBookmarkManagerImpl(), Map.of(), 23, "aBeautifulDatabase", new MetricsCollector() {
+				}, null);
 
 	}
 

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ConnectionImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ConnectionImplTests.java
@@ -131,8 +131,7 @@ class ConnectionImplTests {
 		given(translator.translate(eq(sql), any(DatabaseMetaData.class))).willReturn(expectedNativeSql);
 		var connection = new ConnectionImpl(URI.create("jdbc:neo4j://localhost"), () -> mock(BoltConnection.class),
 				() -> List.of(translator), false, true, false, false, new VoidBookmarkManagerImpl(), Map.of(), 23,
-				"aBeautifulDatabase", new MetricsCollector() {
-				}, null);
+				"aBeautifulDatabase", null);
 
 		var nativeSQL = connection.nativeSQL(sql);
 		nativeSQL = connection.nativeSQL(sql);
@@ -762,8 +761,7 @@ class ConnectionImplTests {
 
 	ConnectionImpl makeConnection(BoltConnection boltConnection) {
 		return new ConnectionImpl(URI.create("jdbc:neo4j://localhost"), () -> boltConnection, List::of, false, false,
-				true, false, new VoidBookmarkManagerImpl(), Map.of(), 23, "aBeautifulDatabase", new MetricsCollector() {
-				}, null);
+				true, false, new VoidBookmarkManagerImpl(), Map.of(), 23, "aBeautifulDatabase", null);
 
 	}
 

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/MetricsCollectorImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/MetricsCollectorImplTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc;
+
+import java.net.URI;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetricsCollectorImplTests {
+
+	@ParameterizedTest
+	@CsvSource(
+			textBlock = """
+					jdbc:neo4j+ssc://localhost:7688?enableSQLTranslation=true&cacheSQLTranslations=true,jdbc:neo4j+ssc://localhost:7688
+					jdbc:neo4j+ssc://localhost?enableSQLTranslation=true&cacheSQLTranslations=true,jdbc:neo4j+ssc://localhost:7687
+					jdbc:neo4j+ssc://localhost/aDatabase?enableSQLTranslation=true&cacheSQLTranslations=true,jdbc:neo4j+ssc://localhost:7687/aDatabase
+					jdbc:neo4j+ssc://localhost/aDatabase?enableSQLTranslation=true&cacheSQLTranslations=true#whatever,jdbc:neo4j+ssc://localhost:7687/aDatabase#whatever
+					jdbc:neo4j+ssc://localhost/aDatabase#whatever,jdbc:neo4j+ssc://localhost:7687/aDatabase#whatever
+					""")
+	void urlCleanerShouldWork(URI in, URI expected) {
+		assertThat(MetricsCollectorImpl.cleanURL(in)).isEqualTo(expected);
+	}
+
+}

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDriverUrlParsingTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDriverUrlParsingTests.java
@@ -501,7 +501,7 @@ class Neo4jDriverUrlParsingTests {
 
 		var url = config.toUrl().toString();
 		assertThat(url).isEqualTo(
-				"jdbc:neo4j+ssc://host:1234/customDb?authScheme=BASIC&user=user1&authRealm=myRealm&agent=baby%27s-first-agent%2F1.2.3&timeout=2000&enableSQLTranslation=true&cacheSQLTranslations=true&rewriteBatchedStatements=false&rewritePlaceholders=false&useBookmarks=true&customProperty=foo&customQuery=bar&relationshipSampleSize=4711&s2c.alwaysEscapeNames=true&s2c.enableCache=true&s2c.prettyPrint=true");
+				"jdbc:neo4j+ssc://host:1234/customDb?enableSQLTranslation=true&cacheSQLTranslations=true&rewriteBatchedStatements=false&rewritePlaceholders=false&useBookmarks=true");
 	}
 
 	@Test
@@ -549,8 +549,8 @@ class Neo4jDriverUrlParsingTests {
 		driver.connect("jdbc:neo4j://host:1000/database", props);
 
 		then(this.boltConnectionProvider).should()
-			.connect(any(), any(), any(), any(), anyInt(), any(), any(), any(), any(), any(), any(), any(), any(),
-					any(), any());
+			.connect(any(), any(), any(), any(), anyInt(), any(), any(), argThat(matches(expectedAuthToken)), any(),
+					any(), any(), any(), any(), any(), any());
 	}
 
 	@Test

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/PackageStructureTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/PackageStructureTests.java
@@ -32,6 +32,7 @@ import org.neo4j.jdbc.values.Value;
 import static com.tngtech.archunit.base.DescribedPredicate.describe;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideOutsideOfPackages;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
@@ -41,12 +42,34 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.theClass;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PackageStructureTests {
 
+	private final DescribedPredicate<JavaClass> jdbcModuleClasses = resideInAPackage("..jdbc");
+
 	private JavaClasses allClasses;
 
 	@BeforeAll
 	void importAllClasses() {
 		this.allClasses = new ClassFileImporter().withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
 			.importPackages("org.neo4j.jdbc..");
+	}
+
+	@Test
+	void jdbcModuleClassesMustNotBeUsedFromBoltInternals() {
+
+		var rule = noClasses().that()
+			.resideInAPackage("..jdbc.internal..")
+			.should()
+			.dependOnClassesThat(this.jdbcModuleClasses);
+		rule.check(this.allClasses);
+	}
+
+	@Test
+	void jdbcModuleClassesMustNotBeUsedFromEvents() {
+
+		var rule = noClasses().that()
+			.resideInAPackage("..jdbc.events..")
+			.should()
+			.dependOnClassesThat(this.jdbcModuleClasses);
+		rule.check(this.allClasses);
 	}
 
 	@Test

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/PreparedStatementImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/PreparedStatementImplTests.java
@@ -107,7 +107,7 @@ class PreparedStatementImplTests {
 		given(transactionSupplier.getTransaction(any())).willReturn(transaction);
 		given(transaction.runAndPull(query, Collections.emptyMap(), StatementImpl.DEFAULT_FETCH_SIZE, 0))
 			.willReturn(new Neo4jTransaction.RunAndPullResponses(runResponse, pullResponse));
-		this.statement = newStatement(mock(Connection.class), transactionSupplier, query);
+		this.statement = newStatement(StatementImplTests.mockConnection(), transactionSupplier, query);
 
 		// when
 		var resultSet = this.statement.executeQuery();
@@ -123,7 +123,7 @@ class PreparedStatementImplTests {
 
 	private static PreparedStatementImpl newStatement(Connection connection,
 			Neo4jTransactionSupplier transactionSupplier, String query) {
-		return new PreparedStatementImpl(connection, transactionSupplier, null, null, false, query);
+		return new PreparedStatementImpl(connection, transactionSupplier, null, null, null, false, query);
 	}
 
 	@Test
@@ -142,7 +142,7 @@ class PreparedStatementImplTests {
 		given(response.counters()).willReturn(counters);
 		var totalUpdates = 5;
 		given(counters.nodesCreated()).willReturn(totalUpdates);
-		this.statement = newStatement(mock(Connection.class), transactionSupplier, query);
+		this.statement = newStatement(StatementImplTests.mockConnection(), transactionSupplier, query);
 
 		// when
 		var updates = this.statement.executeUpdate();
@@ -174,7 +174,7 @@ class PreparedStatementImplTests {
 		given(resultSummary.counters()).willReturn(summaryCounters);
 		given(summaryCounters.totalCount()).willReturn(0);
 		given(pullResponse.records()).willReturn(Collections.emptyList());
-		this.statement = newStatement(mock(Connection.class), transactionSupplier, query);
+		this.statement = newStatement(StatementImplTests.mockConnection(), transactionSupplier, query);
 
 		// when
 		var hasResultSet = this.statement.execute();
@@ -202,14 +202,15 @@ class PreparedStatementImplTests {
 
 	@Test
 	void shouldBePoolableByDefault() throws SQLException {
-		this.statement = newStatement(mock(Connection.class), mock(Neo4jTransactionSupplier.class), "");
+		this.statement = newStatement(StatementImplTests.mockConnection(), mock(Neo4jTransactionSupplier.class), "");
 		assertThat(this.statement.isPoolable()).isTrue();
 	}
 
 	@ParameterizedTest
 	@MethodSource("getShouldThrowWhenClosedArgs")
 	void shouldThrowWhenClosed(StatementMethodRunner consumer) throws SQLException {
-		this.statement = newStatement(mock(Connection.class), mock(Neo4jTransactionSupplier.class), "query");
+		this.statement = newStatement(StatementImplTests.mockConnection(), mock(Neo4jTransactionSupplier.class),
+				"query");
 		this.statement.close();
 		assertThat(this.statement.isClosed()).isTrue();
 		assertThatThrownBy(() -> consumer.run(this.statement)).isInstanceOf(SQLException.class);
@@ -285,8 +286,10 @@ class PreparedStatementImplTests {
 
 	@ParameterizedTest
 	@MethodSource("getShouldThrowUnsupportedArgs")
-	void shouldThrowUnsupported(StatementMethodRunner consumer, Class<? extends SQLException> exceptionType) {
-		this.statement = newStatement(mock(Connection.class), mock(Neo4jTransactionSupplier.class), "query");
+	void shouldThrowUnsupported(StatementMethodRunner consumer, Class<? extends SQLException> exceptionType)
+			throws SQLException {
+		this.statement = newStatement(StatementImplTests.mockConnection(), mock(Neo4jTransactionSupplier.class),
+				"query");
 		assertThatThrownBy(() -> consumer.run(this.statement)).isExactlyInstanceOf(exceptionType);
 	}
 
@@ -335,8 +338,9 @@ class PreparedStatementImplTests {
 
 	@ParameterizedTest
 	@MethodSource("getShouldThrowOnExplicitlyProhibitedMethodsArgs")
-	void shouldThrowOnExplicitlyProhibitedMethods(StatementMethodRunner consumer) {
-		this.statement = newStatement(mock(Connection.class), mock(Neo4jTransactionSupplier.class), "query");
+	void shouldThrowOnExplicitlyProhibitedMethods(StatementMethodRunner consumer) throws SQLException {
+		this.statement = newStatement(StatementImplTests.mockConnection(), mock(Neo4jTransactionSupplier.class),
+				"query");
 		assertThatThrownBy(() -> consumer.run(this.statement)).isExactlyInstanceOf(SQLException.class);
 	}
 
@@ -363,8 +367,9 @@ class PreparedStatementImplTests {
 
 	@ParameterizedTest
 	@MethodSource("getShouldThrowOnInvalidParameterIndexArgs")
-	void shouldThrowOnInvalidParameterIndex(StatementMethodRunner consumer) {
-		this.statement = newStatement(mock(Connection.class), mock(Neo4jTransactionSupplier.class), "query");
+	void shouldThrowOnInvalidParameterIndex(StatementMethodRunner consumer) throws SQLException {
+		this.statement = newStatement(StatementImplTests.mockConnection(), mock(Neo4jTransactionSupplier.class),
+				"query");
 		assertThatThrownBy(() -> consumer.run(this.statement)).isExactlyInstanceOf(SQLException.class);
 	}
 
@@ -407,7 +412,8 @@ class PreparedStatementImplTests {
 	@MethodSource
 	void shouldSetParameter(StatementMethodRunner parameterSettingRunner, Value expectedValue)
 			throws SQLException, MalformedURLException {
-		this.statement = newStatement(mock(Connection.class), mock(Neo4jTransactionSupplier.class), "query");
+		this.statement = newStatement(StatementImplTests.mockConnection(), mock(Neo4jTransactionSupplier.class),
+				"query");
 
 		parameterSettingRunner.run(this.statement);
 
@@ -500,7 +506,8 @@ class PreparedStatementImplTests {
 	@ParameterizedTest
 	@MethodSource("getShouldSetObjectParameterArgs")
 	void shouldSetObjectParameter(Object object, Value expectedValue) throws SQLException {
-		this.statement = newStatement(mock(Connection.class), mock(Neo4jTransactionSupplier.class), "query");
+		this.statement = newStatement(StatementImplTests.mockConnection(), mock(Neo4jTransactionSupplier.class),
+				"query");
 
 		this.statement.setObject(1, object);
 
@@ -522,7 +529,8 @@ class PreparedStatementImplTests {
 
 	@Test
 	void shouldClearParameters() throws SQLException {
-		this.statement = newStatement(mock(Connection.class), mock(Neo4jTransactionSupplier.class), "query");
+		this.statement = newStatement(StatementImplTests.mockConnection(), mock(Neo4jTransactionSupplier.class),
+				"query");
 		this.statement.setBoolean(1, true);
 
 		this.statement.clearParameters();
@@ -531,8 +539,9 @@ class PreparedStatementImplTests {
 	}
 
 	@Test
-	void shouldReturnParameterMetaData() {
-		this.statement = newStatement(mock(Connection.class), mock(Neo4jTransactionSupplier.class), "query");
+	void shouldReturnParameterMetaData() throws SQLException {
+		this.statement = newStatement(StatementImplTests.mockConnection(), mock(Neo4jTransactionSupplier.class),
+				"query");
 
 		var metaData = this.statement.getParameterMetaData();
 
@@ -543,7 +552,8 @@ class PreparedStatementImplTests {
 	@MethodSource("getUnwrapArgs")
 	void shouldUnwrap(Class<?> cls, boolean shouldUnwrap) throws SQLException {
 		// given
-		this.statement = newStatement(mock(Connection.class), mock(Neo4jTransactionSupplier.class), "query");
+		this.statement = newStatement(StatementImplTests.mockConnection(), mock(Neo4jTransactionSupplier.class),
+				"query");
 
 		// when & then
 		if (shouldUnwrap) {
@@ -557,9 +567,10 @@ class PreparedStatementImplTests {
 
 	@ParameterizedTest
 	@MethodSource("getUnwrapArgs")
-	void shouldHandleIsWrapperFor(Class<?> cls, boolean shouldUnwrap) {
+	void shouldHandleIsWrapperFor(Class<?> cls, boolean shouldUnwrap) throws SQLException {
 		// given
-		this.statement = newStatement(mock(Connection.class), mock(Neo4jTransactionSupplier.class), "query");
+		this.statement = newStatement(StatementImplTests.mockConnection(), mock(Neo4jTransactionSupplier.class),
+				"query");
 
 		// when
 		var wrapperFor = this.statement.isWrapperFor(cls);

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.neo4j</groupId>
 	<artifactId>neo4j-jdbc-parent</artifactId>
-	<version>6.2.2-SNAPSHOT</version>
+	<version>6.3.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>Neo4j JDBC Driver</name>
@@ -175,6 +175,7 @@
 		<maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<maven.version>3.9.4</maven.version>
+		<micrometer.version>1.14.5</micrometer.version>
 		<mockito.version>5.16.1</mockito.version>
 		<moditect-maven-plugin.version>1.2.2.Final</moditect-maven-plugin.version>
 		<native-maven-plugin.version>0.10.6</native-maven-plugin.version>
@@ -204,6 +205,13 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>io.micrometer</groupId>
+				<artifactId>micrometer-bom</artifactId>
+				<version>${micrometer.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-bom</artifactId>


### PR DESCRIPTION
This changes adds both events and metrics to the driver.

The event system provides access to

- connections being opend and closed
- statements being created and closed
- execution results
- cache events

Listeners can be added by using `unwrap` on the driver, connection or statement classes and adding the appropriate listeners.

Build on the event system are metrics.

Metrics require Micrometer on the classpath and will configure itself to use the global registry if available. No other configuration is necessary.
Events are translated into corresponding metrics.
