### PR TITLE
build: Use specific commits for none enterprise actions.

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -46,7 +46,7 @@ jobs:
           git add .
           git commit -m "Update GH-Pages."
       - name: Push changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df # v0.8.0
         with:
           directory: target/gh-pages
           branch: gh-pages

--- a/neo4j-jdbc-it/quarkus-smoke-tests/src/main/resources/application.properties
+++ b/neo4j-jdbc-it/quarkus-smoke-tests/src/main/resources/application.properties
@@ -19,6 +19,9 @@
 
 quarkus.datasource.db-kind=other
 quarkus.datasource.jdbc.driver=org.neo4j.jdbc.Neo4jDriver
+quarkus.datasource.username=yourusername
+quarkus.datasource.password=yourpassword
+quarkus.datasource.jdbc.url=jdbc:neo4j+s://yourdb.databases.neo4j.io?enableSQLTranslation=true
 
 quarkus.banner.enabled=false
 


### PR DESCRIPTION
See

* https://forum.operaton.org/t/proposal-to-pin-github-action-runners-to-commits-instead-of-versions/224
* https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
* https://alexwlchan.net/2025/github-actions-audit/

Thanks @javahippie.
