### PR TITLE
build: Add more jOOQ classes to build time initialization.

### DIFF
--- a/neo4j-jdbc-translator/impl/src/main/resources/META-INF/native-image/org.neo4j.driver/neo4j-jdbc-translator-impl/native-image.properties
+++ b/neo4j-jdbc-translator/impl/src/main/resources/META-INF/native-image/org.neo4j.driver/neo4j-jdbc-translator-impl/native-image.properties
@@ -19,4 +19,6 @@
 
 Args = -H:ReflectionConfigurationResources=${.}/reflection-config.json \
   --initialize-at-run-time=org.jooq \
-  --initialize-at-build-time=org.jooq.SQLDialect
+  --initialize-at-build-time=org.jooq.SQLDialect \
+  --initialize-at-build-time=org.jooq.SQLDialectCategory \
+  --initialize-at-build-time=org.jooq.SQLDialect$RequiredVersion


### PR DESCRIPTION
Native image builds fail on Graal 24 without.
