### PR TITLE
fix: Align callable statement with JDBC spec wrt getting parameters back.

### DIFF
--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/CallableStatementIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/CallableStatementIT.java
@@ -123,6 +123,18 @@ class CallableStatementIT extends IntegrationTestBase {
 		}
 	}
 
+	@Test
+	void batchingShouldNotBeSupported() throws SQLException {
+		try (var connection = getConnection(); var statement = connection.prepareCall("{$name = call db.info()}")) {
+			assertThatExceptionOfType(SQLException.class).isThrownBy(statement::clearBatch)
+				.withMessage("general processing exception - This method must not be called on CallableStatement");
+			assertThatExceptionOfType(SQLException.class).isThrownBy(statement::addBatch)
+				.withMessage("general processing exception - This method must not be called on CallableStatement");
+			assertThatExceptionOfType(SQLException.class).isThrownBy(() -> statement.addBatch("RETURN sin(?)"))
+				.withMessage("general processing exception - This method must not be called on CallableStatement");
+		}
+	}
+
 	@ParameterizedTest
 	@ValueSource(strings = { "{? = call sin(?)}", "RETURN sin(?)" })
 	void outByIndexOnFunctionShouldWork(String sql) throws SQLException {

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/CallableStatementIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/CallableStatementIT.java
@@ -18,14 +18,26 @@
  */
 package org.neo4j.jdbc.it.cp;
 
+import java.math.BigDecimal;
+import java.sql.CallableStatement;
+import java.sql.Date;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -90,9 +102,11 @@ class CallableStatementIT extends IntegrationTestBase {
 		try (var connection = getConnection(); var statement = connection.prepareCall("{? = call db.info()}")) {
 
 			statement.execute();
-			var msg = statement.getString(2);
+			var rs = statement.getResultSet();
+			assertThat(rs.next()).isTrue();
+			var msg = rs.getString(2);
 			assertThat(msg).isEqualTo("neo4j");
-			assertThat(msg).isEqualTo(statement.getString(2));
+			assertThat(msg).isEqualTo(rs.getString(2));
 		}
 	}
 
@@ -101,9 +115,11 @@ class CallableStatementIT extends IntegrationTestBase {
 		try (var connection = getConnection(); var statement = connection.prepareCall("{$name = call db.info()}")) {
 
 			statement.execute();
-			var msg = statement.getString("name");
+			var rs = statement.getResultSet();
+			assertThat(rs.next()).isTrue();
+			var msg = rs.getString("name");
 			assertThat(msg).isEqualTo("neo4j");
-			assertThat(msg).isEqualTo(statement.getString("name"));
+			assertThat(msg).isEqualTo(rs.getString("name"));
 		}
 	}
 
@@ -114,10 +130,114 @@ class CallableStatementIT extends IntegrationTestBase {
 
 			statement.setDouble(1, Math.toRadians(150));
 			statement.execute();
-			var sin = statement.getDouble(1);
+			var rs = statement.getResultSet();
+			assertThat(rs.next()).isTrue();
+			var sin = rs.getDouble(1);
 			assertThat(sin).isCloseTo(0.5, Percentage.withPercentage(1));
-			assertThat(sin).isEqualTo(statement.getDouble(1));
+			assertThat(sin).isEqualTo(rs.getDouble(1));
 		}
+	}
+
+	Stream<Arguments> parameterTypeRetrievalShouldWork() {
+		return Stream.of(Arguments.of("RETURN valueType(?)",
+				List.of(new ParametertypeHelper<>(true, (stmt, v) -> stmt.setBoolean(1, v), stmt -> stmt.getBoolean(1)),
+						new ParametertypeHelper<>((byte) 2, (stmt, v) -> stmt.setByte(1, v), stmt -> stmt.getByte(1))),
+				new ParametertypeHelper<>((short) 2, (stmt, v) -> stmt.setShort(1, v), stmt -> stmt.getShort(1)),
+				new ParametertypeHelper<>(2, (stmt, v) -> stmt.setInt(1, v), stmt -> stmt.getInt(1)),
+				new ParametertypeHelper<>(2L, (stmt, v) -> stmt.setLong(1, v), stmt -> stmt.getLong(1)),
+				new ParametertypeHelper<>((float) 2.0, (stmt, v) -> stmt.setFloat(1, v), stmt -> stmt.getFloat(1)),
+				new ParametertypeHelper<>(2.0, (stmt, v) -> stmt.setDouble(1, v), stmt -> stmt.getDouble(1)),
+				new ParametertypeHelper<>(Date.valueOf(LocalDate.now()), (stmt, v) -> stmt.setDate(1, v),
+						stmt -> stmt.getDate(1)),
+				new ParametertypeHelper<>(Time.valueOf(LocalTime.now()), (stmt, v) -> stmt.setTime(1, v),
+						stmt -> stmt.getTime(1)),
+				new ParametertypeHelper<>(Timestamp.valueOf(LocalDateTime.now()), (stmt, v) -> stmt.setTimestamp(1, v),
+						stmt -> stmt.getTimestamp(1)),
+				new ParametertypeHelper<>(BigDecimal.TEN, (stmt, v) -> stmt.setBigDecimal(1, v),
+						stmt -> stmt.getBigDecimal(1)),
+				new ParametertypeHelper<>(null, (stmt, v) -> stmt.setInt(1, v), stmt -> stmt.getInt(1))),
+				Arguments.of("RETURN valueType($input)",
+						List.of(new ParametertypeHelper<>(true, (stmt, v) -> stmt.setBoolean("input", v),
+								stmt -> stmt.getBoolean("input")),
+								new ParametertypeHelper<>((byte) 2, (stmt, v) -> stmt.setByte("input", v),
+										stmt -> stmt.getByte("input"))),
+						new ParametertypeHelper<>((short) 2, (stmt, v) -> stmt.setShort("input", v),
+								stmt -> stmt.getShort("input")),
+						new ParametertypeHelper<>(2, (stmt, v) -> stmt.setInt("input", v),
+								stmt -> stmt.getInt("input")),
+						new ParametertypeHelper<>(2L, (stmt, v) -> stmt.setLong("input", v),
+								stmt -> stmt.getLong("input")),
+						new ParametertypeHelper<>((float) 2.0, (stmt, v) -> stmt.setFloat("input", v),
+								stmt -> stmt.getFloat("input")),
+						new ParametertypeHelper<>(2.0, (stmt, v) -> stmt.setDouble("input", v),
+								stmt -> stmt.getDouble("input")),
+						new ParametertypeHelper<>(Date.valueOf(LocalDate.now()), (stmt, v) -> stmt.setDate("input", v),
+								stmt -> stmt.getDate("input")),
+						new ParametertypeHelper<>(Time.valueOf(LocalTime.now()), (stmt, v) -> stmt.setTime("input", v),
+								stmt -> stmt.getTime("input")),
+						new ParametertypeHelper<>(Timestamp.valueOf(LocalDateTime.now()),
+								(stmt, v) -> stmt.setTimestamp("input", v), stmt -> stmt.getTimestamp("input")),
+						new ParametertypeHelper<>(BigDecimal.TEN, (stmt, v) -> stmt.setBigDecimal("input", v),
+								stmt -> stmt.getBigDecimal("input")),
+
+						new ParametertypeHelper<>(null, (stmt, v) -> stmt.setInt("input", v),
+								stmt -> stmt.getInt("input"))));
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void parameterTypeRetrievalShouldWork(String query, List<ParametertypeHelper<?>> types) throws SQLException {
+		// types passed as list on purpose, so that we catch clearing parameters, too
+		try (var connection = getConnection(); var statement = connection.prepareCall(query)) {
+
+			for (ParametertypeHelper<?> parametertype : types) {
+				assertThat(parametertype.apply(statement)).isEqualTo(parametertype.value);
+				assertThat(statement.wasNull()).isEqualTo(parametertype.value == null);
+				assertStatementResultSet(statement.getResultSet());
+				statement.clearParameters();
+			}
+		}
+	}
+
+	private static void assertStatementResultSet(ResultSet rs) throws SQLException {
+		assertThat(rs.next()).isTrue();
+		assertThat(rs.getString(1)).isNotNull();
+		assertThat(rs.next()).isFalse();
+	}
+
+	interface ThrowingSetter<T> {
+
+		void set(CallableStatement statement, T v) throws SQLException;
+
+	}
+
+	interface ThrowingGetter<T> {
+
+		T get(CallableStatement statement) throws SQLException;
+
+	}
+
+	static class ParametertypeHelper<T> {
+
+		private final T value;
+
+		private final ThrowingSetter<T> setter;
+
+		private final ThrowingGetter<T> getter;
+
+		ParametertypeHelper(T value, ThrowingSetter<T> setter, ThrowingGetter<T> getter) {
+			this.value = value;
+			this.setter = setter;
+			this.getter = getter;
+
+		}
+
+		T apply(CallableStatement stmt) throws SQLException {
+			this.setter.set(stmt, this.value);
+			stmt.execute();
+			return this.getter.get(stmt);
+		}
+
 	}
 
 }

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/PreparedStatementIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/PreparedStatementIT.java
@@ -292,6 +292,23 @@ class PreparedStatementIT extends IntegrationTestBase {
 		}
 	}
 
+	@Test
+	void metadataWillAvailableOnlyAfterExecute() throws SQLException {
+		try (var connection = getConnection();
+				var stmt = connection.prepareStatement("MATCH(p:Person) WHERE p.date >= ? AND p.date  < ? RETURN p")) {
+
+			var ts = Timestamp.from(Instant.now());
+			stmt.setTimestamp(1, ts);
+			stmt.setTimestamp(2, ts);
+
+			assertThatExceptionOfType(SQLException.class).isThrownBy(stmt::getMetaData)
+				.withMessageContaining("#execute has not been called");
+
+			assertThat(stmt.execute()).isTrue();
+			assertThat(stmt.getMetaData()).isNotNull();
+		}
+	}
+
 	@Nested
 	class SymmetricTypeConversionInPreparedStatementAndResultSet {
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
@@ -1261,17 +1261,7 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 			keys.add(k);
 			columns[i++] = (v instanceof Value value) ? value : Values.value(v);
 		}
-		var runResponse = new Neo4jTransaction.RunResponse() {
-			@Override
-			public long queryId() {
-				return 0;
-			}
-
-			@Override
-			public List<String> keys() {
-				return keys;
-			}
-		};
+		var runResponse = createRunResponseForStaticKeys(keys);
 		var pullResponse = DatabaseMetadataImpl.staticPullResponseFor(keys, List.<Value[]>of(columns));
 		return new LocalStatementImpl(connection, runResponse, pullResponse).getResultSet();
 	}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
@@ -1251,6 +1251,31 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 		};
 	}
 
+	static ResultSet resultSetForParameters(Connection connection, Map<String, Object> parameters) throws SQLException {
+		List<String> keys = new ArrayList<>();
+		Value[] columns = new Value[parameters.size()];
+		int i = 0;
+		for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+			String k = entry.getKey();
+			Object v = entry.getValue();
+			keys.add(k);
+			columns[i++] = (v instanceof Value value) ? value : Values.value(v);
+		}
+		var runResponse = new Neo4jTransaction.RunResponse() {
+			@Override
+			public long queryId() {
+				return 0;
+			}
+
+			@Override
+			public List<String> keys() {
+				return keys;
+			}
+		};
+		var pullResponse = DatabaseMetadataImpl.staticPullResponseFor(keys, List.<Value[]>of(columns));
+		return new LocalStatementImpl(connection, runResponse, pullResponse).getResultSet();
+	}
+
 	private static Value getTypeFromList(List<Value> types, String propertyName) {
 		if (types.size() > 1) {
 			LOGGER.log(Level.FINE,

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/DatabaseMetadataImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/DatabaseMetadataImplTests.java
@@ -22,6 +22,7 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -56,6 +57,20 @@ class DatabaseMetadataImplTests {
 		given(this.boltConnectionProvider.connect(any(), any(), any(), any(), anyInt(), any(), any(), any(), any(),
 				any(), any(), any(), any(), any(), any()))
 			.willReturn(mockedFuture);
+	}
+
+	@Test
+	void parameterResultSetShouldWork() throws SQLException {
+		var map = new LinkedHashMap<String, Object>();
+		map.put("1", "a");
+		map.put("2", "b");
+		map.put("3", "c");
+		var rs = DatabaseMetadataImpl.resultSetForParameters(mock(ConnectionImpl.class), map);
+		var meta = rs.getMetaData();
+		assertThat(meta.getColumnCount()).isEqualTo(3);
+		for (int i = 0; i < meta.getColumnCount(); ++i) {
+			assertThat(meta.getColumnLabel(i + 1)).isEqualTo(Integer.toString(i + 1));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Direct getXXX method on the statement refer to the values of the parameters, not of the actual result.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
