### PR TITLE
refactor: Include function and procedure return columns in metadata and add support for parameter metadata in callable statements.

### DIFF
--- a/neo4j-jdbc-it/neo4j-jdbc-it-stub/src/test/java/org/neo4j/jdbc/it/stub/ConnectionIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-stub/src/test/java/org/neo4j/jdbc/it/stub/ConnectionIT.java
@@ -213,9 +213,9 @@ class ConnectionIT extends IntegrationTestBase {
 		try (var connection = getConnection();
 				var statement = connection.createStatement();
 				var preparedStatement = connection.prepareStatement("RETURN 1");
-				var callableStatement = connection.prepareCall("RETURN pi()")) {
+				var anotherStatement = connection.prepareStatement("RETURN 2")) {
 			assertThat(preparedStatement.isClosed()).isFalse();
-			assertThat(callableStatement.isClosed()).isFalse();
+			assertThat(anotherStatement.isClosed()).isFalse();
 			connection.setNetworkTimeout(null, 100);
 			statement.setFetchSize(1);
 			statement.closeOnCompletion();
@@ -227,7 +227,7 @@ class ConnectionIT extends IntegrationTestBase {
 			assertThat(result.isClosed()).isTrue();
 			assertThat(statement.isClosed()).isTrue();
 			assertThat(preparedStatement.isClosed()).isTrue();
-			assertThat(callableStatement.isClosed()).isTrue();
+			assertThat(anotherStatement.isClosed()).isTrue();
 			assertThat(connection.isClosed()).isTrue();
 		}
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/CallableStatementImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/CallableStatementImpl.java
@@ -87,23 +87,21 @@ final class CallableStatementImpl extends PreparedStatementImpl implements Neo4j
 
 		var parameterTypes = new HashMap<Integer, String>();
 
-		if (descriptor.hasParameters()) {
-			try (var columns = descriptor.isFunctionCall() ? meta.getFunctionColumns(null, null, descriptor.fqn(), null)
-					: meta.getProcedureColumns(null, null, descriptor.fqn(), null)) {
-				while (columns.next()) {
-					var type = columns.getInt("COLUMN_TYPE");
-					var ordinalPosition = columns.getInt("ORDINAL_POSITION");
+		try (var columns = descriptor.isFunctionCall() ? meta.getFunctionColumns(null, null, descriptor.fqn(), null)
+				: meta.getProcedureColumns(null, null, descriptor.fqn(), null)) {
+			while (columns.next()) {
+				var type = columns.getInt("COLUMN_TYPE");
+				var ordinalPosition = columns.getInt("ORDINAL_POSITION");
 
-					parameterOrder.put(columns.getString("COLUMN_NAME"), ordinalPosition);
+				parameterOrder.put(columns.getString("COLUMN_NAME"), ordinalPosition);
 
-					// It might be that those JDBC constants are actually the same right
-					// now,
-					// but that might as well change
-					// in a different JDK or "the future"
-					// noinspection ConditionCoveredByFurtherCondition,ConstantValue
-					if (type == DatabaseMetaData.procedureColumnIn || type == DatabaseMetaData.functionColumnIn) {
-						parameterTypes.put(ordinalPosition, columns.getString("DATA_TYPE"));
-					}
+				// It might be that those JDBC constants are actually the same right
+				// now,
+				// but that might as well change
+				// in a different JDK or "the future"
+				// noinspection ConditionCoveredByFurtherCondition,ConstantValue
+				if (type == DatabaseMetaData.procedureColumnIn || type == DatabaseMetaData.functionColumnIn) {
+					parameterTypes.put(ordinalPosition, columns.getString("DATA_TYPE"));
 				}
 			}
 		}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
@@ -1000,7 +1000,8 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 
 		var request = getRequest("getProcedureColumns", "results", intermediateResults, "columnNamePattern",
 				columnNamePattern, "columnType", DatabaseMetaData.procedureColumnIn, "nullable",
-				DatabaseMetaData.procedureNullableUnknown, "catalogAsParameterWorkaround", getSingleCatalog());
+				DatabaseMetaData.procedureNullableUnknown, "catalogAsParameterWorkaround", getSingleCatalog(),
+				"returnType", DatabaseMetadataImpl.procedureColumnResult);
 		return doQueryForResultSet(request);
 	}
 
@@ -1823,9 +1824,11 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 		assertSchemaIsPublicOrNull(schemaPattern);
 
 		var intermediateResults = getArgumentDescriptions("FUNCTIONS", functionNamePattern);
+
 		return doQueryForResultSet(getRequest("getFunctionColumns", "results", intermediateResults, "columnNamePattern",
 				columnNamePattern, "columnType", DatabaseMetaData.functionColumnIn, "nullable",
-				DatabaseMetaData.functionNullableUnknown, "catalogAsParameterWorkaround", getSingleCatalog()));
+				DatabaseMetaData.functionNullableUnknown, "catalogAsParameterWorkaround", getSingleCatalog(),
+				"returnType", DatabaseMetadataImpl.functionColumnResult));
 	}
 
 	private List<Map<String, Object>> getArgumentDescriptions(String category, String namePattern) throws SQLException {
@@ -1842,7 +1845,8 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 		try (var rs = doQueryForResultSet(request)) {
 			while (rs.next()) {
 				intermediateResults.add(Map.of("name", rs.getString("name"), "description", rs.getString("description"),
-						"argumentDescriptions", rs.getObject("argumentDescription")));
+						"argumentDescriptions", rs.getObject("argumentDescription"), "returnDescriptions",
+						rs.getObject("returnDescription")));
 			}
 		}
 		return intermediateResults;

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
@@ -1001,7 +1001,7 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 		var request = getRequest("getProcedureColumns", "results", intermediateResults, "columnNamePattern",
 				columnNamePattern, "columnType", DatabaseMetaData.procedureColumnIn, "nullable",
 				DatabaseMetaData.procedureNullableUnknown, "catalogAsParameterWorkaround", getSingleCatalog(),
-				"returnType", DatabaseMetadataImpl.procedureColumnResult);
+				"returnType", DatabaseMetaData.procedureColumnResult);
 		return doQueryForResultSet(request);
 	}
 
@@ -1828,7 +1828,7 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 		return doQueryForResultSet(getRequest("getFunctionColumns", "results", intermediateResults, "columnNamePattern",
 				columnNamePattern, "columnType", DatabaseMetaData.functionColumnIn, "nullable",
 				DatabaseMetaData.functionNullableUnknown, "catalogAsParameterWorkaround", getSingleCatalog(),
-				"returnType", DatabaseMetadataImpl.functionColumnResult));
+				"returnType", DatabaseMetaData.functionColumnResult));
 	}
 
 	private List<Map<String, Object>> getArgumentDescriptions(String category, String namePattern) throws SQLException {

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jConversions.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jConversions.java
@@ -66,6 +66,10 @@ final class Neo4jConversions {
 	 * 6
 	 */
 	static String oldCypherTypesToNew(String neo4jType) {
+		if (neo4jType == null) {
+			return "ANY";
+		}
+
 		String value = neo4jType;
 		if (value.startsWith("LIST<")) {
 			value = "LIST";
@@ -122,6 +126,10 @@ final class Neo4jConversions {
 	}
 
 	static Type valueOfV5Name(String in) {
+		if (in == null) {
+			return Type.ANY;
+		}
+
 		// See (2025-06-11)
 		// https://neo4j.com/docs/cypher-manual/current/values-and-types/property-structural-constructed/
 		var value = in.replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2")

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ParameterMetaDataImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ParameterMetaDataImpl.java
@@ -20,15 +20,29 @@ package org.neo4j.jdbc;
 
 import java.sql.ParameterMetaData;
 import java.sql.SQLException;
-import java.sql.Types;
+import java.util.Map;
 
 import static org.neo4j.jdbc.Neo4jException.withReason;
 
 class ParameterMetaDataImpl implements ParameterMetaData {
 
+	private final int parameterCount;
+
+	private final Map<Integer, String> parameterTypes;
+
+	ParameterMetaDataImpl(int parameterCount) {
+		this.parameterCount = parameterCount;
+		this.parameterTypes = Map.of();
+	}
+
+	ParameterMetaDataImpl(Map<Integer, String> parameterTypes) {
+		this.parameterCount = parameterTypes.size();
+		this.parameterTypes = Map.copyOf(parameterTypes);
+	}
+
 	@Override
 	public int getParameterCount() {
-		return 0;
+		return this.parameterCount;
 	}
 
 	@Override
@@ -53,12 +67,12 @@ class ParameterMetaDataImpl implements ParameterMetaData {
 
 	@Override
 	public int getParameterType(int param) {
-		return Types.NULL;
+		return Neo4jConversions.toSqlTypeFromOldCypherType(this.parameterTypes.get(param));
 	}
 
 	@Override
 	public String getParameterTypeName(int param) {
-		return null;
+		return Neo4jConversions.oldCypherTypesToNew(this.parameterTypes.get(param));
 	}
 
 	@Override
@@ -68,7 +82,7 @@ class ParameterMetaDataImpl implements ParameterMetaData {
 
 	@Override
 	public int getParameterMode(int param) {
-		return ParameterMetaData.parameterModeUnknown;
+		return ParameterMetaData.parameterModeIn;
 	}
 
 	@Override

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/PreparedStatementImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/PreparedStatementImpl.java
@@ -32,6 +32,7 @@ import java.sql.Connection;
 import java.sql.Date;
 import java.sql.NClob;
 import java.sql.ParameterMetaData;
+import java.sql.PreparedStatement;
 import java.sql.Ref;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -740,10 +741,19 @@ sealed class PreparedStatementImpl extends StatementImpl implements Neo4jPrepare
 		setParameter(computeParameterName(parameterIndex), (url != null) ? Values.value(url.toString()) : Values.NULL);
 	}
 
+	/**
+	 * The Neo4j JDBC Driver does not inspect prepared or callable statements, hence the
+	 * number of parameters will be only known after all parameters have been explicitly
+	 * set. As a consequence, the driver is also not aware of the actual type of
+	 * parameters for prepared statements, meaning for any prepared statement this method
+	 * is of limited use.
+	 * @return a restricted set of information about this statements parameter
+	 * @see PreparedStatement#getParameterMetaData()
+	 */
 	@Override
 	public ParameterMetaData getParameterMetaData() {
 		LOGGER.log(Level.FINER, () -> "Getting parameter meta data");
-		return new ParameterMetaDataImpl();
+		return new ParameterMetaDataImpl(this.getCurrentBatch().size());
 	}
 
 	@Override

--- a/neo4j-jdbc/src/main/resources/queries/DatabaseMetadata.properties
+++ b/neo4j-jdbc/src/main/resources/queries/DatabaseMetadata.properties
@@ -42,6 +42,33 @@ $procedureType AS PROCEDURE_TYPE, \
 PROCEDURE_NAME as SPECIFIC_NAME
 
 getProcedureColumns=UNWIND $results AS result \
+WITH result, range(0, size(result.returnDescriptions) - 1) AS ordinal_positions \
+UNWIND ordinal_positions AS ORDINAL_POSITION \
+WITH result, ORDINAL_POSITION \
+WHERE result.returnDescriptions[ORDINAL_POSITION].name = $columnNamePattern OR $columnNamePattern IS NULL OR $columnNamePattern = '%' \
+RETURN \
+$catalogAsParameterWorkaround AS PROCEDURE_CAT, \
+'public' AS PROCEDURE_SCHEM, \
+result.name AS PROCEDURE_NAME, \
+result.returnDescriptions[ORDINAL_POSITION].name AS COLUMN_NAME, \
+$returnType AS COLUMN_TYPE, \
+result.returnDescriptions[ORDINAL_POSITION].type AS DATA_TYPE, \
+NULL AS TYPE_NAME, \
+NULL AS PRECISION, \
+NULL AS LENGTH, \
+NULL AS SCALE, \
+NULL AS RADIX, \
+$nullable AS NULLABLE, \
+result.returnDescriptions[ORDINAL_POSITION].description AS REMARKS, \
+NULL AS COLUMN_DEF, \
+NULL AS SQL_DATA_TYPE, \
+NULL AS SQL_DATETIME_SUB, \
+NULL AS CHAR_OCTET_LENGTH, \
+ORDINAL_POSITION + 1 AS ORDINAL_POSITION, \
+'' AS IS_NULLABLE, \
+result.name AS SPECIFIC_NAME \
+UNION ALL \
+UNWIND $results AS result \
 WITH result, range(0, size(result.argumentDescriptions) - 1) AS ordinal_positions \
 UNWIND ordinal_positions AS ORDINAL_POSITION \
 WITH result, ORDINAL_POSITION \
@@ -52,7 +79,7 @@ $catalogAsParameterWorkaround AS PROCEDURE_CAT, \
 result.name AS PROCEDURE_NAME, \
 result.argumentDescriptions[ORDINAL_POSITION].name AS COLUMN_NAME, \
 $columnType AS COLUMN_TYPE, \
-NULL AS DATA_TYPE, \
+result.argumentDescriptions[ORDINAL_POSITION].type AS DATA_TYPE, \
 NULL AS TYPE_NAME, \
 NULL AS PRECISION, \
 NULL AS LENGTH, \
@@ -270,6 +297,26 @@ $functionType AS FUNCTION_TYPE, \
 FUNCTION_NAME AS SPECIFIC_NAME
 
 getFunctionColumns=UNWIND $results AS result \
+RETURN \
+$catalogAsParameterWorkaround AS FUNCTION_CAT, \
+'public' AS FUNCTION_SCHEM, \
+result.name AS FUNCTION_NAME, \
+NULL AS COLUMN_NAME, \
+$returnType AS COLUMN_TYPE, \
+result.returnDescriptions AS DATA_TYPE, \
+NULL AS TYPE_NAME, \
+NULL AS PRECISION, \
+NULL AS LENGTH, \
+NULL AS SCALE, \
+NULL AS RADIX, \
+$nullable AS NULLABLE, \
+NULL AS REMARKS, \
+NULL AS CHAR_OCTET_LENGTH, \
+0 AS ORDINAL_POSITION, \
+'' AS IS_NULLABLE, \
+result.name AS SPECIFIC_NAME \
+UNION ALL \
+UNWIND $results AS result \
 WITH result, range(0, size(result.argumentDescriptions) - 1) AS ordinal_positions \
 UNWIND ordinal_positions AS ORDINAL_POSITION \
 WITH result, ORDINAL_POSITION \
@@ -280,7 +327,7 @@ $catalogAsParameterWorkaround AS FUNCTION_CAT, \
 result.name AS FUNCTION_NAME, \
 result.argumentDescriptions[ORDINAL_POSITION].name AS COLUMN_NAME, \
 $columnType AS COLUMN_TYPE, \
-NULL AS DATA_TYPE, \
+result.argumentDescriptions[ORDINAL_POSITION].type AS DATA_TYPE, \
 NULL AS TYPE_NAME, \
 NULL AS PRECISION, \
 NULL AS LENGTH, \
@@ -293,7 +340,7 @@ ORDINAL_POSITION + 1 AS ORDINAL_POSITION, \
 '' AS IS_NULLABLE, \
 result.name AS SPECIFIC_NAME
 
-getArgumentDescriptions=SHOW %s YIELD name, description, argumentDescription \
+getArgumentDescriptions=SHOW %s YIELD name, description, argumentDescription, returnDescription \
 ORDER BY name \
 WHERE (name = $name OR $name IS NULL OR $name = '%%')
 

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/CallableStatementImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/CallableStatementImplTests.java
@@ -95,7 +95,7 @@ class CallableStatementImplTests {
 	void shouldSetParameter(StatementMethodRunner parameterSettingRunner, Value expectedValue)
 			throws SQLException, MalformedURLException, IllegalAccessException {
 		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), null,
-				false, "RETURN $x");
+				false, "RETURN $x", new ParameterMetaDataImpl(0));
 
 		parameterSettingRunner.run(this.statement);
 
@@ -191,7 +191,7 @@ class CallableStatementImplTests {
 	@MethodSource
 	void shouldThrowWhenClosed(StatementMethodRunner consumer) throws SQLException {
 		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), null,
-				false, TEST_STATEMENT);
+				false, TEST_STATEMENT, new ParameterMetaDataImpl(0));
 		this.statement.close();
 		assertThat(this.statement.isClosed()).isTrue();
 		assertThatThrownBy(() -> consumer.run(this.statement)).isInstanceOf(SQLException.class);
@@ -290,7 +290,7 @@ class CallableStatementImplTests {
 	@MethodSource
 	void shouldThrowUnsupported(StatementMethodRunner consumer, Class<? extends SQLException> exceptionType) {
 		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), null,
-				false, TEST_STATEMENT);
+				false, TEST_STATEMENT, new ParameterMetaDataImpl(0));
 		assertThatThrownBy(() -> consumer.run(this.statement)).isInstanceOf(exceptionType);
 	}
 
@@ -397,7 +397,7 @@ class CallableStatementImplTests {
 	void shouldUnwrap(Class<?> cls, boolean shouldUnwrap) throws SQLException {
 		// given
 		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), null,
-				false, TEST_STATEMENT);
+				false, TEST_STATEMENT, new ParameterMetaDataImpl(0));
 
 		// when & then
 		if (shouldUnwrap) {
@@ -414,7 +414,7 @@ class CallableStatementImplTests {
 	void shouldHandleIsWrapperFor(Class<?> cls, boolean shouldUnwrap) {
 		// given
 		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), null,
-				false, TEST_STATEMENT);
+				false, TEST_STATEMENT, new ParameterMetaDataImpl(0));
 
 		// when
 		var wrapperFor = this.statement.isWrapperFor(cls);
@@ -436,7 +436,7 @@ class CallableStatementImplTests {
 	void shouldNotAllowMixingParameterTypes(StatementMethodRunner firstSetter, StatementMethodRunner secondSetter)
 			throws MalformedURLException, SQLException, IllegalAccessException {
 		this.statement = new CallableStatementImpl(mock(Connection.class), mock(Neo4jTransactionSupplier.class), null,
-				false, TEST_STATEMENT);
+				false, TEST_STATEMENT, new ParameterMetaDataImpl(0));
 
 		try {
 			firstSetter.run(this.statement);

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ConnectionImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ConnectionImplTests.java
@@ -127,15 +127,6 @@ class ConnectionImplTests {
 	}
 
 	@Test
-	void shouldPrepareCall() throws SQLException {
-		var connection = makeConnection(mock(BoltConnection.class));
-
-		var statement = connection.prepareCall("RETURN pi()");
-
-		assertThat(statement).isNotNull();
-	}
-
-	@Test
 	void shouldCallTranslator() throws SQLException {
 		var translator = mock(Translator.class);
 		var sql = "SQL";

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ParameterMetaDataImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ParameterMetaDataImplTests.java
@@ -38,7 +38,7 @@ class ParameterMetaDataImplTests {
 
 	@Test
 	void shouldHaveNoParameterCount() {
-		this.metaData = new ParameterMetaDataImpl();
+		this.metaData = new ParameterMetaDataImpl(0);
 
 		assertThat(this.metaData.getParameterCount()).isEqualTo(0);
 	}
@@ -47,7 +47,7 @@ class ParameterMetaDataImplTests {
 	@MethodSource("getUnwrapArgs")
 	void shouldUnwrap(Class<?> cls, boolean shouldUnwrap) throws SQLException {
 		// given
-		this.metaData = new ParameterMetaDataImpl();
+		this.metaData = new ParameterMetaDataImpl(0);
 
 		// when & then
 		if (shouldUnwrap) {
@@ -61,9 +61,9 @@ class ParameterMetaDataImplTests {
 
 	@ParameterizedTest
 	@MethodSource("getUnwrapArgs")
-	void shouldHandleIsWrapperFor(Class<?> cls, boolean shouldUnwrap) throws SQLException {
+	void shouldHandleIsWrapperFor(Class<?> cls, boolean shouldUnwrap) {
 		// given
-		this.metaData = new ParameterMetaDataImpl();
+		this.metaData = new ParameterMetaDataImpl(0);
 
 		// when
 		var wrapperFor = this.metaData.isWrapperFor(cls);


### PR DESCRIPTION
Closes #1011.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
