### PR TITLE
fix: Allow coercion of map, list and points to string.

### DIFF
--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/StatementIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/StatementIT.java
@@ -421,23 +421,6 @@ class StatementIT extends IntegrationTestBase {
 		}
 	}
 
-	// GH-401
-	@Test
-	void noSurpriseGetString() throws SQLException {
-		try (var connection = getConnection();
-				var stmt = connection.createStatement();
-				var result = stmt.executeQuery("RETURN {a: '1', b: '2'} AS m, [1,2,3] AS l")) {
-
-			assertThat(result.next()).isTrue();
-			assertThatExceptionOfType(SQLException.class).isThrownBy(() -> result.getString("m"))
-				.withMessage("data exception - Cannot coerce {a: \"1\", b: \"2\"} (MAP) to String");
-			assertThat(result.getObject("m")).isInstanceOf(Map.class);
-			assertThatExceptionOfType(SQLException.class).isThrownBy(() -> result.getString("l"))
-				.withMessage("data exception - Cannot coerce [1, 2, 3] (LIST OF ANY?) to String");
-			assertThat(result.getObject("l")).isInstanceOf(List.class);
-		}
-	}
-
 	@Test
 	void pathsShouldBeAccessible() throws SQLException {
 		try (var connection = getConnection();

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ResultSetImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ResultSetImpl.java
@@ -94,8 +94,7 @@ final class ResultSetImpl implements Neo4jResultSet {
 	 */
 	static final int SUPPORTED_FETCH_DIRECTION = ResultSet.FETCH_FORWARD;
 
-	static final EnumSet<Type> NO_TO_STRING_SUPPORT = EnumSet.of(Type.NODE, Type.RELATIONSHIP, Type.PATH, Type.MAP,
-			Type.LIST);
+	static final EnumSet<Type> NO_TO_STRING_SUPPORT = EnumSet.of(Type.NODE, Type.RELATIONSHIP, Type.PATH);
 
 	private final StatementImpl statement;
 
@@ -1387,7 +1386,7 @@ final class ResultSetImpl implements Neo4jResultSet {
 			if (NO_TO_STRING_SUPPORT.stream().anyMatch(t -> t.isTypeOf(value))) {
 				throw new UncoercibleException(value.type().name(), "String");
 			}
-			return value.asObject().toString();
+			return value.toString();
 		}
 		catch (UncoercibleException ex) {
 			throw new Neo4jException(GQLError.$22N37.withTemplatedMessage(value.toDisplayString(), "String"));

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/AbstractValue.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/AbstractValue.java
@@ -118,7 +118,7 @@ abstract class AbstractValue extends AbstractMapAccessorWithDefaultValue impleme
 
 	@Override
 	public List<Object> asList() {
-		return asList(Values.ofObject());
+		return asList(Value::asObject);
 	}
 
 	@Override
@@ -128,7 +128,7 @@ abstract class AbstractValue extends AbstractMapAccessorWithDefaultValue impleme
 
 	@Override
 	public Map<String, Object> asMap() {
-		return asMap(Values.ofObject());
+		return asMap(Value::asObject);
 	}
 
 	@Override

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/ListValue.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/ListValue.java
@@ -47,12 +47,12 @@ public final class ListValue extends AbstractValue {
 
 	@Override
 	public List<Object> asObject() {
-		return asList(Values.ofObject());
+		return asList(Value::asObject);
 	}
 
 	@Override
 	public List<Object> asList() {
-		return list(this.values, Values.ofObject());
+		return list(this.values, Value::asObject);
 	}
 
 	@Override

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/MapValue.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/MapValue.java
@@ -45,12 +45,12 @@ public final class MapValue extends AbstractValue {
 
 	@Override
 	public Map<String, Object> asObject() {
-		return asMap(Values.ofObject());
+		return asMap(Value::asObject);
 	}
 
 	@Override
 	public Map<String, Object> asMap() {
-		return map(this.val, Values.ofObject());
+		return map(this.val, Value::asObject);
 	}
 
 	@Override

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Point2DImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Point2DImpl.java
@@ -26,6 +26,6 @@ record Point2DImpl(int srid, double x, double y) implements Point {
 
 	@Override
 	public String toString() {
-		return "Point{" + "srid=" + this.srid + ", x=" + this.x + ", y=" + this.y + '}';
+		return "point({srid:%d, x:%s, y:%s})".formatted(this.srid, this.x, this.y);
 	}
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Point3DImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Point3DImpl.java
@@ -18,9 +18,9 @@
  */
 package org.neo4j.jdbc.values;
 
-record Point3DImpl(int srid, double x, double y, double z) {
+record Point3DImpl(int srid, double x, double y, double z) implements Point {
 	@Override
 	public String toString() {
-		return "Point{" + "srid=" + this.srid + ", x=" + this.x + ", y=" + this.y + ", z=" + this.z + '}';
+		return "point({srid:%d, x:%s, y:%s, z:%s})".formatted(this.srid, this.x, this.y, this.z);
 	}
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/RecordImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/RecordImpl.java
@@ -93,7 +93,7 @@ final class RecordImpl extends AbstractMapAccessorWithDefaultValue implements Re
 
 	@Override
 	public Map<String, Object> asMap() {
-		return ValueUtils.map(this, Values.ofObject());
+		return ValueUtils.map(this, Value::asObject);
 	}
 
 	@Override

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ResultSetImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ResultSetImplTests.java
@@ -123,7 +123,7 @@ class ResultSetImplTests {
 								supplier -> assertThat(supplier.get()).isEqualTo("0"))),
 				Arguments.of(Values.value(true),
 						Named.<VerificationLogic<String>>of("verify throws exception",
-								supplier -> assertThat(supplier.get()).isEqualTo("true"))))
+								supplier -> assertThat(supplier.get()).isEqualTo("TRUE"))))
 			// map each set of arguments to both index and label access methods
 			.flatMap(ResultSetImplTests::mapArgumentToBothIndexAndLabelAccess);
 	}

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/values/GQLConformanceTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/values/GQLConformanceTests.java
@@ -30,6 +30,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
@@ -73,7 +74,8 @@ class GQLConformanceTests {
 						new Holder(Values.value(Duration.ofSeconds(150)), "DURATION 'PT2M30S'"),
 						new Holder(Values.value(Period.ofMonths(3).plusDays(1)), "P3M1D"),
 						new Holder(Values.value(Period.ofMonths(12)), "P1Y")),
-				newContainer("Collections", new Holder(Values.value(List.of(1, 2, 3, 4)), "[1, 2, 3, 4]")),
+				newContainer("Collections", new Holder(Values.value(List.of(1, 2, 3, 4)), "[1, 2, 3, 4]"),
+						new Holder(Values.value(Map.of("a", 1, "b", 2, "c", "haha")), "{a: 1, b: 2, c: \"haha\"}")),
 				newContainer("Strings", new Holder(Values.value("test"), "\"test\"")));
 	}
 


### PR DESCRIPTION
All of the mentioned types do have a defined (gql) compliant string representation, so we should use that in a coercsion to string.
