### PR TITLE
feat: Allow the retrieval of graph data as JsonNode objects.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -168,6 +168,8 @@ To use it with a Neo4j cluster, server-side routing must be enabled on the clust
 * Provides an optional default implementation to translate many SQL statements into semantically similar Cypher statements
 * Supports client-side Cypher-backed views
 * Can be safely used with JDBC connection pools as opposed to the common Neo4j Java Driver or any JDBC driver based on that, as it doesn't do internal connection pooling and transaction management otherwise than dictated by the JDBC Spec
+* Built-in token based authentication, including reauthentication on token expiration plus an optiona Keycloak based SSO module
+* Built-in JSON based Object mapping
 
 The absence of any connection pooling and transaction management is an advantage of the Neo4j JDBC Driver over the common Neo4j Java Driver.
 It allows to pick and choose any database connection pooling system such as https://github.com/brettwooldridge/HikariCP[HikariCP] and transaction management such as https://jakarta.ee/specifications/transactions/[Jakarta Transactions].

--- a/benchkit/pom.xml
+++ b/benchkit/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-benchkit</artifactId>
 

--- a/bundles/neo4j-jdbc-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/bundles/neo4j-jdbc-full-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-full-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 
@@ -59,6 +59,11 @@
 		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-jdbc-translator-impl</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
@@ -131,7 +136,9 @@
 						<configuration>
 							<artifactSet>
 								<includes>
-									<include>com.fasterxml.jackson.*:*</include>
+									<include>com.fasterxml.jackson.core:jackson-core</include>
+									<include>com.fasterxml.jackson.core:jackson-annotations</include>
+									<include>com.fasterxml.jackson.jr:*</include>
 									<include>io.github.cdimascio:dotenv-java</include>
 									<include>io.netty:*</include>
 									<include>io.r2dbc:*</include>
@@ -148,24 +155,28 @@
 							</artifactSet>
 							<relocations>
 								<relocation>
-									<pattern>com.fasterxml.jackson</pattern>
-									<shadedPattern>org.neo4j.jdbc.internal.shaded.jackson</shadedPattern>
+									<pattern>com.fasterxml.jackson.core</pattern>
+									<shadedPattern>org.neo4j.jdbc.internal.shaded.jackson.core</shadedPattern>
 								</relocation>
 								<relocation>
-									<pattern>META-INF/versions/11/com.fasterxml.jackson</pattern>
-									<shadedPattern>META-INF/versions/11/org.neo4j.jdbc.internal.shaded.jackson</shadedPattern>
+									<pattern>com.fasterxml.jackson.jr</pattern>
+									<shadedPattern>org.neo4j.jdbc.internal.shaded.jackson.jr</shadedPattern>
 								</relocation>
 								<relocation>
-									<pattern>META-INF/versions/17/com.fasterxml.jackson</pattern>
-									<shadedPattern>META-INF/versions/17/org.neo4j.jdbc.internal.shaded.jackson</shadedPattern>
+									<pattern>META-INF/versions/11/com.fasterxml.jackson.core</pattern>
+									<shadedPattern>META-INF/versions/11/org.neo4j.jdbc.internal.shaded.jackson.core</shadedPattern>
 								</relocation>
 								<relocation>
-									<pattern>META-INF/versions/21/com.fasterxml.jackson</pattern>
-									<shadedPattern>META-INF/versions/21/org.neo4j.jdbc.internal.shaded.jackson</shadedPattern>
+									<pattern>META-INF/versions/17/com.fasterxml.jackson.core</pattern>
+									<shadedPattern>META-INF/versions/17/org.neo4j.jdbc.internal.shaded.jackson.core</shadedPattern>
 								</relocation>
 								<relocation>
-									<pattern>META-INF/versions/22/com.fasterxml.jackson</pattern>
-									<shadedPattern>META-INF/versions/22/org.neo4j.jdbc.internal.shaded.jackson</shadedPattern>
+									<pattern>META-INF/versions/21/com.fasterxml.jackson.core</pattern>
+									<shadedPattern>META-INF/versions/21/org.neo4j.jdbc.internal.shaded.jackson.core</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/22/com.fasterxml.jackson.core</pattern>
+									<shadedPattern>META-INF/versions/22/org.neo4j.jdbc.internal.shaded.jackson.core</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>io.github.cdimascio.dotenv</pattern>

--- a/bundles/neo4j-jdbc-full-bundle/src/test/java/org/neo4j/jdbc/bundle/CypherBackedViewsBundleIT.java
+++ b/bundles/neo4j-jdbc-full-bundle/src/test/java/org/neo4j/jdbc/bundle/CypherBackedViewsBundleIT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.bundle;
+
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@Testcontainers(disabledWithoutDocker = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CypherBackedViewsBundleIT {
+
+	@SuppressWarnings("resource") // On purpose to reuse this
+	protected final Neo4jContainer<?> neo4j = new Neo4jContainer<>(System.getProperty("neo4j-jdbc.default-neo4j-image"))
+		.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+		.waitingFor(Neo4jContainer.WAIT_FOR_BOLT)
+		.withReuse(true);
+
+	@BeforeAll
+	void startNeo4j() {
+
+		this.neo4j.start();
+	}
+
+	@Test
+	void shadedJacksonJRShouldWork() throws SQLException {
+
+		try (var connection = DriverManager.getConnection(
+				"jdbc:neo4j://%s:%d?enableSQLTranslation=true&viewDefinitions=%s".formatted(this.neo4j.getHost(),
+						this.neo4j.getMappedPort(7687),
+						Objects.requireNonNull(this.getClass().getResource("/it-views.json")).toString()),
+				"neo4j", this.neo4j.getAdminPassword()); var stmt = connection.createStatement()) {
+
+			ResultSet labels = connection.getMetaData().getTables(null, null, "cbv1", null);
+			assertThat(labels).isNotNull();
+			List<String> tableNames = new ArrayList<>();
+
+			while (labels.next()) {
+				var tableName = labels.getString("TABLE_NAME");
+				tableNames.add(tableName);
+				if (tableName.startsWith("cbv")) {
+					assertThat(labels.getString("TABLE_TYPE")).isEqualTo("CBV");
+				}
+			}
+
+			assertThat(tableNames).containsExactly("cbv1");
+			assertThatNoException().isThrownBy(() -> stmt.executeQuery("SELECT * FROM cbv1 WHERE a = 'The Matrix'"));
+		}
+
+	}
+
+}

--- a/bundles/neo4j-jdbc-full-bundle/src/test/java/org/neo4j/jdbc/bundle/JacksonBundleIT.java
+++ b/bundles/neo4j-jdbc-full-bundle/src/test/java/org/neo4j/jdbc/bundle/JacksonBundleIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.bundle;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers(disabledWithoutDocker = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JacksonBundleIT {
+
+	@SuppressWarnings("resource") // On purpose to reuse this
+	protected final Neo4jContainer<?> neo4j = new Neo4jContainer<>(System.getProperty("neo4j-jdbc.default-neo4j-image"))
+		.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+		.waitingFor(Neo4jContainer.WAIT_FOR_BOLT)
+		.withReuse(true);
+
+	@BeforeAll
+	void startNeo4j() {
+
+		this.neo4j.start();
+	}
+
+	@Test
+	void jacksonMapperShouldBeFoundFromBundle() throws SQLException {
+		try (var connection = DriverManager.getConnection(
+				"jdbc:neo4j://%s:%d".formatted(this.neo4j.getHost(), this.neo4j.getMappedPort(7687)), "neo4j",
+				this.neo4j.getAdminPassword()); var stmt = connection.createStatement();) {
+			var result = stmt.executeQuery("""
+					RETURN true AS bv
+					""");
+
+			assertThat(result.next()).isTrue();
+			var json = result.getObject("bv", JsonNode.class);
+			assertThat(json.isValueNode()).isTrue();
+		}
+	}
+
+}

--- a/bundles/neo4j-jdbc-full-bundle/src/test/resources/it-views.json
+++ b/bundles/neo4j-jdbc-full-bundle/src/test/resources/it-views.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "cbv1",
+    "query": "MATCH (n:Movie)<-[:ACTED_IN]-(:Person) RETURN *",
+    "columns": [
+      {
+        "name": "a",
+        "propertyName": "n.title",
+        "type": "STRING"
+      },
+      {
+        "name": "c1",
+        "propertyName": "n.released",
+        "type": "INTEGER"
+      }
+    ]
+  }
+]

--- a/bundles/neo4j-jdbc-text2cypher-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-text2cypher-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-dist</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-docs</artifactId>

--- a/docs/src/main/asciidoc/modules/ROOT/nav.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/nav.adoc
@@ -4,6 +4,7 @@
 * xref:metadata.adoc[]
 * xref:sql2cypher.adoc[]
 * xref:cypher_backed_views.adoc[]
+* xref:object_mapping.adoc[]
 * xref:text2cypher.adoc[]
 * xref:datatypes.adoc[]
 * xref:syntax.adoc[]

--- a/docs/src/main/asciidoc/modules/ROOT/pages/index.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/pages/index.adoc
@@ -52,6 +52,8 @@ include::sql2cypher.adoc[leveloffset=+1]
 
 include::cypher_backed_views.adoc[leveloffset=+1]
 
+include::object_mapping.adoc[leveloffset=+1]
+
 include::text2cypher.adoc[leveloffset=+1]
 
 [appendix]

--- a/docs/src/main/asciidoc/modules/ROOT/pages/object_mapping.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/pages/object_mapping.adoc
@@ -1,0 +1,182 @@
+[#object_mapping]
+= Object mapping
+
+== Introduction
+
+There are many different tools to do Object–relational mapping (ORM, O/RM, and O/R mapping tool) with JDBC and the Neo4j JDBC driver does support some of them, such as MyBatis or result-set / tuple oriented mapping with tools such as JDBI or Springs JDBC template.
+However, many of those tools also generate SQL queries and often times depend on very specific SQL functionality, that we cannot fully translate in our xref:sql2cypher.adoc#s2c_introduction[SQL to Cypher translation], and therefor, your milage may vary.
+
+TIP: The most "graphy" ways of Object mapping with Neo4j are either https://github.com/neo4j/neo4j-ogm[Neo4j-OGM], which is offered with integrations for Spring and Quarkus, or https://github.com/spring-projects/spring-data-neo4j[Spring Data Neo4j]. Both solutions are built on top of the https://github.com/neo4j/neo4j-java-driver[common Neo4j Java Driver]. Those solutions are favorable if you are looking for an end-to-end solution with repository support and advanced mapping and query capabilities.
+
+Sometimes, simple solutions are enough however and one solution that might be already enough is an easy and direct way of mapping graph data to JSON objects and passing back JSON objects into queries.
+The JDBC spec allows for getting and setting arbitrary objects of arbitrary types via the `ResultSet` and `PreparedStatement` types and
+the Neo4j JDBC driver utilizes those for turning nodes and relationships into JSON objects.
+
+As there is no standard JSON object in the JDK, this functionality requires additional, optional dependencies as described in the following sections.
+
+=== With Jackson Databind
+
+The Neo4j JDBC Driver can utilise https://github.com/FasterXML/jackson-databind[Jackson Databind] to transform graph objects into JSON Nodes and read back those objects into maps usable in Cypher queries.
+
+Put the following dependency on your class- or module path to enable mapping into objects of type `JsonNode`:
+
+[source,xml]
+.Required dependency for Object mapping through Jackson Databind
+----
+<dependency>
+    <groupId>com.fasterxml.jackson.core</groupId>
+    <artifactId>jackson-databind</artifactId>
+    <version>2.19.1</version>
+</dependency>
+----
+
+You now can pass `JsonObject.class` as type parameter to any overload of `getObject` on a `ResultSet` that supports a type parameter to retrieve JSON like this:
+
+[source, java, tabsize=4, indent=0]
+.Retrieving a list of nodes as JSON Array
+----
+import java.io.StringWriter;
+import java.sql.DriverManager;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+public class ReadNodesIntoJson {
+
+	public static void main(String... args) throws Exception {
+
+		var objectMapper = new ObjectMapper();
+		objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+		objectMapper.enable(JsonGenerator.Feature.IGNORE_UNKNOWN);
+
+		try (var connection = DriverManager.getConnection("jdbc:neo4j://localhost:7687/movies", "neo4j", "verysecret");
+				var stmt = connection.createStatement()) {
+
+			var result = stmt.executeQuery("""
+					MATCH (n:Movie) LIMIT 2
+					WITH n RETURN collect(n) AS movies
+					""");
+			result.next();
+
+			var json = result.getObject("movies", JsonNode.class);
+			var sw = new StringWriter();
+			objectMapper.writeTree(objectMapper.createGenerator(sw), json);
+			System.out.println(sw);
+		}
+	}
+}
+----
+
+The output will look similar to this:
+
+[source,json]
+----
+[ {
+  "elementId" : "4:5c0c7e77-4034-45a1-ab00-a159be8dbf04:0",
+  "labels" : [ "Movie" ],
+  "properties" : {
+    "title" : "The Matrix",
+    "tagline" : "Welcome to the Real World",
+    "released" : 1999
+  }
+}, {
+  "elementId" : "4:5c0c7e77-4034-45a1-ab00-a159be8dbf04:9",
+  "labels" : [ "Movie" ],
+  "properties" : {
+    "title" : "The Matrix Reloaded",
+    "tagline" : "Free your mind",
+    "released" : 2003
+  }
+} ]
+----
+
+You'll notice that the nodes carry their element id, a list of labels and a property object.
+This structure is aligned with the https://neo4j.com/docs/query-api/current/result-formats/[Query API], so that any mapping will be similar to deal with. The JDBC driver however will always use the "Plain JSON" format, so that further mapping into domain objects will be as straight forward as possible, without custom deserializers.
+
+Here's one example that shows a query that structures the result of matching all movies and their actors into maps, collects them as a list, retrieves that again as a JSON node, which can ultimately mapped by Jacksons Object mapper into a list of domain objects:
+
+[source, java, tabsize=4, indent=0]
+.Mapping JSON nodes into domain objects
+----
+import java.sql.DriverManager;
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class MapNodesIntoObjects {
+
+	public static void main(String... args) throws Exception {
+
+		var objectMapper = new ObjectMapper();
+
+		record Actor(String name, short born) {
+		}
+		record Movie(String title, short released, List<Actor> actors) {
+		}
+
+		try (var connection = DriverManager.getConnection("jdbc:neo4j://localhost:7687/movies", "neo4j",
+				"verysecret"); var stmt = connection.createStatement()) {
+
+			var result = stmt.executeQuery("""
+					MATCH (m:Movie)<-[:ACTED_IN]-(a:Person)
+					WITH m, collect(a{.*}) AS actors
+					ORDER BY m.title
+					LIMIT 5
+					RETURN collect({title: m.title, released: m.released, actors: actors})
+					""");
+			result.next();
+
+			var json = result.getObject(1, JsonNode.class); // <.>
+			var movies = objectMapper.treeToValue(json, new TypeReference<List<Movie>>() {}); // <.>
+
+			movies.forEach(System.out::println);
+		}
+	}
+}
+----
+<.> First retrieve the list as Json array again
+<.> Use Jacksons `ObjectMapper` to map that array into a list of `Movie` objects containing their actors
+
+Of course, writing back JSON nodes does work, too:
+
+[source, java, tabsize=4, indent=0]
+.Using JSON Nodes as parameters
+----
+import java.sql.DriverManager;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class WritingObjects {
+
+	public static void main(String... args) throws Exception {
+
+		var objectMapper = new ObjectMapper();
+
+		record Movie(String title, String tagline, long released) {
+		}
+
+		var movie = new Movie("title", "tagline", 2025);
+		try (var connection = DriverManager.getConnection("jdbc:neo4j://localhost:7687/movies", "neo4j",
+				"verysecret"); var stmt = connection.prepareStatement("CREATE (m:Movie $1) RETURN m")) {
+			stmt.setObject(1, objectMapper.valueToTree(movie));
+			var rs = stmt.executeQuery();
+			rs.next();
+			var json = rs.getObject("m", JsonNode.class);
+			var newMovie = objectMapper.treeToValue(json.get("properties"), Movie.class);
+			System.out.println("New movie " + newMovie + " has id " + json.get("elementId"));
+		}
+	}
+}
+----
+
+It will produce output similar to this:
+
+[source,text]
+----
+New movie Movie[title=title, tagline=tagline, released=2025] has id "4:5c0c7e77-4034-45a1-ab00-a159be8dbf04:173"
+----

--- a/neo4j-jdbc-authn/kc/pom.xml
+++ b/neo4j-jdbc-authn/kc/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-authn</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-authn-kc</artifactId>

--- a/neo4j-jdbc-authn/pom.xml
+++ b/neo4j-jdbc-authn/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-authn</artifactId>
 

--- a/neo4j-jdbc-authn/spi/pom.xml
+++ b/neo4j-jdbc-authn/spi/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-authn</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-authn-spi</artifactId>

--- a/neo4j-jdbc-bom/pom.xml
+++ b/neo4j-jdbc-bom/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-bom</artifactId>

--- a/neo4j-jdbc-it/hibernate-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-hibernate-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/mybatis-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/mybatis-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-mybatis-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-cp</artifactId>
 
@@ -37,6 +37,11 @@
 	</properties>
 
 	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>com.github.stefanbirkner</groupId>
 			<artifactId>system-lambda</artifactId>
@@ -93,19 +98,19 @@
 					<execution>
 						<configuration combine.self="append">
 							<excludes>
-								<exclude>org.neo4j.jdbc.it.cp.Neo4jDriverExtensionsIT</exclude>
+								<exclude>**/Neo4jDriverExtensionsIT.java</exclude>
 							</excludes>
 						</configuration>
 					</execution>
 					<execution>
-						<id>modified_env</id>
+						<id>driver_extension</id>
 						<goals>
 							<goal>integration-test</goal>
 							<goal>verify</goal>
 						</goals>
 						<configuration>
 							<includes>
-								<include>org.neo4j.jdbc.it.cp.Neo4jDriverExtensionsIT</include>
+								<include>**/Neo4jDriverExtensionsIT.java</include>
 							</includes>
 							<!-- Needed to modify system environment variables in this particular test, don't want to have it everywhere. -->
 							<argLine>@{argLine} --add-opens java.base/java.util=ALL-UNNAMED</argLine>

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/GQLCodesIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/GQLCodesIT.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.jdbc.it.cp;
 
+import java.math.BigDecimal;
 import java.sql.SQLException;
 
 import org.junit.jupiter.api.Test;
@@ -60,6 +61,9 @@ class GQLCodesIT extends IntegrationTestBase {
 			assertThatNoException().isThrownBy(() -> rs.getDate(1));
 
 			assertThatExceptionOfType(SQLException.class).isThrownBy(() -> rs.getBigDecimal(2))
+				.withMessage("data exception - Cannot coerce \"abc\" (STRING) to java.math.BigDecimal")
+				.matches(ex -> "22N37".equals(ex.getSQLState()));
+			assertThatExceptionOfType(SQLException.class).isThrownBy(() -> rs.getObject(2, BigDecimal.class))
 				.withMessage("data exception - Cannot coerce \"abc\" (STRING) to java.math.BigDecimal")
 				.matches(ex -> "22N37".equals(ex.getSQLState()));
 			assertThatExceptionOfType(SQLException.class).isThrownBy(() -> rs.getDouble(2))

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/IntegrationTestBase.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/IntegrationTestBase.java
@@ -49,6 +49,8 @@ abstract class IntegrationTestBase {
 	@SuppressWarnings("resource") // On purpose to reuse this
 	protected final Neo4jContainer<?> neo4j;
 
+	protected boolean doClean = true;
+
 	protected Driver driver;
 
 	@BeforeAll
@@ -75,6 +77,9 @@ abstract class IntegrationTestBase {
 
 	@BeforeEach
 	void clearDatabase() throws SQLException {
+		if (!this.doClean) {
+			return;
+		}
 		try (var connection = this.getConnection(); var stmt = connection.createStatement()) {
 			stmt.execute("""
 					MATCH (n)

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/JacksonIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/JacksonIT.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.it.cp;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatRuntimeException;
+
+/**
+ * Mapping tests are disabled in native image so that we don't have to register the
+ * records. Only the fact that JSON mappers can be loaded must be asserted in native
+ * image.
+ */
+class JacksonIT extends IntegrationTestBase {
+
+	private final ObjectMapper objectMapper;
+
+	JacksonIT() {
+		super.doClean = false;
+
+		this.objectMapper = new ObjectMapper();
+		this.objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+		this.objectMapper.enable(JsonGenerator.Feature.IGNORE_UNKNOWN);
+	}
+
+	@BeforeAll
+	void prepareData() throws SQLException, IOException {
+		try (var connection = getConnection()) {
+			connection.setAutoCommit(false);
+			var stmt = connection.createStatement();
+			stmt.executeQuery("MATCH (n) DETACH DELETE n");
+			TestUtils.createMovieGraph(connection);
+			connection.setAutoCommit(true);
+		}
+	}
+
+	@Test
+	void jsonMappingShouldWork() throws SQLException {
+		try (var connection = getConnection(); var stmt = connection.createStatement()) {
+			var result = stmt.executeQuery("""
+					RETURN true AS bv
+					""");
+
+			assertThat(result.next()).isTrue();
+			var json = result.getObject("bv", JsonNode.class);
+			assertThat(json.isValueNode()).isTrue();
+		}
+	}
+
+	@Test
+	@DisabledInNativeImage
+	void nodeMappingShouldWork() throws SQLException, IOException {
+
+		try (var connection = getConnection(); var stmt = connection.createStatement()) {
+			var result = stmt.executeQuery("""
+					MATCH (n:Movie {title: 'The Matrix'})
+					RETURN n AS movieNode,
+					       n{.*} AS movieMap,
+					       [n] AS movieList,
+					       [n{.*}] AS movieMapList,
+					       elementId(n) AS elementId
+					""");
+
+			assertThat(result.next()).isTrue();
+
+			var elementId = result.getString("elementId");
+			var expectedJson = """
+					{
+					  "elementId" : "%s",
+					  "labels" : [ "Movie" ],
+					  "properties" : {
+					    "title" : "The Matrix",
+					    "tagline" : "Welcome to the Real World",
+					    "released" : 1999
+					  }
+					}""".formatted(elementId);
+
+			// Given the JDBC driver returns a graph node as JsonNode
+			var json = result.getObject("movieNode", JsonNode.class);
+
+			// then the json node is an object node
+			assertThat(json.isObject()).isTrue();
+
+			// then the object node adheres to the same format as the Query api
+			assertThat(prettyPrint(json)).isEqualTo(expectedJson);
+
+			record Movie(String title, String tagline, int released) {
+			}
+
+			Consumer<Movie> assertMovie = movie -> {
+				assertThat(movie.title).isEqualTo("The Matrix");
+				assertThat(movie.tagline).isEqualTo("Welcome to the Real World");
+				assertThat(movie.released).isEqualTo(1999);
+			};
+
+			// then it can easily be further processed by $someoneElsesTooling
+			assertMovie.accept(this.objectMapper.treeToValue(json.get("properties"), Movie.class));
+
+			// then the same should apply to a map
+			var map = result.getObject("movieMap", JsonNode.class);
+			assertMovie.accept(this.objectMapper.treeToValue(map, Movie.class));
+
+			// then it should be able to deal with lists of nodes
+			for (var element : result.getObject("movieList", JsonNode.class)) {
+				assertMovie.accept(this.objectMapper.treeToValue(element.get("properties"), Movie.class));
+			}
+
+			// then it also should be able to deal with a list of maps
+			for (var element : result.getObject("movieMapList", JsonNode.class)) {
+				assertMovie.accept(this.objectMapper.treeToValue(element, Movie.class));
+			}
+		}
+	}
+
+	@Test
+	@DisabledInNativeImage
+	void relationshipMappingShouldWork() throws SQLException, IOException {
+
+		try (var connection = getConnection(); var stmt = connection.createStatement()) {
+			var result = stmt.executeQuery("""
+					MATCH (:Movie {title: 'Cloud Atlas'})<-[r:ACTED_IN]-()
+					RETURN r AS actedNode,
+					       r{.*} AS actedMap,
+					       [r] AS actedList,
+					       [r{.*}] AS actedMapList,
+					       r.roles AS roles,
+					       elementId(r) AS elementId,
+					       elementId(startNode(r)) AS startNodeElementId,
+					       elementId(endNode(r)) AS endNodeElementId
+					""");
+
+			record Acted(List<String> roles) {
+			}
+
+			var results = new AtomicBoolean();
+			while (result.next()) {
+				results.compareAndSet(false, true);
+				@SuppressWarnings("unchecked")
+				var roles = (List<String>) result.getObject("roles", List.class);
+				var elementId = result.getString("elementId");
+				var expectedJson = """
+						{
+						  "elementId" : "%s",
+						  "startNodeElementId" : "%s",
+						  "endNodeElementId" : "%s",
+						  "type" : "ACTED_IN",
+						  "properties" : {
+						    "roles" : %s
+						  }
+						}""".formatted(elementId, result.getString("startNodeElementId"),
+						result.getString("endNodeElementId"),
+						roles.stream().map("\"%s\""::formatted).collect(Collectors.joining(", ", "[ ", " ]")));
+
+				// Given the JDBC driver returns a graph node as JsonNode
+				var json = result.getObject("actedNode", JsonNode.class);
+
+				// then the json node is an object node
+				assertThat(json.isObject()).isTrue();
+
+				// then the object node adheres to the same format as the Query api
+				assertThat(prettyPrint(json)).isEqualTo(expectedJson);
+
+				Consumer<Acted> assertActed = acted -> assertThat(acted.roles)
+					.containsExactlyInAnyOrderElementsOf(roles);
+
+				// then it can easily be further processed by $someoneElsesTooling
+				assertActed.accept(this.objectMapper.treeToValue(json.get("properties"), Acted.class));
+
+				// then the same should apply to a map
+				var map = result.getObject("actedMap", JsonNode.class);
+				assertActed.accept(this.objectMapper.treeToValue(map, Acted.class));
+
+				// then it should be able to deal with lists of relationships
+				for (var element : result.getObject("actedList", JsonNode.class)) {
+					assertActed.accept(this.objectMapper.treeToValue(element.get("properties"), Acted.class));
+				}
+
+				// then it also should be able to deal with a list of maps
+				for (var element : result.getObject("actedMapList", JsonNode.class)) {
+					assertActed.accept(this.objectMapper.treeToValue(element, Acted.class));
+				}
+			}
+			assertThat(results).isTrue();
+		}
+	}
+
+	@Test
+	@DisabledInNativeImage
+	void pathMappingShouldWork() throws SQLException {
+		try (var connection = getConnection(); var stmt = connection.createStatement()) {
+			var result = stmt.executeQuery("""
+					MATCH p=(actor:Person)-[:ACTED_IN]->(movie:Movie)<-[:DIRECTED]-(director:Person)
+					RETURN p
+					""");
+
+			assertThat(result.next()).isTrue();
+			assertThatNoException().isThrownBy(() -> result.getObject("p", JsonNode.class));
+			assertThatNoException().isThrownBy(() -> result.getObject("p", ArrayNode.class));
+		}
+	}
+
+	@Test
+	void shouldNotMapToWrongType() throws SQLException {
+		try (var connection = getConnection(); var stmt = connection.createStatement()) {
+			var result = stmt.executeQuery("""
+					MATCH p=(actor:Person)-[:ACTED_IN]->(movie:Movie)<-[:DIRECTED]-(director:Person)
+					RETURN p
+					""");
+
+			assertThat(result.next()).isTrue();
+			assertThatRuntimeException().isThrownBy(() -> result.getObject("p", ObjectNode.class))
+				.withMessage(
+						"Resulting type after mapping is incompatible, use com.fasterxml.jackson.databind.node.ArrayNode or com.fasterxml.jackson.databind.JsonNode for reification");
+		}
+	}
+
+	@Test
+	@DisabledInNativeImage
+	void javaDriverMappingExamplesShouldWorkToo() throws SQLException, JsonProcessingException {
+		record MovieInfo(String title, String director, List<String> actors) {
+		}
+
+		try (var connection = getConnection(); var stmt = connection.createStatement()) {
+			var result = stmt.executeQuery("""
+					MATCH (actor:Person)-[:ACTED_IN]->(movie:Movie)<-[:DIRECTED]-(director:Person)
+					WITH movie.title AS title, director.name AS director, collect(actor.name) AS actors
+					RETURN {title: title, director: director, actors: actors}
+					""");
+
+			var results = new AtomicBoolean();
+			while (result.next()) {
+				results.compareAndSet(false, true);
+				var json = result.getObject(1, JsonNode.class);
+				var movieInfo = this.objectMapper.treeToValue(json, MovieInfo.class);
+				assertThat(movieInfo.title).isNotNull();
+				assertThat(movieInfo.director).isNotNull();
+				assertThat(movieInfo.actors).isNotEmpty();
+			}
+
+			assertThat(results).isTrue();
+
+		}
+	}
+
+	@Test
+	@DisabledInNativeImage
+	void writingShouldWork() throws Exception {
+		record Movie(String title, String tagline, long released) {
+		}
+
+		var movie = new Movie("title", "tagline", 2025);
+		try (var connection = getConnection(); var stmt = connection.prepareStatement("CREATE (m:Movie $1) RETURN m")) {
+			stmt.setObject(1, this.objectMapper.valueToTree(movie));
+			var rs = stmt.executeQuery();
+			assertThat(rs.next()).isTrue();
+			var json = rs.getObject("m", JsonNode.class);
+			assertThat(json.get("elementId")).isNotNull();
+			var newMovie = this.objectMapper.treeToValue(json.get("properties"), Movie.class);
+			assertThat(newMovie.title).isEqualTo("title");
+		}
+	}
+
+	private String prettyPrint(JsonNode json) throws IOException {
+		var sw = new StringWriter();
+		var gen = this.objectMapper.createGenerator(sw);
+		gen.writeTree(json);
+		return sw.toString();
+	}
+
+}

--- a/neo4j-jdbc-it/neo4j-jdbc-it-mp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-mp/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-mp</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-sso/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-sso/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-sso</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-stub/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-stub/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-stub</artifactId>
 

--- a/neo4j-jdbc-it/pom.xml
+++ b/neo4j-jdbc-it/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it</artifactId>
 

--- a/neo4j-jdbc-it/quarkus-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/quarkus-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-quarkus-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/spring-boot-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/spring-boot-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-spring-boot-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-test-results/pom.xml
+++ b/neo4j-jdbc-test-results/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-test-results</artifactId>

--- a/neo4j-jdbc-tracing/micrometer/pom.xml
+++ b/neo4j-jdbc-tracing/micrometer/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-tracing</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-tracing-micrometer</artifactId>

--- a/neo4j-jdbc-tracing/pom.xml
+++ b/neo4j-jdbc-tracing/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-tracing</artifactId>
 

--- a/neo4j-jdbc-translator/impl/pom.xml
+++ b/neo4j-jdbc-translator/impl/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-impl</artifactId>

--- a/neo4j-jdbc-translator/pom.xml
+++ b/neo4j-jdbc-translator/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-translator</artifactId>
 

--- a/neo4j-jdbc-translator/sparkcleaner/pom.xml
+++ b/neo4j-jdbc-translator/sparkcleaner/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-sparkcleaner</artifactId>

--- a/neo4j-jdbc-translator/spi/pom.xml
+++ b/neo4j-jdbc-translator/spi/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-spi</artifactId>

--- a/neo4j-jdbc-translator/text2cypher/pom.xml
+++ b/neo4j-jdbc-translator/text2cypher/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-text2cypher-translator</artifactId>

--- a/neo4j-jdbc/pom.xml
+++ b/neo4j-jdbc/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.6.2-SNAPSHOT</version>
+		<version>6.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc</artifactId>
@@ -51,6 +51,11 @@
 	</dependencyManagement>
 
 	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>io.github.cdimascio</groupId>
 			<artifactId>dotenv-java</artifactId>
@@ -114,6 +119,49 @@
 			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-test</id>
+						<configuration combine.self="override">
+							<excludes>
+								<exclude>**/JSONMappersTests.java</exclude>
+							</excludes>
+						</configuration>
+					</execution>
+
+					<execution>
+						<id>json_mappers_with_deps</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<useModulePath>false</useModulePath>
+							<includes>
+								<include>**/JSONMappersTests.java</include>
+							</includes>
+						</configuration>
+					</execution>
+					<execution>
+						<id>json_mappers_without_deps</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<useModulePath>false</useModulePath>
+							<includes>
+								<include>**/JSONMappersTests.java</include>
+							</includes>
+							<argLine>@{argLine} -DwithoutRequiredJSONDependencies=true</argLine>
+							<classpathDependencyExcludes>
+								<dependency>com.fasterxml.jackson.core:jackson-databind</dependency>
+							</classpathDependencyExcludes>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/neo4j-jdbc/src/main/java/module-info.java
+++ b/neo4j-jdbc/src/main/java/module-info.java
@@ -23,6 +23,7 @@
 module org.neo4j.jdbc {
 	requires transitive java.sql;
 	requires static micrometer.core;
+	requires static com.fasterxml.jackson.databind;
 
 	// start::shaded-dependencies
 	requires io.github.cdimascio.dotenv.java;

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JSONMapper.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JSONMapper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc;
+
+import org.neo4j.jdbc.values.Value;
+
+/**
+ * A mapper from {@link Value values} to arbitrary JSON types. A {@code JSONMapper} has a
+ * base type ({@link #getBaseType()}) that represents a JSON type that the given mapper
+ * can handle, such as {@code com.fasterxml.jackson.databind.JsonNode} or
+ * {@code javax.json.JsonValue}. The base type will be used programmatically only to
+ * generate helpful error messages, as the JDBC driver wants to avoid any premature
+ * initialisation of optional types (i.e. the JDBC driver only optionally depends on
+ * Jackson databind). Hence, all mappers must be registered manually in
+ * {@link JSONMappers}.
+ *
+ * @param <T> the JSON type this mapper can produce
+ * @author Michael J. Simons
+ * @since 6.7.0
+ */
+interface JSONMapper<T> {
+
+	/**
+	 * Converts a Neo4j {@link Value} to a JSON object supported by this mapper. This
+	 * method should be {@literal null} safe, meaning that for a {@literal null} input a
+	 * Null-representation is returned and no exception should be thrown.
+	 * @param value the value to convert
+	 * @return a JSON value
+	 */
+	T toJson(Value value);
+
+	/**
+	 * Converts a JSON object supported by this mapper to a Neo4j {@link Value}. A
+	 * {@literal null} JSON object or a null representation must be converted to
+	 * {@link org.neo4j.jdbc.values.Values#NULL}.
+	 * @param json the json value to convert
+	 * @return a Neo4j value
+	 */
+	Value fromJson(Object json);
+
+	/**
+	 * {@return the JSON base type supported by this mapper}
+	 */
+	Class<T> getBaseType();
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JSONMappers.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JSONMappers.java
@@ -57,7 +57,8 @@ enum JSONMappers {
 			try {
 				var type = Class.forName(typeName);
 
-				for (@SuppressWarnings("squid:S2864") var mappedTypedName : KNOWN_MAPPERS.keySet()) {
+				for (@SuppressWarnings("squid:S2864")
+				var mappedTypedName : KNOWN_MAPPERS.keySet()) {
 					var mappedType = Class.forName(mappedTypedName, false, JSONMappers.class.getClassLoader());
 					if (mappedType.isAssignableFrom(type)) {
 						mapperClass = KNOWN_MAPPERS.get(mappedTypedName);

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JSONMappers.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JSONMappers.java
@@ -45,6 +45,7 @@ enum JSONMappers {
 	@SuppressWarnings("squid:S1452") // Generic items, this is exactly what we want here
 	private final Map<String, Optional<JSONMapper<?>>> loadedMappers = new ConcurrentHashMap<>();
 
+	@SuppressWarnings("squid:S1452") // With little surprise, here as well...
 	public Optional<JSONMapper<?>> getMapper(String typeName) {
 		return this.loadedMappers.computeIfAbsent(typeName, JSONMappers::loadMapper);
 	}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JSONMappers.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JSONMappers.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Access to our JSON Mappers, very indirect to avoid touch any classes in a premature
+ * fashion.
+ *
+ * @author Michael J. Simons
+ * @since 6.7.0
+ */
+enum JSONMappers {
+
+	/** Single instance of this utility class. */
+	INSTANCE;
+
+	private static final Logger LOGGER = Logger.getLogger(JSONMappers.class.getName());
+
+	private static final Map<String, String> KNOWN_MAPPERS = Map.of("com.fasterxml.jackson.databind.JsonNode",
+			"JacksonJSONMapperImpl");
+
+	private final Map<String, Optional<JSONMapper<?>>> loadedMappers = new ConcurrentHashMap<>();
+
+	public Optional<JSONMapper<?>> getMapper(String typeName) {
+		return this.loadedMappers.computeIfAbsent(typeName, JSONMappers::loadMapper);
+	}
+
+	private static Optional<JSONMapper<?>> loadMapper(String typeName) {
+
+		var mapperClass = KNOWN_MAPPERS.get(typeName);
+		if (mapperClass == null) {
+			// If this isn't preconfigured, we compare types and assignability
+			try {
+				var type = Class.forName(typeName);
+
+				for (var mappedTypedName : KNOWN_MAPPERS.keySet()) {
+					var mappedType = Class.forName(mappedTypedName, false, JSONMappers.class.getClassLoader());
+					if (mappedType.isAssignableFrom(type)) {
+						mapperClass = KNOWN_MAPPERS.get(mappedTypedName);
+					}
+				}
+			}
+			catch (Exception ignored) {
+			}
+		}
+
+		if (mapperClass == null) {
+			return Optional.empty();
+		}
+
+		try {
+			var name = JSONMappers.class.getPackageName() + "." + mapperClass;
+			LOGGER.log(Level.FINE, "Trying to load mapper {0}", name);
+			@SuppressWarnings("unchecked")
+			var mapperType = (Class<JSONMapper<?>>) Class.forName(name, true, JSONMappers.class.getClassLoader());
+			return Optional.of(mapperType.getDeclaredConstructor().newInstance());
+		}
+		catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException
+				| InvocationTargetException | NoClassDefFoundError ex) {
+			LOGGER.log(Level.WARNING, "Could not load a mapper for %s".formatted(typeName));
+			return Optional.empty();
+		}
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JSONMappers.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JSONMappers.java
@@ -42,6 +42,7 @@ enum JSONMappers {
 	private static final Map<String, String> KNOWN_MAPPERS = Map.of("com.fasterxml.jackson.databind.JsonNode",
 			"JacksonJSONMapperImpl");
 
+	@SuppressWarnings("squid:S1452") // Generic items, this is exactly what we want here
 	private final Map<String, Optional<JSONMapper<?>>> loadedMappers = new ConcurrentHashMap<>();
 
 	public Optional<JSONMapper<?>> getMapper(String typeName) {
@@ -56,7 +57,7 @@ enum JSONMappers {
 			try {
 				var type = Class.forName(typeName);
 
-				for (var mappedTypedName : KNOWN_MAPPERS.keySet()) {
+				for (@SuppressWarnings("squid:S2864") var mappedTypedName : KNOWN_MAPPERS.keySet()) {
 					var mappedType = Class.forName(mappedTypedName, false, JSONMappers.class.getClassLoader());
 					if (mappedType.isAssignableFrom(type)) {
 						mapperClass = KNOWN_MAPPERS.get(mappedTypedName);
@@ -64,6 +65,7 @@ enum JSONMappers {
 				}
 			}
 			catch (Exception ignored) {
+				// This is fine
 			}
 		}
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JacksonJSONMapperImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JacksonJSONMapperImpl.java
@@ -23,9 +23,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.LinkedHashMap;
-import java.util.Map;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -72,11 +70,9 @@ import org.neo4j.jdbc.values.Values;
  */
 final class JacksonJSONMapperImpl implements JSONMapper<JsonNode> {
 
-	private static final TypeReference<Map<String, Object>> MAP_OF_STRING_TO_OBJECT = new TypeReference<Map<String, Object>>() {
-	};
-
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
+	@SuppressWarnings("squid:S3776") // Has a lot of ifs, but isn't really complex
 	@Override
 	public JsonNode toJson(Value value) {
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JacksonJSONMapperImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/JacksonJSONMapperImpl.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BinaryNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.FloatNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.NumericNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.neo4j.jdbc.values.BooleanValue;
+import org.neo4j.jdbc.values.BytesValue;
+import org.neo4j.jdbc.values.DateTimeValue;
+import org.neo4j.jdbc.values.DateValue;
+import org.neo4j.jdbc.values.DurationValue;
+import org.neo4j.jdbc.values.FloatValue;
+import org.neo4j.jdbc.values.IntegerValue;
+import org.neo4j.jdbc.values.ListValue;
+import org.neo4j.jdbc.values.LocalDateTimeValue;
+import org.neo4j.jdbc.values.LocalTimeValue;
+import org.neo4j.jdbc.values.MapValue;
+import org.neo4j.jdbc.values.Node;
+import org.neo4j.jdbc.values.NodeValue;
+import org.neo4j.jdbc.values.NullValue;
+import org.neo4j.jdbc.values.Path;
+import org.neo4j.jdbc.values.PathValue;
+import org.neo4j.jdbc.values.PointValue;
+import org.neo4j.jdbc.values.Relationship;
+import org.neo4j.jdbc.values.RelationshipValue;
+import org.neo4j.jdbc.values.StringValue;
+import org.neo4j.jdbc.values.TimeValue;
+import org.neo4j.jdbc.values.Value;
+import org.neo4j.jdbc.values.Values;
+
+/**
+ * A {@link Value} to JSON mapper based on Jackson-Databind. The class will be loaded via
+ * reflection, hence it appears as unused.
+ *
+ * @author Michael J. Simons
+ * @since 6.7.0
+ */
+final class JacksonJSONMapperImpl implements JSONMapper<JsonNode> {
+
+	private static final TypeReference<Map<String, Object>> MAP_OF_STRING_TO_OBJECT = new TypeReference<Map<String, Object>>() {
+	};
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public JsonNode toJson(Value value) {
+
+		// Formats are aligned with the Query API.
+		if (value instanceof BooleanValue booleanValue) {
+			return BooleanNode.valueOf(booleanValue.asBoolean());
+		}
+		else if (value instanceof BytesValue bytesValue) {
+			return TextNode.valueOf(Base64.getEncoder().encodeToString(bytesValue.asByteArray()));
+		}
+		else if (value instanceof DateTimeValue dateTimeValue) {
+			String textValue;
+			if (dateTimeValue.asZonedDateTime().getZone().normalized() instanceof ZoneOffset) {
+				textValue = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dateTimeValue.asOffsetDateTime());
+			}
+			else {
+				textValue = DateTimeFormatter.ISO_ZONED_DATE_TIME.format(dateTimeValue.asZonedDateTime());
+			}
+			return TextNode.valueOf(textValue);
+		}
+		else if (value instanceof DateValue dateValue) {
+			return TextNode.valueOf(DateTimeFormatter.ISO_LOCAL_DATE.format(dateValue.asObject()));
+		}
+		else if (value instanceof DurationValue durationValue) {
+			return TextNode.valueOf(durationValue.toString().replace("DURATION '", "").replace("'", ""));
+		}
+		else if (value instanceof FloatValue floatValue) {
+			return DoubleNode.valueOf(floatValue.asDouble());
+		}
+		else if (value instanceof IntegerValue integerValue) {
+			return LongNode.valueOf(integerValue.asLong());
+		}
+		else if (value instanceof ListValue listValue) {
+			return mapList(listValue);
+		}
+		else if (value instanceof LocalDateTimeValue localDateTimeValue) {
+			return TextNode.valueOf(DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTimeValue.asObject()));
+		}
+		else if (value instanceof LocalTimeValue localTimeValue) {
+			return TextNode.valueOf(DateTimeFormatter.ISO_LOCAL_TIME.format(localTimeValue.asObject()));
+		}
+		else if (value instanceof MapValue mapValue) {
+			return mapMap(mapValue);
+		}
+		else if (value instanceof NodeValue nodeValue) {
+			return mapNode(nodeValue.asNode());
+		}
+		else if (value == null || value instanceof NullValue) {
+			return NullNode.getInstance();
+		}
+		else if (value instanceof PathValue pathValue) {
+			return mapPath(pathValue.asPath());
+		}
+		else if (value instanceof PointValue pointValue) {
+			var point = pointValue.asPoint();
+			var is3d = !Double.isNaN(point.z());
+			return TextNode.valueOf("SRID=" + point.srid() + ";POINT" + (is3d ? " Z " : " ") + "(" + point.x() + " "
+					+ point.y() + (is3d ? " " + point.z() + ")" : ")"));
+		}
+		else if (value instanceof RelationshipValue relationshipValue) {
+			return mapRelationship(relationshipValue.asRelationship());
+		}
+		else if (value instanceof StringValue stringValue) {
+			return TextNode.valueOf(stringValue.asString());
+		}
+		else if (value instanceof TimeValue timeValue) {
+			return TextNode.valueOf(DateTimeFormatter.ISO_OFFSET_TIME.format(timeValue.asObject()));
+		}
+
+		throw new UnsupportedOperationException(
+				"Cannot map %s to a %s".formatted(value, this.getBaseType().getSimpleName()));
+	}
+
+	@Override
+	public Value fromJson(Object in) {
+		if (in == null) {
+			return Values.NULL;
+		}
+		if (!(in instanceof JsonNode json)) {
+			throw new UnsupportedOperationException("Cannot map objects of type %s to %s"
+				.formatted(in.getClass().getName(), this.getBaseType().getSimpleName()));
+		}
+		if (json.isNull()) {
+			return Values.NULL;
+		}
+		else if (json instanceof BooleanNode booleanNode) {
+			return Values.value(booleanNode.booleanValue());
+		}
+		else if (json instanceof BinaryNode binaryNode) {
+			return Values.value(Base64.getEncoder().encodeToString(binaryNode.binaryValue()));
+		}
+		else if (json instanceof DecimalNode decimalNode) {
+			return Values.value(decimalNode.decimalValue().toString());
+		}
+		else if (json instanceof DoubleNode doubleNode) {
+			return Values.value(doubleNode.doubleValue());
+		}
+		else if (json instanceof FloatNode floatNode) {
+			return Values.value(floatNode.floatValue());
+		}
+		else if (json instanceof NumericNode numericNode) {
+			return Values.value(numericNode.longValue());
+		}
+		else if (json instanceof TextNode textNode) {
+			return Values.value(textNode.textValue());
+		}
+		else if (json instanceof ObjectNode objectNode) {
+			var result = new LinkedHashMap<String, Value>();
+			objectNode.forEachEntry((k, v) -> result.put(k, fromJson(v)));
+			return Values.value(result);
+		}
+		else if (json instanceof ArrayNode arrayNode) {
+			var result = new ArrayList<Value>();
+			arrayNode.forEach(v -> result.add(fromJson(v)));
+			return Values.value(result);
+		}
+
+		throw new UnsupportedOperationException("Cannot map %s to a %s".formatted(json, Value.class.getSimpleName()));
+	}
+
+	@Override
+	public Class<JsonNode> getBaseType() {
+		return JsonNode.class;
+	}
+
+	private JsonNode mapPath(Path path) {
+
+		var result = this.objectMapper.createArrayNode();
+		result.add(mapNode(path.start()));
+		path.relationships().forEach(relationship -> result.add(mapRelationship(relationship)));
+		result.add(mapNode(path.end()));
+		return result;
+	}
+
+	private JsonNode mapRelationship(Relationship relationship) {
+		var result = this.objectMapper.createObjectNode();
+
+		result.put("elementId", relationship.elementId());
+		result.put("startNodeElementId", relationship.startNodeElementId());
+		result.put("endNodeElementId", relationship.endNodeElementId());
+		result.put("type", relationship.type());
+
+		var properties = this.objectMapper.createObjectNode();
+		relationship.keys().forEach(key -> properties.set(key, toJson(relationship.get(key))));
+		result.set("properties", properties);
+		return result;
+	}
+
+	private JsonNode mapList(ListValue listValue) {
+		var result = this.objectMapper.createArrayNode();
+		listValue.values().forEach(value -> result.add(toJson(value)));
+		return result;
+	}
+
+	private JsonNode mapMap(MapValue mapValue) {
+		var result = this.objectMapper.createObjectNode();
+		mapValue.keys().forEach(key -> result.set(key, toJson(mapValue.get(key))));
+		return result;
+	}
+
+	private JsonNode mapNode(Node node) {
+		var result = this.objectMapper.createObjectNode();
+
+		result.put("elementId", node.elementId());
+
+		var labels = this.objectMapper.createArrayNode();
+		node.labels().forEach(labels::add);
+		result.set("labels", labels);
+
+		var properties = this.objectMapper.createObjectNode();
+		node.keys().forEach(key -> properties.set(key, toJson(node.get(key))));
+		result.set("properties", properties);
+		return result;
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/DateValue.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/DateValue.java
@@ -31,7 +31,7 @@ import java.time.format.DateTimeFormatterBuilder;
 public final class DateValue extends AbstractObjectValue<LocalDate> {
 
 	private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder().appendLiteral("DATE '")
-		.append(DateTimeFormatter.ISO_DATE)
+		.append(DateTimeFormatter.ISO_LOCAL_DATE)
 		.appendLiteral('\'')
 		.toFormatter();
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/LocalTimeValue.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/LocalTimeValue.java
@@ -31,7 +31,7 @@ import java.time.format.DateTimeFormatterBuilder;
 public final class LocalTimeValue extends AbstractObjectValue<LocalTime> {
 
 	private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder().appendLiteral("TIME '")
-		.append(DateTimeFormatter.ISO_TIME)
+		.append(DateTimeFormatter.ISO_LOCAL_TIME)
 		.appendLiteral('\'')
 		.toFormatter();
 

--- a/neo4j-jdbc/src/main/resources/META-INF/native-image/org.neo4j/neo4j-jdbc/native-image.properties
+++ b/neo4j-jdbc/src/main/resources/META-INF/native-image/org.neo4j/neo4j-jdbc/native-image.properties
@@ -17,4 +17,6 @@
 # limitations under the License.
 #
 
-Args = -H:ResourceConfigurationResources=${.}/resources-config.json
+Args = \
+  -H:ResourceConfigurationResources=${.}/resources-config.json \
+  -H:ReflectionConfigurationResources=${.}/reflection-config.json

--- a/neo4j-jdbc/src/main/resources/META-INF/native-image/org.neo4j/neo4j-jdbc/reflection-config.json
+++ b/neo4j-jdbc/src/main/resources/META-INF/native-image/org.neo4j/neo4j-jdbc/reflection-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "org.neo4j.jdbc.JacksonJSONMapperImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/JSONMappersTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/JSONMappersTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JSONMappersTests {
+
+	static boolean withDependencies() {
+		return !withoutRequiredDependencies();
+	}
+
+	static boolean withoutRequiredDependencies() {
+		return Boolean.getBoolean("withoutRequiredJSONDependencies");
+	}
+
+	@EnabledIf(value = "withDependencies",
+			disabledReason = "Dependencies are not on the classpath, so we cannot test their presence")
+	@ParameterizedTest
+	@ValueSource(
+			strings = { "com.fasterxml.jackson.databind.JsonNode", "com.fasterxml.jackson.databind.node.ObjectNode" })
+	void shouldLoadJacksonTreeNodeMapper(String typeName) {
+		var mapper = JSONMappers.INSTANCE.getMapper(typeName);
+		assertThat(mapper).isNotEmpty();
+	}
+
+	// @DisabledIf("withJackson") just didn't call the method, so ¯\_(ツ)_/¯
+	@EnabledIf(value = "withoutRequiredDependencies",
+			disabledReason = "Dependencies are on the classpath, so we cannot test their absence")
+	@Test
+	void shouldGracefullyFail() {
+		var handler = new CapturingHandler();
+		var logger = Logger.getLogger("org.neo4j.jdbc.JSONMappers");
+		logger.addHandler(handler);
+
+		try {
+			var mapper = JSONMappers.INSTANCE.getMapper("com.fasterxml.jackson.databind.JsonNode");
+			assertThat(mapper).isEmpty();
+			Assertions.assertThat(handler.messages)
+				.contains("Could not load a mapper for com.fasterxml.jackson.databind.JsonNode");
+		}
+		finally {
+			logger.removeHandler(handler);
+		}
+	}
+
+	static class CapturingHandler extends Handler {
+
+		List<String> messages = new ArrayList<>();
+
+		@Override
+		public void publish(LogRecord record) {
+			this.messages.add(record.getMessage());
+		}
+
+		@Override
+		public void flush() {
+
+		}
+
+		@Override
+		public void close() throws SecurityException {
+
+		}
+
+	}
+
+}

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/JacksonJSONMapperImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/JacksonJSONMapperImplTests.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.BigIntegerNode;
+import com.fasterxml.jackson.databind.node.BinaryNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.FloatNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.neo4j.jdbc.values.Value;
+import org.neo4j.jdbc.values.Values;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.BDDMockito.given;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JacksonJSONMapperImplTests {
+
+	private final JacksonJSONMapperImpl mapper = new JacksonJSONMapperImpl();
+
+	static Stream<Arguments> toJsonShouldWork() {
+		return Stream.of(Arguments.of(Values.value(true), BooleanNode.valueOf(true)),
+				Arguments.of(Values.value(new byte[] { -54, -2, -70, -66 }), TextNode.valueOf("yv66vg==")),
+				Arguments.of(Values
+					.value(ZonedDateTime.of(LocalDate.of(2025, 7, 3), LocalTime.of(9, 56, 0), ZoneOffset.ofHours(2))),
+						TextNode.valueOf("2025-07-03T09:56:00+02:00")),
+				Arguments.of(
+						Values.value(ZonedDateTime.of(LocalDate.of(2025, 7, 3), LocalTime.of(9, 56, 0),
+								ZoneId.of("Europe/Berlin"))),
+						TextNode.valueOf("2025-07-03T09:56:00+02:00[Europe/Berlin]")),
+				Arguments.of(Values.value(LocalDate.of(2025, 7, 3)), TextNode.valueOf("2025-07-03")),
+				Arguments.of(Values.value(Duration.ofHours(23).plusMinutes(2).plusSeconds(1)),
+						TextNode.valueOf("PT23H2M1S")),
+				Arguments.of(Values.value(Period.ofMonths(1)), TextNode.valueOf("P1M")),
+				Arguments.of(Values.value(1.23), DoubleNode.valueOf(1.23)),
+				Arguments.of(Values.value(666), LongNode.valueOf(666)),
+				Arguments.of(Values.value(LocalDateTime.of(LocalDate.of(2025, 7, 3), LocalTime.of(9, 56, 0))),
+						TextNode.valueOf("2025-07-03T09:56:00")),
+				Arguments.of(Values.value(LocalTime.of(9, 56, 0)), TextNode.valueOf("09:56:00")),
+				Arguments.of(null, NullNode.getInstance()), Arguments.of(Values.NULL, NullNode.getInstance()),
+				Arguments.of(Values.point(4326, 56.7, 12.78), TextNode.valueOf("SRID=4326;POINT (56.7 12.78)")),
+				Arguments.of(Values.point(9157, 2.3, 4.5, 2.0), TextNode.valueOf("SRID=9157;POINT Z (2.3 4.5 2.0)")),
+				Arguments.of(Values.value("Hallo"), TextNode.valueOf("Hallo")),
+				Arguments.of(Values.value(OffsetTime.of(LocalTime.of(11, 0), ZoneOffset.UTC)),
+						TextNode.valueOf("11:00:00Z")));
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void toJsonShouldWork(Value in, JsonNode out) {
+		assertThat(this.mapper.toJson(in)).isEqualTo(out);
+	}
+
+	@Test
+	void toJsonShouldThrowMeaningfulErrorWhenUnsupported() {
+		var unsupportedValue = Mockito.mock(Value.class);
+
+		given(unsupportedValue.toString()).willReturn("whatever");
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+			.isThrownBy(() -> this.mapper.toJson(unsupportedValue))
+			.withMessage("Cannot map whatever to a JsonNode");
+	}
+
+	static Stream<Arguments> fromJsonShouldWork() {
+		var om = new ObjectMapper();
+		var on = om.createObjectNode();
+		on.put("i", 1);
+		on.put("bd", BigDecimal.TEN);
+		on.put("d", 47.11);
+
+		var an = om.createArrayNode();
+		an.add(1);
+		an.add(2);
+		an.add(3);
+		on.set("l1", an);
+
+		an = om.createArrayNode();
+		var on2 = om.createObjectNode();
+		on2.put("s", "Hello");
+		an.add(on2);
+		on.set("l2", an);
+
+		return Stream.of(Arguments.of(null, Values.NULL), Arguments.of(NullNode.getInstance(), Values.NULL),
+				Arguments.of(BooleanNode.getTrue(), Values.value(true)),
+				Arguments.of(DecimalNode.valueOf(BigDecimal.ONE), Values.value("1")),
+				Arguments.of(BigIntegerNode.valueOf(BigInteger.ONE), Values.value(1L)),
+				Arguments.of(DoubleNode.valueOf(47.11), Values.value(47.11)),
+				Arguments.of(FloatNode.valueOf(2.2f), Values.value(2.2f)),
+				Arguments.of(LongNode.valueOf(1979), Values.value(1979)),
+				Arguments.of(IntNode.valueOf(1979), Values.value(1979)),
+				Arguments.of(TextNode.valueOf("Guten Tag"), Values.value("Guten Tag")),
+				Arguments.of(on,
+						Values.value(Map.of("i", Values.value(1), "bd", Values.value("10"), "d", Values.value(47.11),
+								"l1", Values.value(1, 2, 3), "l2",
+								Values.value(List.of(Values.value(Map.of("s", Values.value("Hello")))))))),
+				Arguments.of(BinaryNode.valueOf(new byte[] { -54, -2, -70, -66 }), Values.value("yv66vg==")));
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void fromJsonShouldWork(JsonNode in, Value out) {
+		assertThat(this.mapper.fromJson(in)).isEqualTo(out);
+	}
+
+	@Test
+	void fromJsonShouldThrowMeaningfulErrorWhenUnsupportedNode() {
+		var unsupportedValue = Mockito.mock(JsonNode.class);
+
+		given(unsupportedValue.toString()).willReturn("whatever");
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+			.isThrownBy(() -> this.mapper.fromJson(unsupportedValue))
+			.withMessage("Cannot map whatever to a Value");
+	}
+
+	@Test
+	void fromJsonShouldThrowMeaningfulErrorWhenUnsupportedType() {
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+			.isThrownBy(() -> this.mapper.fromJson("unsupportedValue"))
+			.withMessage("Cannot map objects of type java.lang.String to JsonNode");
+	}
+
+}

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ResultSetImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ResultSetImplTests.java
@@ -1491,7 +1491,7 @@ class ResultSetImplTests {
 		try (var rs = setupWithValue(Values.value("test"), 0)) {
 			rs.next();
 			assertThatExceptionOfType(SQLException.class).isThrownBy(() -> rs.getObject(1, Float.class))
-				.withMessage("data exception - Cannot coerce java.lang.String to java.lang.Float");
+				.withMessage("data exception - Cannot coerce \"test\" (STRING) to java.lang.Float");
 		}
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.neo4j</groupId>
 	<artifactId>neo4j-jdbc-parent</artifactId>
-	<version>6.6.2-SNAPSHOT</version>
+	<version>6.7.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>Neo4j JDBC Driver</name>


### PR DESCRIPTION
This features allows the retrieval of graph data, including nodes, relationships and path, as `JsonNode` objects when Jackson Databind is on the classpath. This is a completely optional feature and doesn’t change any public API. It is opt-in.
