### PR TITLE
feat: allow user-agent customization.

### DIFF
--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -583,10 +583,15 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 			.join();
 	}
 
-	static String getDefaultUserAgent(String envUserAgent) {
-		return Optional.ofNullable(System.getProperty(USER_AGENT_ENV_KEY))
-			.or(() -> Optional.ofNullable(envUserAgent))
-			.orElse("neo4j-jdbc/%s".formatted(ProductVersion.getValue()));
+	static String getDefaultUserAgent() {
+		if (System.getProperties().containsKey(USER_AGENT_ENV_KEY)
+				&& !System.getProperties().getProperty(USER_AGENT_ENV_KEY).isBlank()) {
+			return System.getProperties().getProperty(USER_AGENT_ENV_KEY);
+		}
+		if (System.getenv().containsKey(USER_AGENT_ENV_KEY) && !System.getenv().get(USER_AGENT_ENV_KEY).isBlank()) {
+			return System.getenv().get(USER_AGENT_ENV_KEY);
+		}
+		return "neo4j-jdbc/%s".formatted(ProductVersion.getValue());
 	}
 
 	static Map<String, String> mergeConfig(String[] urlParams, Properties jdbcProperties) {
@@ -1162,8 +1167,7 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 			var password = String.valueOf(config.getOrDefault(PROPERTY_PASSWORD, ""));
 			var authRealm = config.getOrDefault(PROPERTY_AUTH_REALM, "");
 
-			var userAgent = String.valueOf(
-					config.getOrDefault(PROPERTY_USER_AGENT, getDefaultUserAgent(System.getenv(USER_AGENT_ENV_KEY))));
+			var userAgent = String.valueOf(config.getOrDefault(PROPERTY_USER_AGENT, getDefaultUserAgent()));
 			var connectionTimeoutMillis = Integer.parseInt(config.getOrDefault(PROPERTY_TIMEOUT, "1000"));
 			var automaticSqlTranslation = Boolean
 				.parseBoolean(config.getOrDefault(PROPERTY_SQL_TRANSLATION_ENABLED, "false"));

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -124,6 +124,11 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 	public static final String PROPERTY_USER_AGENT = "agent";
 
 	/**
+	 * The environment and system property key for the user-agent.
+	 */
+	public static final String USER_AGENT_ENV_KEY = "NEO4J_JDBC_USER_AGENT";
+
+	/**
 	 * The name of the {@link #getPropertyInfo(String, Properties) property} containing
 	 * the password.
 	 */
@@ -578,8 +583,10 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 			.join();
 	}
 
-	static String getDefaultUserAgent() {
-		return "neo4j-jdbc/%s".formatted(ProductVersion.getValue());
+	static String getDefaultUserAgent(String envUserAgent) {
+		return Optional.ofNullable(System.getProperty(USER_AGENT_ENV_KEY))
+			.or(() -> Optional.ofNullable(envUserAgent))
+			.orElse("neo4j-jdbc/%s".formatted(ProductVersion.getValue()));
 	}
 
 	static Map<String, String> mergeConfig(String[] urlParams, Properties jdbcProperties) {
@@ -1155,7 +1162,8 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 			var password = String.valueOf(config.getOrDefault(PROPERTY_PASSWORD, ""));
 			var authRealm = config.getOrDefault(PROPERTY_AUTH_REALM, "");
 
-			var userAgent = String.valueOf(config.getOrDefault(PROPERTY_USER_AGENT, getDefaultUserAgent()));
+			var userAgent = String.valueOf(
+					config.getOrDefault(PROPERTY_USER_AGENT, getDefaultUserAgent(System.getenv(USER_AGENT_ENV_KEY))));
 			var connectionTimeoutMillis = Integer.parseInt(config.getOrDefault(PROPERTY_TIMEOUT, "1000"));
 			var automaticSqlTranslation = Boolean
 				.parseBoolean(config.getOrDefault(PROPERTY_SQL_TRANSLATION_ENABLED, "false"));

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDriverTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDriverTests.java
@@ -157,7 +157,23 @@ class Neo4jDriverTests {
 
 	@Test
 	void defaultUAShouldWork() {
-		assertThat(Neo4jDriver.getDefaultUserAgent()).matches("neo4j-jdbc/dev");
+		assertThat(Neo4jDriver.getDefaultUserAgent(null)).matches("neo4j-jdbc/dev");
+	}
+
+	@Test
+	void defaultUAFromSystemPropertiesShouldWork() {
+		try {
+			System.setProperty(Neo4jDriver.USER_AGENT_ENV_KEY, "agent-smith");
+			assertThat(Neo4jDriver.getDefaultUserAgent("ignore-me")).matches("agent-smith");
+		}
+		finally {
+			System.clearProperty(Neo4jDriver.USER_AGENT_ENV_KEY);
+		}
+	}
+
+	@Test
+	void defaultUAFromEnvShouldWork() {
+		assertThat(Neo4jDriver.getDefaultUserAgent("agent-00-schneider")).matches("agent-00-schneider");
 	}
 
 	@Nested

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDriverTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDriverTests.java
@@ -157,23 +157,18 @@ class Neo4jDriverTests {
 
 	@Test
 	void defaultUAShouldWork() {
-		assertThat(Neo4jDriver.getDefaultUserAgent(null)).matches("neo4j-jdbc/dev");
+		assertThat(Neo4jDriver.getDefaultUserAgent()).matches("neo4j-jdbc/dev");
 	}
 
 	@Test
 	void defaultUAFromSystemPropertiesShouldWork() {
 		try {
-			System.setProperty(Neo4jDriver.USER_AGENT_ENV_KEY, "agent-smith");
-			assertThat(Neo4jDriver.getDefaultUserAgent("ignore-me")).matches("agent-smith");
+			System.setProperty(Neo4jDriver.USER_AGENT_ENV_KEY, "agent-00-schneider");
+			assertThat(Neo4jDriver.getDefaultUserAgent()).matches("agent-00-schneider");
 		}
 		finally {
 			System.clearProperty(Neo4jDriver.USER_AGENT_ENV_KEY);
 		}
-	}
-
-	@Test
-	void defaultUAFromEnvShouldWork() {
-		assertThat(Neo4jDriver.getDefaultUserAgent("agent-00-schneider")).matches("agent-00-schneider");
 	}
 
 	@Nested


### PR DESCRIPTION
The user-agent can now be configured either by
an environment variable or a system property.
Where the property will overwrite the system property which overrides the environment variable.

For testing, I had to add a `String` parameter to the `getDefaultUserAgent` signature.
Don't know if it's better to keep it as it is, or to do the signature change.
Up to the reviewer to decide.