### PR TITLE
remove quotes from prerelease attribute

### DIFF
--- a/docs/src/main/asciidoc/antora.yml
+++ b/docs/src/main/asciidoc/antora.yml
@@ -21,7 +21,7 @@
 
 name: jdbc-manual
 version: ${project.version}
-prerelease: "false"
+prerelease: false
 title: Neo4j JDBC Driver manual
 start_page: ROOT:index.adoc
 nav:


### PR DESCRIPTION
Fixes an issue where the canonical URL is not generated correctly with `/current/` in the path.

Prerelease value in `antora.yml` should be boolean `false` or `true`, or removed.

