### PR TITLE
feat: Add support for the new Neo4j `Vector` type.

### DIFF
--- a/benchkit/pom.xml
+++ b/benchkit/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-benchkit</artifactId>
 

--- a/bundles/neo4j-jdbc-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/bundles/neo4j-jdbc-full-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-full-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/bundles/neo4j-jdbc-text2cypher-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-text2cypher-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-dist</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-docs</artifactId>

--- a/docs/src/main/asciidoc/modules/ROOT/pages/configuration.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/pages/configuration.adoc
@@ -49,7 +49,7 @@ Usually, Neo4j provides the HTTP port on 7474 or 7473. When you don't specify th
 
 WARNING: The query API behaves different in a couple of edge cases. Especially, for big results the driver will materialize them completely and not stream individual records as it does over the binary neo4j protocol. Also, queries that produce n results and may fail on the nth+1 result, will fail immediate when run over HTTP. +
  +
- Some features such as transactional metadata are not supported at all over HTTP.
+ Some features such as support for the `Vector` datatype and transactional metadata are not supported at all over HTTP.
 
 The driver accepts the following configuration arguments, either as properties or as URL query parameters:
 

--- a/docs/src/main/asciidoc/modules/ROOT/pages/datatypes.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/pages/datatypes.adoc
@@ -21,3 +21,31 @@ Any parameter of those types passed to `PreparedStatement` or `CallableStatement
 For information on Cypher date types, see https://neo4j.com/docs/cypher-manual/current/values-and-types/temporal/[Temporal types].
 
 For more precise a mapping, use a Neo4j https://neo4j.com/docs/api/java-driver/current/org.neo4j.driver/org/neo4j/driver/Value.html[`Value`] instance with the appropriate type and its methods `setObject` and `getObject`.
+
+== Vector support
+
+WARNING: You need a compatible Neo4j version to use native Vectors with Neo4j.
+
+The Neo4j driver supports the Neo4j `Vector` datatype. The `Vector` type is a uniform container value that has a fixed size of at least one and at most 4096 elements. The latter restriction might be lifted in a future version of Neo4j. Each element is of the same inner type and cannot be null.
+
+The Neo4j `Vector` supports the following inner types:
+
+`INTEGER8`:: Mapping to a Java `byte`
+`INTEGER16`:: Mapping to a Java `short`
+`INTEGER32`:: Mapping to a Java `int`
+`INTEGER`:: Mapping to a Java `long`
+`FLOAT32`:: Mapping to a Java `float`
+`FLOAT`:: Mapping to a Java `double`
+
+Instances returned by any query, either from a call to the Cypher constructor function `vector()` or by accessing node or relationship properties, can be accessed by using the `getObject` method of the JDBC `ResultSet`, passing in the index or the name of the field as well as the type `org.neo4j.jdbc.values.Vector`. The latter is also the entry point of creating instances from the client side:
+
+`Vector#of(byte[])`:: Creates an `INTEGER8` vector (`Int8Vector`)
+`Vector#of(short[])`:: Creates an `INTEGER16` vector (`Int16Vector`)
+`Vector#of(int[])`:: Creates an `INTEGER32` vector (`Int32Vector`)
+`Vector#of(long[])`:: Creates an `INTEGER` vector (`Int64Vector`)
+`Vector#of(float[])`:: Creates an `FLOAT32` vector (`Float32Vector`)
+`Vector#of(double[])`:: Creates an `FLOAT` vector (`Float64Vector`)
+
+The type has a guaranteed set of implementations (listed above). Each implementation provides `toArray()` returning a copy of its data as an array of the matching Java primitive. The `Vector` instances themselves are immutable.
+
+Last but not least, vectors returned from any query can also be accessed as `java.sql.Array`.

--- a/neo4j-jdbc-authn/kc/pom.xml
+++ b/neo4j-jdbc-authn/kc/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-authn</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-authn-kc</artifactId>

--- a/neo4j-jdbc-authn/pom.xml
+++ b/neo4j-jdbc-authn/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-authn</artifactId>
 

--- a/neo4j-jdbc-authn/spi/pom.xml
+++ b/neo4j-jdbc-authn/spi/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-authn</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-authn-spi</artifactId>

--- a/neo4j-jdbc-bom/pom.xml
+++ b/neo4j-jdbc-bom/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-bom</artifactId>

--- a/neo4j-jdbc-it/hibernate-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-hibernate-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/mybatis-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/mybatis-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-mybatis-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-cp</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/AbstractVectorIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/AbstractVectorIT.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.it.cp;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.neo4j.bolt.connection.exception.BoltFailureException;
+import org.neo4j.bolt.connection.exception.BoltGqlErrorException;
+import org.neo4j.jdbc.Neo4jDatabaseMetaData;
+import org.neo4j.jdbc.values.Node;
+import org.neo4j.jdbc.values.Vector;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+@Testcontainers(disabledWithoutDocker = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIf("databaseSupportsVectors")
+abstract class AbstractVectorIT {
+
+	protected final Neo4jContainer<?> neo4j;
+
+	protected final boolean databaseSupportsVectors;
+
+	AbstractVectorIT(String defaultLanguage) {
+		this.neo4j = getNeo4jContainer("neo4j:2025.07-enterprise", defaultLanguage);
+		var logs = new ArrayList<String>();
+		this.neo4j.withLogConsumer(frame -> logs.add(frame.getUtf8String().trim()));
+		this.neo4j.start();
+		this.databaseSupportsVectors = logs.stream()
+			.noneMatch(l -> l
+				.contains("Unrecognized setting. No declared setting with name: internal.cypher.enable_vector_type"));
+	}
+
+	@AfterAll
+	void stopNeo4j() {
+		this.neo4j.stop();
+	}
+
+	private Connection getConnection() throws SQLException {
+		return DriverManager.getConnection(
+				"jdbc:neo4j://%s:%d".formatted(this.neo4j.getHost(), this.neo4j.getMappedPort(7687)), "neo4j",
+				this.neo4j.getAdminPassword());
+	}
+
+	@SuppressWarnings("resource")
+	private static Neo4jContainer<?> getNeo4jContainer(String image, String defaultLanguage) {
+
+		var dockerImageName = Optional.ofNullable(image)
+			.orElseGet(() -> System.getProperty("neo4j-jdbc.default-neo4j-image"));
+		if (!dockerImageName.contains("-enterprise")) {
+			dockerImageName = dockerImageName + "-enterprise";
+		}
+		return new Neo4jContainer<>(dockerImageName).withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+			.waitingFor(Neo4jContainer.WAIT_FOR_BOLT)
+			.withNeo4jConfig("server.config.strict_validation.enabled", "false")
+			.withNeo4jConfig("internal.cypher.enable_extra_semantic_features", "VectorType")
+			.withNeo4jConfig("internal.dbms.bolt.max_protocol_version", "6.0")
+			.withNeo4jConfig("db.query.default_language", defaultLanguage)
+			.withNeo4jConfig("internal.cypher.enable_vector_type", "true");
+	}
+
+	final boolean databaseSupportsVectors() {
+		return this.databaseSupportsVectors;
+	}
+
+	@Test
+	@EnabledIf("databaseSupportsVectors")
+	final void shouldReadVector() throws SQLException {
+		try (var connection = getConnection(); var stmt = connection.createStatement(); var rs = stmt.executeQuery("""
+				CYPHER 25
+				RETURN
+					VECTOR([10,20,30], 3, INT8) as i8,
+					VECTOR([10,20,30], 3, INT16) as i16,
+					VECTOR([10,20,30], 3, INT32) as i32,
+					VECTOR([10,20,30], 3, INT64) as i64,
+					VECTOR([1.0,2.0,3.0], 3, FLOAT32) as f32,
+					VECTOR([1.0,2.0,3.0], 3, FLOAT64) as f64""")) {
+			assertThat(rs.next()).isTrue();
+			assertThat(rs.getObject("i8", Vector.class)).isEqualTo(Vector.of(new byte[] { 10, 20, 30 }));
+			assertThat(rs.getObject("i16", Vector.class)).isEqualTo(Vector.of(new short[] { 10, 20, 30 }));
+			assertThat(rs.getObject("i32", Vector.class)).isEqualTo(Vector.of(new int[] { 10, 20, 30 }));
+			assertThat(rs.getObject("i64", Vector.class)).isEqualTo(Vector.of(new long[] { 10, 20, 30 }));
+			assertThat(rs.getObject("f32", Vector.class)).isEqualTo(Vector.of(new float[] { 1.0f, 2.0f, 3.0f }));
+			assertThat(rs.getObject("f64", Vector.class)).isEqualTo(Vector.of(new double[] { 1.0, 2.0, 3.0 }));
+			var metadata = rs.getMetaData();
+			for (int i = 1; i <= metadata.getColumnCount(); ++i) {
+				assertThat(metadata.getColumnType(i)).isEqualTo(Types.ARRAY);
+				assertThat(metadata.getColumnTypeName(i)).isEqualTo("VECTOR");
+			}
+		}
+	}
+
+	@Test
+	@EnabledIf("databaseSupportsVectors")
+	final void shouldReadVectorAsArray() throws SQLException {
+		try (var connection = getConnection(); var stmt = connection.createStatement(); var rs = stmt.executeQuery("""
+				CYPHER 25
+				RETURN
+					VECTOR([10,20,30], 3, INT8) as i8,
+					VECTOR([10,20,30], 3, INT16) as i16,
+					VECTOR([10,20,30], 3, INT32) as i32,
+					VECTOR([10,20,30], 3, INT64) as i64,
+					VECTOR([1.0,2.0,3.0], 3, FLOAT32) as f32,
+					VECTOR([1.0,2.0,3.0], 3, FLOAT64) as f64""")) {
+			assertThat(rs.next()).isTrue();
+			assertThat(rs.getArray("i8").getArray()).isEqualTo(new byte[] { 10, 20, 30 });
+			assertThat(rs.getArray("i16").getArray()).isEqualTo(new short[] { 10, 20, 30 });
+			assertThat(rs.getArray("i32").getArray()).isEqualTo(new int[] { 10, 20, 30 });
+			assertThat(rs.getArray("i64").getArray()).isEqualTo(new long[] { 10, 20, 30 });
+			assertThat(rs.getArray("f32").getArray()).isEqualTo(new float[] { 1.0f, 2.0f, 3.0f });
+			assertThat(rs.getArray("f64").getArray()).isEqualTo(new double[] { 1.0, 2.0, 3.0 });
+		}
+	}
+
+	@Test
+	@EnabledIf("databaseSupportsVectors")
+	final void shouldExtractProperErrorMessage() throws SQLException {
+		try (var connection = getConnection(); var stmt = connection.createStatement()) {
+			assertThatException().isThrownBy(() -> stmt.executeQuery("CYPHER 25 RETURN VECTOR([1], 0, INT8)"))
+				.matches(ex -> {
+					if (ex.getCause() instanceof BoltFailureException bfe
+							&& bfe.getCause() instanceof BoltGqlErrorException bgee) {
+						return bgee.gqlStatus().equals("42N31") && bgee.statusDescription()
+							.contains(
+									"specified number out of range. Expected 'dimension' to be NUMBER in the range 1 to");
+					}
+					return false;
+				});
+		}
+	}
+
+	@Test
+	@EnabledIf("databaseSupportsVectors")
+	final void shouldWriteVector() throws SQLException {
+		try (var connection = getConnection(); var stmt = connection.prepareStatement("""
+				CREATE (n:VectorTest)
+				SET n.i8 = ?,
+					n.i16 = ?,
+					n.i32 = ?,
+					n.i64 = ?,
+					n.f32 = ?,
+					n.f64 = ?
+				RETURN n,
+					valueType(n.i8) AS ti8,
+					valueType(n.i16) AS ti16,
+					valueType(n.i32) AS ti32,
+					valueType(n.i64) AS ti64,
+					valueType(n.f32) AS tf32,
+					valueType(n.f64) AS tf64
+				""")) {
+			stmt.setObject(1, Vector.of(new byte[] { 10, 20, 30 }));
+			stmt.setObject(2, Vector.of(new short[] { 10, 20, 30 }));
+			stmt.setObject(3, Vector.of(new int[] { 10, 20, 30 }));
+			stmt.setObject(4, Vector.of(new long[] { 10, 20, 30 }));
+			stmt.setObject(5, Vector.of(new float[] { 1.0f, 2.0f, 3.0f }));
+			stmt.setObject(6, Vector.of(new double[] { 1.0, 2.0, 3.0 }));
+			var rs = stmt.executeQuery();
+
+			assertThat(rs.next()).isTrue();
+			assertThat(rs.getString("ti8")).isEqualTo("VECTOR<INTEGER8 NOT NULL>(3) NOT NULL");
+			assertThat(rs.getString("ti16")).isEqualTo("VECTOR<INTEGER16 NOT NULL>(3) NOT NULL");
+			assertThat(rs.getString("ti32")).isEqualTo("VECTOR<INTEGER32 NOT NULL>(3) NOT NULL");
+			assertThat(rs.getString("ti64")).isEqualTo("VECTOR<INTEGER NOT NULL>(3) NOT NULL");
+			assertThat(rs.getString("tf32")).isEqualTo("VECTOR<FLOAT32 NOT NULL>(3) NOT NULL");
+			assertThat(rs.getString("tf64")).isEqualTo("VECTOR<FLOAT NOT NULL>(3) NOT NULL");
+
+			var node = rs.getObject("n", Node.class);
+			assertThat(node.get("i8").asVector()).isEqualTo(Vector.of(new byte[] { 10, 20, 30 }));
+			assertThat(node.get("i16").asVector()).isEqualTo(Vector.of(new short[] { 10, 20, 30 }));
+			assertThat(node.get("i32").asVector()).isEqualTo(Vector.of(new int[] { 10, 20, 30 }));
+			assertThat(node.get("i64").asVector()).isEqualTo(Vector.of(new long[] { 10, 20, 30 }));
+			assertThat(node.get("f32").asVector()).isEqualTo(Vector.of(new float[] { 1.0f, 2.0f, 3.0f }));
+			assertThat(node.get("f64").asVector()).isEqualTo(Vector.of(new double[] { 1.0, 2.0, 3.0 }));
+		}
+	}
+
+	@Test
+	@EnabledIf("databaseSupportsVectors")
+	final void metadataShouldWork() throws SQLException {
+		try (var connection = getConnection(); var stmt = connection.createStatement()) {
+
+			var expected = new HashSet<>(Set.of("i8", "i16", "i32", "i64", "f32", "f64"));
+			stmt.executeUpdate("""
+					CYPHER 25
+					CREATE (n:VectorMetadataTest {
+						i8:  VECTOR([10,20,30], 3, INT8),
+						i16: VECTOR([10,20,30], 3, INT16),
+						i32: VECTOR([10,20,30], 3, INT32),
+						i64: VECTOR([10,20,30], 3, INT64),
+						f32: VECTOR([1.0,2.0,3.0], 3, FLOAT32),
+						f64: VECTOR([1.0,2.0,3.0], 3, FLOAT64)})""");
+
+			var metadata = connection.getMetaData().unwrap(Neo4jDatabaseMetaData.class);
+			metadata.flush();
+			var columns = metadata.getColumns(null, null, "VectorMetadataTest", null);
+			while (columns.next()) {
+				if (expected.remove(columns.getString("COLUMN_NAME"))) {
+					assertThat(columns.getInt("DATA_TYPE")).isEqualTo(Types.ARRAY);
+					assertThat(columns.getString("TYPE_NAME")).isEqualTo("VECTOR");
+				}
+			}
+			assertThat(expected).isEmpty();
+		}
+	}
+
+}

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/Cypher25VectorIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/Cypher25VectorIT.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.it.cp;
+
+/**
+ * Dedicated vector test with database default to Cypher 25 (Testing the metadata).
+ *
+ * @author Michael J. Simons
+ */
+class Cypher25VectorIT extends AbstractVectorIT {
+
+	Cypher25VectorIT() {
+		super("CYPHER_25");
+	}
+
+}

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/Cypher5VectorIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/Cypher5VectorIT.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.it.cp;
+
+/**
+ * Dedicated vector test with database default to Cypher 5 (Testing the metadata).
+ *
+ * @author Michael J. Simons
+ */
+class Cypher5VectorIT extends AbstractVectorIT {
+
+	Cypher5VectorIT() {
+		super("CYPHER_5");
+	}
+
+}

--- a/neo4j-jdbc-it/neo4j-jdbc-it-mp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-mp/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-mp</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-sso/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-sso/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-sso</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-stub/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-stub/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-stub</artifactId>
 

--- a/neo4j-jdbc-it/pom.xml
+++ b/neo4j-jdbc-it/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it</artifactId>
 

--- a/neo4j-jdbc-it/quarkus-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/quarkus-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-quarkus-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/spring-boot-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/spring-boot-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-spring-boot-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-test-results/pom.xml
+++ b/neo4j-jdbc-test-results/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-test-results</artifactId>

--- a/neo4j-jdbc-tracing/micrometer/pom.xml
+++ b/neo4j-jdbc-tracing/micrometer/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-tracing</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-tracing-micrometer</artifactId>

--- a/neo4j-jdbc-tracing/pom.xml
+++ b/neo4j-jdbc-tracing/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-tracing</artifactId>
 

--- a/neo4j-jdbc-translator/impl/pom.xml
+++ b/neo4j-jdbc-translator/impl/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-impl</artifactId>

--- a/neo4j-jdbc-translator/pom.xml
+++ b/neo4j-jdbc-translator/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-translator</artifactId>
 

--- a/neo4j-jdbc-translator/sparkcleaner/pom.xml
+++ b/neo4j-jdbc-translator/sparkcleaner/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-sparkcleaner</artifactId>

--- a/neo4j-jdbc-translator/spi/pom.xml
+++ b/neo4j-jdbc-translator/spi/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-spi</artifactId>

--- a/neo4j-jdbc-translator/text2cypher/pom.xml
+++ b/neo4j-jdbc-translator/text2cypher/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-text2cypher-translator</artifactId>

--- a/neo4j-jdbc/pom.xml
+++ b/neo4j-jdbc/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.7.4-SNAPSHOT</version>
+		<version>6.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc</artifactId>

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jConversions.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jConversions.java
@@ -116,7 +116,7 @@ final class Neo4jConversions {
 			case STRING -> Types.VARCHAR;
 			case NUMBER, INTEGER -> Types.BIGINT;
 			case FLOAT -> Types.DOUBLE;
-			case LIST -> Types.ARRAY;
+			case LIST, VECTOR -> Types.ARRAY;
 			case MAP, POINT, PATH, RELATIONSHIP, NODE -> Types.STRUCT;
 			case DATE -> Types.DATE;
 			case TIME -> Types.TIME;
@@ -137,6 +137,9 @@ final class Neo4jConversions {
 			.toUpperCase(Locale.ROOT);
 		if (value.startsWith("LIST<")) {
 			value = "LIST";
+		}
+		if (value.startsWith("VECTOR<") || value.endsWith("VECTOR")) {
+			value = "VECTOR";
 		}
 		value = value.replaceAll("( NOT)? NULL", "");
 		value = switch (value) {

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -254,7 +254,7 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 	private static final BoltProtocolVersion MIN_BOLT_VERSION = new BoltProtocolVersion(5, 1);
 
 	private static final Map<String, Object> BOLT_CONNECTION_OPTIONS = Map.of("eventLoopThreadNamePrefix",
-			"Neo4jJDBCDriverIO", "maxVersion", new BoltProtocolVersion(5, 8));
+			"Neo4jJDBCDriverIO", "maxVersion", new BoltProtocolVersion(6, 0));
 
 	/*
 	 * Register one default instance globally.

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/internal/bolt/ValueFactoryImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/internal/bolt/ValueFactoryImpl.java
@@ -53,6 +53,8 @@ import org.neo4j.jdbc.values.StringValue;
 import org.neo4j.jdbc.values.TimeValue;
 import org.neo4j.jdbc.values.UnsupportedDateTimeValue;
 import org.neo4j.jdbc.values.Values;
+import org.neo4j.jdbc.values.Vector;
+import org.neo4j.jdbc.values.VectorValue;
 
 enum ValueFactoryImpl implements ValueFactory {
 
@@ -81,6 +83,7 @@ enum ValueFactoryImpl implements ValueFactory {
 		hlp.put(PathValue.class, Type.PATH);
 		hlp.put(ListValue.class, Type.LIST);
 		hlp.put(BytesValue.class, Type.BYTES);
+		hlp.put(VectorValue.class, Type.VECTOR);
 		TYPE_MAP = Map.copyOf(hlp);
 	}
 
@@ -134,8 +137,38 @@ enum ValueFactoryImpl implements ValueFactory {
 	}
 
 	@Override
-	public Value vector(Class<?> aClass, Object o) {
-		throw new UnsupportedOperationException();
+	public Value value(org.neo4j.bolt.connection.values.Vector vector) {
+		return vector(vector.elementType(), vector.elements());
+	}
+
+	@Override
+	public Value vector(Class<?> elementType, Object elements) {
+
+		Vector vector;
+		if (elementType == byte.class) {
+			vector = Vector.of((byte[]) elements);
+		}
+		else if (elementType == short.class) {
+			vector = Vector.of((short[]) elements);
+		}
+		else if (elementType == int.class) {
+			vector = Vector.of((int[]) elements);
+		}
+		else if (elementType == long.class) {
+			vector = Vector.of((long[]) elements);
+		}
+		else if (elementType == float.class) {
+			vector = Vector.of((float[]) elements);
+		}
+		else if (elementType == double.class) {
+			vector = Vector.of((double[]) elements);
+		}
+		else {
+			throw new IllegalArgumentException(
+					"Element type %s is not a supported element type for vectors".formatted(elementType.getName()));
+		}
+
+		return asBoltValue(vector.asValue());
 	}
 
 	@Override

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/AbstractValue.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/AbstractValue.java
@@ -285,6 +285,11 @@ abstract class AbstractValue extends AbstractMapAccessorWithDefaultValue impleme
 	}
 
 	@Override
+	public Vector asVector() {
+		throw new UncoercibleException(type().name(), "Vector");
+	}
+
+	@Override
 	public Value get(int index) {
 		throw new NotMultiValuedException(type().name() + " is not an indexed collection");
 	}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/ArrayBasedVectors.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/ArrayBasedVectors.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.values;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.neo4j.jdbc.values.Vector.Float32Vector;
+import org.neo4j.jdbc.values.Vector.Float64Vector;
+import org.neo4j.jdbc.values.Vector.Int16Vector;
+import org.neo4j.jdbc.values.Vector.Int32Vector;
+import org.neo4j.jdbc.values.Vector.Int64Vector;
+import org.neo4j.jdbc.values.Vector.Int8Vector;
+
+final class ArrayBasedVectors {
+
+	private ArrayBasedVectors() {
+	}
+
+	@SuppressWarnings("unused")
+	static final Function<Vector, Object> ELEMENT_ACCESSOR = vector -> {
+		// The field is reflected upon (hence the suppression).
+		Objects.requireNonNull(vector);
+
+		if (vector instanceof Int8VectorImpl int8Vector) {
+			return int8Vector.elements();
+		}
+		else if (vector instanceof Int16VectorImpl v) {
+			return v.elements();
+		}
+		else if (vector instanceof Int32VectorImpl v) {
+			return v.elements();
+		}
+		else if (vector instanceof Int64VectorImpl v) {
+			return v.elements();
+		}
+		else if (vector instanceof Float32VectorImpl v) {
+			return v.elements();
+		}
+		else if (vector instanceof Float64VectorImpl v) {
+			return v.elements();
+		}
+
+		throw new IllegalArgumentException("Unsupported vector implementation: " + vector.getClass().getName());
+	};
+
+	static String toString(Vector vector) {
+		var value = vector.stream().map(Number::toString).collect(Collectors.joining(", ", "[", "]"));
+		return "vector(%s, %d, %s NOT NULL)".formatted(value, vector.size(), vector.elementType());
+	}
+
+	record Int8VectorImpl(ElementType elementType, int size, byte[] elements) implements Int8Vector {
+
+		@Override
+		public byte[] toArray() {
+			return Arrays.copyOf(this.elements, this.size);
+		}
+
+		@Override
+		public Stream<Byte> stream() {
+			return IntStream.range(0, this.elements.length).mapToObj(i -> this.elements[i]);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == this) {
+				return true;
+			}
+			if (obj == null || obj.getClass() != this.getClass()) {
+				return false;
+			}
+			var that = (Int8VectorImpl) obj;
+			return Objects.equals(this.elementType, that.elementType) && this.size == that.size
+					&& Arrays.equals(this.elements, that.elements);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(this.elementType, this.size, Arrays.hashCode(this.elements));
+		}
+
+		@Override
+		public String toString() {
+			return ArrayBasedVectors.toString(this);
+		}
+
+	}
+
+	record Int16VectorImpl(ElementType elementType, int size, short[] elements) implements Int16Vector {
+
+		@Override
+		public short[] toArray() {
+			return Arrays.copyOf(this.elements, this.size);
+		}
+
+		@Override
+		public Stream<Short> stream() {
+			return IntStream.range(0, this.elements.length).mapToObj(i -> this.elements[i]);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == this) {
+				return true;
+			}
+			if (obj == null || obj.getClass() != this.getClass()) {
+				return false;
+			}
+			var that = (Int16VectorImpl) obj;
+			return Objects.equals(this.elementType, that.elementType) && this.size == that.size
+					&& Arrays.equals(this.elements, that.elements);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(this.elementType, this.size, Arrays.hashCode(this.elements));
+		}
+
+		@Override
+		public String toString() {
+			return ArrayBasedVectors.toString(this);
+		}
+
+	}
+
+	record Int32VectorImpl(ElementType elementType, int size, int[] elements) implements Int32Vector {
+
+		@Override
+		public int[] toArray() {
+			return Arrays.copyOf(this.elements, this.size);
+		}
+
+		@Override
+		public Stream<Integer> stream() {
+			return Arrays.stream(this.elements).boxed();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == this) {
+				return true;
+			}
+			if (obj == null || obj.getClass() != this.getClass()) {
+				return false;
+			}
+			var that = (Int32VectorImpl) obj;
+			return Objects.equals(this.elementType, that.elementType) && this.size == that.size
+					&& Arrays.equals(this.elements, that.elements);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(this.elementType, this.size, Arrays.hashCode(this.elements));
+		}
+
+		@Override
+		public String toString() {
+			return ArrayBasedVectors.toString(this);
+		}
+
+	}
+
+	record Int64VectorImpl(ElementType elementType, int size, long[] elements) implements Int64Vector {
+
+		@Override
+		public long[] toArray() {
+			return Arrays.copyOf(this.elements, this.size);
+		}
+
+		@Override
+		public Stream<Long> stream() {
+			return Arrays.stream(this.elements).boxed();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == this) {
+				return true;
+			}
+			if (obj == null || obj.getClass() != this.getClass()) {
+				return false;
+			}
+			var that = (Int64VectorImpl) obj;
+			return Objects.equals(this.elementType, that.elementType) && this.size == that.size
+					&& Arrays.equals(this.elements, that.elements);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(this.elementType, this.size, Arrays.hashCode(this.elements));
+		}
+
+		@Override
+		public String toString() {
+			return ArrayBasedVectors.toString(this);
+		}
+
+	}
+
+	record Float32VectorImpl(ElementType elementType, int size, float[] elements) implements Float32Vector {
+
+		@Override
+		public float[] toArray() {
+			return Arrays.copyOf(this.elements, this.size);
+		}
+
+		@Override
+		public Stream<Float> stream() {
+			return IntStream.range(0, this.elements.length).mapToObj(i -> this.elements[i]);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == this) {
+				return true;
+			}
+			if (obj == null || obj.getClass() != this.getClass()) {
+				return false;
+			}
+			var that = (Float32VectorImpl) obj;
+			return Objects.equals(this.elementType, that.elementType) && this.size == that.size
+					&& Arrays.equals(this.elements, that.elements);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(this.elementType, this.size, Arrays.hashCode(this.elements));
+		}
+
+		@Override
+		public String toString() {
+			return ArrayBasedVectors.toString(this);
+		}
+
+	}
+
+	record Float64VectorImpl(ElementType elementType, int size, double[] elements) implements Float64Vector {
+
+		@Override
+		public double[] toArray() {
+			return Arrays.copyOf(this.elements, this.size);
+		}
+
+		@Override
+		public Stream<Double> stream() {
+			return Arrays.stream(this.elements).boxed();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == this) {
+				return true;
+			}
+			if (obj == null || obj.getClass() != this.getClass()) {
+				return false;
+			}
+			var that = (Float64VectorImpl) obj;
+			return Objects.equals(this.elementType, that.elementType) && this.size == that.size
+					&& Arrays.equals(this.elements, that.elements);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(this.elementType, this.size, Arrays.hashCode(this.elements));
+		}
+
+		@Override
+		public String toString() {
+			return ArrayBasedVectors.toString(this);
+		}
+
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Type.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Type.java
@@ -148,7 +148,12 @@ public enum Type {
 	 * Null type.
 	 * @since 6.0.0
 	 */
-	NULL;
+	NULL,
+	/**
+	 * A typed vector type.
+	 * @since 6.8.0
+	 */
+	VECTOR;
 
 	/**
 	 * Test if the given value has this type.

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Value.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Value.java
@@ -480,6 +480,16 @@ public interface Value extends MapAccessorWithDefaultValue {
 	Point asPoint();
 
 	/**
+	 * Returns the value as a {@link Vector}, if possible.
+	 * @return the value as a {@link Vector}, if possible.
+	 * @throws UncoercibleException if value types are incompatible.
+	 * @since 6.8.0
+	 */
+	default Vector asVector() {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
 	 * Returns the value as local date if possible or the default value otherwise.
 	 * @param defaultValue default to this value if the value is a {@link NullValue}
 	 * @return the value as a {@link LocalDate}, if possible.
@@ -542,6 +552,17 @@ public interface Value extends MapAccessorWithDefaultValue {
 	 * @throws UncoercibleException if value types are incompatible.
 	 */
 	Point asPoint(Point defaultValue);
+
+	/**
+	 * Returns the value as a {@link Vector}, if possible.
+	 * @param defaultValue default to this value if the value is a {@link NullValue}
+	 * @return the value as a {@link Vector}, if possible.
+	 * @throws UncoercibleException if value types are incompatible.
+	 * @since 6.8.0
+	 */
+	default Vector asVector(Vector defaultValue) {
+		return computeOrDefault(Value::asVector, defaultValue);
+	}
 
 	/**
 	 * Return as a map of string keys and values converted using {@link Value#asObject()}.

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Values.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Values.java
@@ -201,6 +201,9 @@ public final class Values {
 		if (value instanceof Object[]) {
 			return value(Arrays.asList((Object[]) value));
 		}
+		if (value instanceof Vector vector) {
+			return new VectorValue(vector);
+		}
 
 		throw new ValueException("Unable to convert " + value.getClass().getName() + " to Neo4j Value.");
 	}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Vector.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Vector.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.values;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+import org.neo4j.jdbc.values.ArrayBasedVectors.Float32VectorImpl;
+import org.neo4j.jdbc.values.ArrayBasedVectors.Float64VectorImpl;
+import org.neo4j.jdbc.values.ArrayBasedVectors.Int16VectorImpl;
+import org.neo4j.jdbc.values.ArrayBasedVectors.Int32VectorImpl;
+import org.neo4j.jdbc.values.ArrayBasedVectors.Int64VectorImpl;
+import org.neo4j.jdbc.values.ArrayBasedVectors.Int8VectorImpl;
+
+/**
+ * This type represents a Neo4j {@code Vector}. A Neo4j vector is a vector in the
+ * mathematical sense composed of a uniform element-type and a fixed length. The
+ * element-type of a vector can be of the following types (the types in parentheses are
+ * the Java types to which the Neo4j types are mapped):
+ * <ul>
+ * <li>{@link ElementType#INTEGER8} ({@code byte})</li>
+ * <li>{@link ElementType#INTEGER16} ({@code short})</li>
+ * <li>{@link ElementType#INTEGER32} ({@code int})</li>
+ * <li>{@link ElementType#INTEGER} ({@code long})</li>
+ * <li>{@link ElementType#FLOAT32} ({@code float})</li>
+ * <li>{@link ElementType#FLOAT} ({@code double})</li>
+ * </ul>
+ * A vector is immutable, and all {@literal toXXXArray} methods will return a copy. Hence,
+ * it is advised that you keep that copy around for as long as you need it and not
+ * recreate it on every use. Constructions of {@link Vector instances} must go through the
+ * appropriate factory methods in this interface.
+ *
+ * @author Michael J. Simons
+ * @since 6.8.0
+ */
+public sealed interface Vector extends AsValue {
+
+	/**
+	 * The maximum size of a vector property supported by Neo4j as of Neo4j 2025.07.
+	 */
+	int MAX_VECTOR_SIZE = 4096;
+
+	/**
+	 * A flag to turn of upper bounds check. Recommended to use only as an escape hedge
+	 * for in a scenario in which the Neo4j server increases its upper bounds, but it is
+	 * unfeasible to update the JDBC driver.
+	 */
+	AtomicBoolean CHECK_UPPER_RANGE = new AtomicBoolean(true);
+
+	/**
+	 * {@return element-type of this vector}
+	 */
+	ElementType elementType();
+
+	/**
+	 * {@return the size of this vector}
+	 */
+	int size();
+
+	/**
+	 * This is an alias for {@link #size()}, aligning with the GQL compliant database
+	 * function of the same name.
+	 * @return the size of this vector
+	 */
+	default int vectorDimensionCount() {
+		return size();
+	}
+
+	@Override
+	default Value asValue() {
+		return new VectorValue(this);
+	};
+
+	/**
+	 * {@return a stream of the vectors elements}
+	 */
+	Stream<? extends Number> stream();
+
+	private static void assertSize(int size) {
+
+		if (size <= 0 || (size > MAX_VECTOR_SIZE && CHECK_UPPER_RANGE.get())) {
+			throw new IllegalArgumentException(
+					"'%d' is not a valid value. Must be a %s in the range %d to %d (GQL 42N31)".formatted(size,
+							"number", 1, MAX_VECTOR_SIZE));
+		}
+	}
+
+	/**
+	 * Creates a vector composed of {@link ElementType#INTEGER8}.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link Vector}
+	 */
+	static Vector of(byte[] elements) {
+		assertSize(Objects.requireNonNull(elements, "Vector elements must not be literal null").length);
+		return new ArrayBasedVectors.Int8VectorImpl(ElementType.INTEGER8, elements.length,
+				Arrays.copyOf(elements, elements.length));
+	}
+
+	/**
+	 * Creates a vector composed of {@link ElementType#INTEGER16}.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link Vector}
+	 */
+	static Vector of(short[] elements) {
+		assertSize(Objects.requireNonNull(elements, "Vector elements must not be literal null").length);
+		return new ArrayBasedVectors.Int16VectorImpl(ElementType.INTEGER16, elements.length,
+				Arrays.copyOf(elements, elements.length));
+	}
+
+	/**
+	 * Creates a vector composed of {@link ElementType#INTEGER32}.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link Vector}
+	 */
+	static Vector of(int[] elements) {
+		assertSize(Objects.requireNonNull(elements, "Vector elements must not be literal null").length);
+		return new ArrayBasedVectors.Int32VectorImpl(ElementType.INTEGER32, elements.length,
+				Arrays.copyOf(elements, elements.length));
+	}
+
+	/**
+	 * Creates a vector composed of {@link ElementType#INTEGER}.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link Vector}
+	 */
+	static Vector of(long[] elements) {
+		assertSize(Objects.requireNonNull(elements, "Vector elements must not be literal null").length);
+		return new ArrayBasedVectors.Int64VectorImpl(ElementType.INTEGER, elements.length,
+				Arrays.copyOf(elements, elements.length));
+	}
+
+	/**
+	 * Creates a vector composed of {@link ElementType#FLOAT32}.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link Vector}
+	 */
+	static Vector of(float[] elements) {
+		assertSize(Objects.requireNonNull(elements, "Vector elements must not be literal null").length);
+		return new ArrayBasedVectors.Float32VectorImpl(ElementType.FLOAT32, elements.length,
+				Arrays.copyOf(elements, elements.length));
+	}
+
+	/**
+	 * Creates a vector composed of {@link ElementType#FLOAT}.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link Vector}
+	 */
+	static Vector of(double[] elements) {
+		assertSize(Objects.requireNonNull(elements, "Vector elements must not be literal null").length);
+		return new ArrayBasedVectors.Float64VectorImpl(ElementType.FLOAT, elements.length,
+				Arrays.copyOf(elements, elements.length));
+	}
+
+	/**
+	 * This enum describes the element-type of a {@link VectorValue} and the corresponding
+	 * Java type.
+	 */
+	enum ElementType {
+
+		/**
+		 * Neo4j INTEGER8 type.
+		 */
+		INTEGER8(byte.class),
+		/**
+		 * Neo4j INTEGER16 type.
+		 */
+		INTEGER16(short.class),
+		/**
+		 * Neo4j INTEGER32 type.
+		 */
+		INTEGER32(int.class),
+		/**
+		 * Neo4j INTEGER64 type (Cypher CIP-200 normalises INTEGER64 to INTEGER, and we
+		 * want the JDBC driver to be aligned here).
+		 */
+		INTEGER(long.class),
+		/**
+		 * Neo4j FLOAT32 type.
+		 */
+		FLOAT32(float.class),
+		/**
+		 * Neo4j FLOAT64 type (Cypher CIP-200 normalises FLOAT64 to FLOAT, and we want the
+		 * JDBC driver to be aligned here).
+		 */
+		FLOAT(double.class);
+
+		private final Class<?> javaType;
+
+		ElementType(Class<?> javaType) {
+			this.javaType = javaType;
+		}
+
+		/**
+		 * {@return the Java type to which elements of a vector are mapped}
+		 */
+		public Class<?> getJavaType() {
+			return this.javaType;
+		}
+
+	}
+
+	sealed interface Int8Vector extends Vector permits Int8VectorImpl {
+
+		/**
+		 * {@return a copy of this vector as an array of Java {@code byte} values}
+		 */
+		byte[] toArray();
+
+	}
+
+	sealed interface Int16Vector extends Vector permits Int16VectorImpl {
+
+		/**
+		 * {@return a copy of this vector as an array of Java {@code short} values}
+		 */
+		short[] toArray();
+
+	}
+
+	sealed interface Int32Vector extends Vector permits Int32VectorImpl {
+
+		/**
+		 * {@return a copy of this vector as an array of Java {@code int} values}
+		 */
+		int[] toArray();
+
+	}
+
+	sealed interface Int64Vector extends Vector permits Int64VectorImpl {
+
+		/**
+		 * {@return a copy of this vector as an array of Java {@code long} values}
+		 */
+		long[] toArray();
+
+	}
+
+	sealed interface Float32Vector extends Vector permits Float32VectorImpl {
+
+		/**
+		 * {@return a copy of this vector as an array of Java {@code float} values}
+		 */
+		float[] toArray();
+
+	}
+
+	sealed interface Float64Vector extends Vector permits Float64VectorImpl {
+
+		/**
+		 * {@return a copy of this vector as an array of Java {@code double} values}
+		 */
+		double[] toArray();
+
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/VectorValue.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/VectorValue.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.values;
+
+/**
+ * A value containing a Neo4j {@link Vector}. Please use {@link Vector#elementType()} for
+ * retrieving the concrete element-type or use the type-hierarchy of the {@link Vector
+ * interface} to check the concrete type and extracting Java arrays from a vector.
+ *
+ * @author Michael J. Simons
+ * @since 6.8.0
+ */
+public final class VectorValue extends AbstractObjectValue<Vector> {
+
+	VectorValue(Vector adapted) {
+		super(adapted);
+	}
+
+	@Override
+	public Type type() {
+		return Type.VECTOR;
+	}
+
+	@Override
+	public Vector asVector() {
+		return super.asObject();
+	}
+
+}

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ResultSetImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ResultSetImplTests.java
@@ -73,6 +73,7 @@ import org.neo4j.jdbc.values.Record;
 import org.neo4j.jdbc.values.Type;
 import org.neo4j.jdbc.values.Value;
 import org.neo4j.jdbc.values.Values;
+import org.neo4j.jdbc.values.Vector;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -1118,6 +1119,11 @@ class ResultSetImplTests {
 					.of(Arguments.of(durationValue, Named.<VerificationLogic<Object>>of("verify returns IsoDuration",
 							supplier -> assertThat(supplier.get()).isEqualTo(durationValue.asIsoDuration())))));
 
+			var vectorStream = Stream.of(Values.value(Vector.of(new int[1])))
+				.flatMap(vectorValue -> Stream
+					.of(Arguments.of(vectorValue, Named.<VerificationLogic<Object>>of("verify returns Vector",
+							supplier -> assertThat(supplier.get()).isEqualTo(Vector.of(new int[1]))))));
+
 			return switch (type) {
 				case ANY, NODE, RELATIONSHIP, PATH, NUMBER -> Stream.of();
 				case BOOLEAN -> booleanStream;
@@ -1127,6 +1133,7 @@ class ResultSetImplTests {
 				case FLOAT -> floatStream;
 				case NULL -> nullStream;
 				case LIST -> listStream;
+				case VECTOR -> vectorStream;
 				case MAP -> mapStream;
 				case POINT -> pointStream;
 				case DATE -> dateStream;

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/internal/bolt/ValueFactoryImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/internal/bolt/ValueFactoryImplTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.internal.bolt;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.bolt.connection.values.Vector;
+import org.neo4j.jdbc.values.AsValue;
+import org.neo4j.jdbc.values.VectorValue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class ValueFactoryImplTests {
+
+	@Test
+	void vectorOfBoltValueMustWork() {
+		var boltVector = new Vector() {
+
+			@Override
+			public Class<?> elementType() {
+				return int.class;
+			}
+
+			@Override
+			public Object elements() {
+				return new int[] { 6, 6, 6 };
+			}
+		};
+		var value = ValueFactoryImpl.INSTANCE.value(boltVector);
+		assertThat(value).isNotNull();
+		assertThat(value).isInstanceOf(AsValue.class);
+		var jdbcValue = ((AsValue) value).asValue();
+		assertThat(jdbcValue).isInstanceOf(VectorValue.class);
+		var vector = jdbcValue.asVector();
+		assertThat(vector).isEqualTo(org.neo4j.jdbc.values.Vector.of(new int[] { 6, 6, 6 }));
+	}
+
+	@Test
+	void vectorMustFailWithInvalidType() {
+		var elements = new String[0];
+		assertThatIllegalArgumentException().isThrownBy(() -> ValueFactoryImpl.INSTANCE.vector(String.class, elements))
+			.withMessage("Element type java.lang.String is not a supported element type for vectors");
+	}
+
+}

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/values/ArrayBasedVectorsTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/values/ArrayBasedVectorsTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.values;
+
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class ArrayBasedVectorsTests {
+
+	static Stream<Arguments> hasToString() {
+
+		var longDoubleArray = ThreadLocalRandom.current().doubles(4096).toArray();
+		var doubles = Arrays.stream(longDoubleArray).mapToObj(Double::toString).collect(Collectors.joining(", "));
+
+		return Stream.of(Arguments.of(Vector.of(new byte[1]), "vector([0], 1, INTEGER8 NOT NULL)"),
+				Arguments.of(Vector.of(new short[2]), "vector([0, 0], 2, INTEGER16 NOT NULL)"),
+				Arguments.of(Vector.of(new int[3]), "vector([0, 0, 0], 3, INTEGER32 NOT NULL)"),
+				Arguments.of(Vector.of(new long[4]), "vector([0, 0, 0, 0], 4, INTEGER NOT NULL)"),
+				Arguments.of(Vector.of(new float[5]), "vector([0.0, 0.0, 0.0, 0.0, 0.0], 5, FLOAT32 NOT NULL)"),
+				Arguments.of(Vector.of(new double[6]), "vector([0.0, 0.0, 0.0, 0.0, 0.0, 0.0], 6, FLOAT NOT NULL)"),
+				Arguments.of(Vector.of(longDoubleArray), "vector([%s], 4096, FLOAT NOT NULL)".formatted(doubles))
+
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void hasToString(Vector vector, String expected) {
+		assertThat(vector).hasToString(expected);
+	}
+
+	static Stream<Arguments> nullCheckShouldWork() {
+		return Stream.of(Arguments.of((Supplier<Vector>) () -> Vector.of((byte[]) null)),
+				Arguments.of((Supplier<Vector>) () -> Vector.of((short[]) null)),
+				Arguments.of((Supplier<Vector>) () -> Vector.of((int[]) null)),
+				Arguments.of((Supplier<Vector>) () -> Vector.of((long[]) null)),
+				Arguments.of((Supplier<Vector>) () -> Vector.of((float[]) null)),
+				Arguments.of((Supplier<Vector>) () -> Vector.of((double[]) null)));
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void nullCheckShouldWork(Supplier<Vector> factory) {
+		assertThatNullPointerException().isThrownBy(factory::get)
+			.withMessage("Vector elements must not be literal null");
+	}
+
+	static Stream<Arguments> rangeCheckShouldWorkLower() {
+		return Stream.of(Arguments.of((Supplier<Vector>) () -> Vector.of(new byte[0])),
+				Arguments.of((Supplier<Vector>) () -> Vector.of(new short[0])),
+				Arguments.of((Supplier<Vector>) () -> Vector.of(new int[0])),
+				Arguments.of((Supplier<Vector>) () -> Vector.of(new long[0])),
+				Arguments.of((Supplier<Vector>) () -> Vector.of(new float[0])),
+				Arguments.of((Supplier<Vector>) () -> Vector.of(new double[0])));
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void rangeCheckShouldWorkLower(Supplier<Vector> factory) {
+		assertThatIllegalArgumentException().isThrownBy(factory::get)
+			.withMessage("'0' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	static Stream<Arguments> rangeCheckShouldWorkUpper() {
+		return Stream.of(Arguments.of((Supplier<Vector>) () -> Vector.of(new byte[4097])),
+				Arguments.of((Supplier<Vector>) () -> Vector.of(new short[4097])),
+				Arguments.of((Supplier<Vector>) () -> Vector.of(new int[4097])),
+				Arguments.of((Supplier<Vector>) () -> Vector.of(new long[4097])),
+				Arguments.of((Supplier<Vector>) () -> Vector.of(new float[4097])),
+				Arguments.of((Supplier<Vector>) () -> Vector.of(new double[4097])));
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void rangeCheckShouldWorkUpper(Supplier<Vector> factory) {
+		Vector.CHECK_UPPER_RANGE.compareAndSet(false, true);
+		assertThatIllegalArgumentException().isThrownBy(factory::get)
+			.withMessage("'4097' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@ParameterizedTest
+	@MethodSource("rangeCheckShouldWorkUpper")
+	void rangeCheckShouldWorkUpperDisabled(Supplier<Vector> factory) {
+		Vector.CHECK_UPPER_RANGE.compareAndSet(true, false);
+		assertThatNoException().isThrownBy(factory::get);
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.neo4j</groupId>
 	<artifactId>neo4j-jdbc-parent</artifactId>
-	<version>6.7.4-SNAPSHOT</version>
+	<version>6.8.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>Neo4j JDBC Driver</name>


### PR DESCRIPTION
This change adds support for the new Neo4j vector type. A corresponding new Java type `org.neo4j.jdbc.values.Vector` has been introduced together with the appropriate factory methods. Vectors can be retrieved either through that type or as `java.sql.Array`.

The feature can only be used with Neo4j versions supporting Bolt protocol 6 or higher, in a version with enabled Vector support.