### PR TITLE
refactor: More improvements on the metadata of virtual tables for relationships.

### DIFF
--- a/neo4j-jdbc-it/hibernate-smoke-tests/src/main/java/org/neo4j/jdbc/it/hibernate/Person.java
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/src/main/java/org/neo4j/jdbc/it/hibernate/Person.java
@@ -18,19 +18,29 @@
  */
 package org.neo4j.jdbc.it.hibernate;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 
 @Entity
-public class Movie {
+public class Person {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)
 	private String id;
 
-	private String title;
+	private String name;
+
+	private Integer born;
+
+	@OneToMany(cascade = CascadeType.PERSIST)
+	private Set<Movie> actedIn = new HashSet<>();
 
 	public String getId() {
 		return this.id;
@@ -40,12 +50,24 @@ public class Movie {
 		this.id = id;
 	}
 
-	public String getTitle() {
-		return this.title;
+	public String getName() {
+		return this.name;
 	}
 
-	public void setTitle(String title) {
-		this.title = title;
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Integer getBorn() {
+		return this.born;
+	}
+
+	public void setBorn(Integer born) {
+		this.born = born;
+	}
+
+	public Set<Movie> getMovies() {
+		return this.actedIn;
 	}
 
 }

--- a/neo4j-jdbc-it/hibernate-smoke-tests/src/test/java/org/neo4j/jdbc/it/hibernate/HibernateIT.java
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/src/test/java/org/neo4j/jdbc/it/hibernate/HibernateIT.java
@@ -18,8 +18,8 @@
  */
 package org.neo4j.jdbc.it.hibernate;
 
+import org.assertj.core.api.Assertions;
 import org.hibernate.SessionFactory;
-import org.hibernate.annotations.processing.GenericDialect;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.junit.jupiter.api.AfterAll;
@@ -49,6 +49,7 @@ class HibernateIT {
 	void startNeo4j() {
 		this.neo4j.start();
 		this.sessionFactory = new Configuration().addAnnotatedClass(Movie.class)
+			.addAnnotatedClass(Person.class)
 			.setProperty(AvailableSettings.JAKARTA_JDBC_DRIVER, Neo4jDriver.class)
 			.setProperty(AvailableSettings.JAKARTA_JDBC_URL,
 					"jdbc:neo4j://" + this.neo4j.getHost() + ":" + this.neo4j.getMappedPort(7687)
@@ -58,8 +59,8 @@ class HibernateIT {
 			.setProperty(AvailableSettings.SHOW_SQL, true)
 			.setProperty(AvailableSettings.FORMAT_SQL, true)
 			.setProperty(AvailableSettings.HIGHLIGHT_SQL, true)
-			.setProperty(AvailableSettings.DIALECT, GenericDialect.class)
-
+			.setProperty(AvailableSettings.DIALECT, Neo4jDialect.class)
+			.setProperty(AvailableSettings.IMPLICIT_NAMING_STRATEGY, Neo4jNamingStrategy.class)
 			.buildSessionFactory();
 	}
 
@@ -76,6 +77,13 @@ class HibernateIT {
 								WITH n DETACH DELETE n
 							}
 							IN TRANSACTIONS OF 1000 ROWs""");
+
+					stmt.execute("""
+							/*+ NEO4J FORCE_CYPHER */
+							CREATE (p:Person {id: randomUUID(), name: 'Helge Schneider', born: 1995})
+							       -[:ACTED_IN {roles: ['Himself']}]
+							       ->(:Movie {id: randomUUID(), title: 'The Klimperclown'})
+							""");
 				}
 			});
 		}
@@ -100,12 +108,13 @@ class HibernateIT {
 
 		this.sessionFactory.inSession(session -> {
 			var tx = session.beginTransaction();
-			var movies = session.createSelectionQuery("from Movie", Movie.class).getResultList();
+			var movies = session.createSelectionQuery("from Movie where title like 'Winter%'", Movie.class)
+				.getResultList();
 			assertThat(movies).hasSize(1).first().satisfies(m -> {
 				assertThat(m.getId()).isNotNull();
 				assertThat(m.getTitle()).isEqualTo("Winter is coming.");
+				m.setTitle("We hibernated.");
 			});
-			movies.get(0).setTitle("We hibernated.");
 			tx.commit();
 		});
 
@@ -119,8 +128,53 @@ class HibernateIT {
 
 		this.sessionFactory.inSession(session -> {
 			var movies = session.createSelectionQuery("from Movie", Movie.class).getResultList();
-			assertThat(movies).isEmpty();
+			assertThat(movies).hasSize(1).first().satisfies(m -> {
+				assertThat(m.getId()).isNotNull();
+				assertThat(m.getTitle()).isEqualTo("The Klimperclown");
+			});
 		});
+	}
+
+	@Test
+	void shouldBeAbleToWorkWithRelationships() {
+		this.sessionFactory.inSession(session -> {
+			var people = session.createSelectionQuery("from Person", Person.class).getResultList();
+			assertThat(people).hasSize(1).first().satisfies(p -> {
+				assertThat(p.getName()).isEqualTo("Helge Schneider");
+				assertThat(p.getMovies()).hasSize(1);
+			});
+		});
+
+		this.sessionFactory.inSession(session -> {
+			var person = new Person();
+			person.setName("Jack Nicholson");
+			var movie = new Movie();
+			movie.setTitle("The Shining");
+			person.getMovies().add(movie);
+
+			var tx = session.beginTransaction();
+			session.persist(person);
+			tx.commit();
+		});
+
+		this.sessionFactory.inSession(session -> session.doWork(connection -> {
+			try (var stmt = connection.createStatement()) {
+				var rs = stmt.executeQuery("/*+ NEO4J FORCE_CYPHER */ MATCH (n:Person) RETURN count(n)");
+				rs.next();
+				Assertions.assertThat(rs.getInt(1)).isEqualTo(2L);
+				rs.close();
+
+				rs = stmt.executeQuery("/*+ NEO4J FORCE_CYPHER */ MATCH (n:Movie) RETURN count(n)");
+				rs.next();
+				Assertions.assertThat(rs.getInt(1)).isEqualTo(2L);
+				rs.close();
+
+				rs = stmt.executeQuery("/*+ NEO4J FORCE_CYPHER */ MATCH ()-[r:ACTED_IN]->() RETURN count(r)");
+				rs.next();
+				Assertions.assertThat(rs.getInt(1)).isEqualTo(2L);
+				rs.close();
+			}
+		}));
 	}
 
 }

--- a/neo4j-jdbc-it/hibernate-smoke-tests/src/test/java/org/neo4j/jdbc/it/hibernate/Neo4jDialect.java
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/src/test/java/org/neo4j/jdbc/it/hibernate/Neo4jDialect.java
@@ -18,34 +18,15 @@
  */
 package org.neo4j.jdbc.it.hibernate;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import org.hibernate.annotations.processing.GenericDialect;
+import org.hibernate.sql.ast.SqlAstTranslatorFactory;
+import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 
-@Entity
-public class Movie {
+public final class Neo4jDialect extends GenericDialect {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.UUID)
-	private String id;
-
-	private String title;
-
-	public String getId() {
-		return this.id;
-	}
-
-	public void setId(String id) {
-		this.id = id;
-	}
-
-	public String getTitle() {
-		return this.title;
-	}
-
-	public void setTitle(String title) {
-		this.title = title;
+	@Override
+	public SqlAstTranslatorFactory getSqlAstTranslatorFactory() {
+		return new StandardSqlAstTranslatorFactory();
 	}
 
 }

--- a/neo4j-jdbc-translator/impl/src/test/resources/joins.adoc
+++ b/neo4j-jdbc-translator/impl/src/test/resources/joins.adoc
@@ -38,7 +38,7 @@ MATCH (p:Person)-->(m:Movie) RETURN p, m
 `NATURAL` joins can be chained, and the connecting join table does not need to exist.
 This will be turned into a Neo4j relationship:
 
-[source,sql,id=nj2,name=naturalJoins,metaData=Movie:title|released]
+[source,sql,id=nj2,name=naturalJoins,metaData=Movie:title|released;ACTED_IN:roles;Person_ACTED_IN_Movie:roles]
 ----
 SELECT p.name, r.roles, m.* FROM Person p
 NATURAL JOIN ACTED_IN r

--- a/neo4j-jdbc/src/main/resources/queries/DatabaseMetadata.properties
+++ b/neo4j-jdbc/src/main/resources/queries/DatabaseMetadata.properties
@@ -230,8 +230,7 @@ getColumns=// First part gets simple node properties \
 \n // Unionised with all relationship properties \
 \n CALL db.schema.relTypeProperties() YIELD relType, propertyName, propertyTypes \
 \n WITH substring(relType, 2, size(relType)-3) AS relationshipType, propertyName, propertyTypes \
-\n WHERE propertyName IS NOT NULL \
-\n   AND ($column_name IS NULL OR propertyName =~ $column_name) \
+\n WHERE ($column_name IS NULL OR propertyName =~ $column_name) \
 \n CALL { \
 \n   // Determining start and end of all relationships in question, to compute the virtual table name (and filter on that) \
 \n   WITH relationshipType \
@@ -251,7 +250,6 @@ getColumns=// First part gets simple node properties \
 \n   CALL db.schema.nodeTypeProperties() YIELD nodeLabels, propertyName, propertyTypes \
 \n   WITH *, ANY (label IN nodeLabels WHERE label = from) AS is_start, ANY (label IN nodeLabels WHERE label = to) AS is_end  \
 \n   WHERE (is_start OR is_end) \
-\n     AND propertyName IS NOT NULL \
 \n     AND ($column_name IS NULL OR propertyName =~ $column_name) \
 \n   RETURN propertyName, propertyTypes, \
 \n          CASE WHEN is_start THEN from \


### PR DESCRIPTION
- If a property is present in both the relationship and in one or both of the nodes, it will be prefixed with the node label in the virtual column
- relationships without properties will now appear as virtual tables too
- prefxed id columns will be treated as join columns in the translator if available

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
