### PR TITLE
feat(translator): Add support for `LEFT JOIN` and improve flattening of joins.

### DIFF
--- a/neo4j-jdbc-it/hibernate-smoke-tests/src/main/java/org/neo4j/jdbc/it/hibernate/Actor.java
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/src/main/java/org/neo4j/jdbc/it/hibernate/Actor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023-2025 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.it.hibernate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Person_ACTED_IN_Movie")
+public class Actor {
+
+	@EmbeddedId
+	private ActorId id;
+
+	@ManyToOne
+	@MapsId("movieId")
+	private Movie movie;
+
+	@ManyToOne
+	@MapsId("personId")
+	private Person person;
+
+	private List<String> roles = new ArrayList<>();
+
+	public Actor() {
+	}
+
+	public ActorId getId() {
+		return this.id;
+	}
+
+	public void setId(ActorId id) {
+		this.id = id;
+	}
+
+	public Movie getMovie() {
+		return this.movie;
+	}
+
+	public void setMovie(Movie movie) {
+		this.movie = movie;
+	}
+
+	public Person getPerson() {
+		return this.person;
+	}
+
+	public void setPerson(Person person) {
+		this.person = person;
+	}
+
+	public List<String> getRoles() {
+		return this.roles;
+	}
+
+	@Embeddable
+	public record ActorId(String movieId, String personId) {
+
+		public ActorId() {
+			this(null, null);
+		}
+	}
+
+}

--- a/neo4j-jdbc-it/hibernate-smoke-tests/src/main/java/org/neo4j/jdbc/it/hibernate/Movie.java
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/src/main/java/org/neo4j/jdbc/it/hibernate/Movie.java
@@ -18,10 +18,15 @@
  */
 package org.neo4j.jdbc.it.hibernate;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
 
 @Entity
 public class Movie {
@@ -31,6 +36,12 @@ public class Movie {
 	private String id;
 
 	private String title;
+
+	@OneToMany(mappedBy = "movie")
+	private Set<Actor> actors = new HashSet<>();
+
+	@ManyToMany(mappedBy = "directed")
+	private Set<Person> directors = new HashSet<>();
 
 	public String getId() {
 		return this.id;
@@ -46,6 +57,14 @@ public class Movie {
 
 	public void setTitle(String title) {
 		this.title = title;
+	}
+
+	public Set<Actor> getActors() {
+		return this.actors;
+	}
+
+	public Set<Person> getDirectors() {
+		return this.directors;
 	}
 
 }

--- a/neo4j-jdbc-it/hibernate-smoke-tests/src/main/java/org/neo4j/jdbc/it/hibernate/Person.java
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/src/main/java/org/neo4j/jdbc/it/hibernate/Person.java
@@ -26,7 +26,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.ManyToMany;
 
 @Entity
 public class Person {
@@ -39,8 +39,8 @@ public class Person {
 
 	private Integer born;
 
-	@OneToMany(cascade = CascadeType.PERSIST)
-	private Set<Movie> actedIn = new HashSet<>();
+	@ManyToMany(cascade = CascadeType.PERSIST)
+	private Set<Movie> directed = new HashSet<>();
 
 	public String getId() {
 		return this.id;
@@ -66,8 +66,8 @@ public class Person {
 		this.born = born;
 	}
 
-	public Set<Movie> getMovies() {
-		return this.actedIn;
+	public Set<Movie> getMoviesDirected() {
+		return this.directed;
 	}
 
 }

--- a/neo4j-jdbc-it/hibernate-smoke-tests/src/test/java/org/neo4j/jdbc/it/hibernate/Neo4jDialect.java
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/src/test/java/org/neo4j/jdbc/it/hibernate/Neo4jDialect.java
@@ -29,4 +29,9 @@ public final class Neo4jDialect extends GenericDialect {
 		return new StandardSqlAstTranslatorFactory();
 	}
 
+	@Override
+	public boolean supportsStandardArrays() {
+		return true;
+	}
+
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
@@ -1112,7 +1112,7 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 
 		// Distribution of property names
 		var propertyCount = new HashMap<Value, AtomicInteger>();
-		for (Record record : records) {
+		for (Record record : records) { @SuppressWarnings("squid:S3047")
 
 			var propertyName = record.get(1);
 			propertyCount.computeIfAbsent(propertyName, ignored -> new AtomicInteger()).incrementAndGet();


### PR DESCRIPTION
This add support for explicit left joins and also improves the flattening of joins, that is: If there’s enough probability that the start or end of relationship table is matched by a node table given the existing schema columns, the join is flattened.

In terms of columns returned: Columns projected from a relationship table will now always be alias, so that they don’t conflict with columns projected from the node tables.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
