### PR TITLE
refactor(metadata): Match only Nodes with all labels matching start/end for virtual relationship tables.

### DIFF
--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/AbstractDatabaseMetadata.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/AbstractDatabaseMetadata.java
@@ -1180,11 +1180,11 @@ abstract class AbstractDatabaseMetadata extends IntegrationTestBase {
 					CREATE (a1)-[:ACTED_IN {role: 'Polizist im Gewahrsam'}]->(:Movie {title: 'Der demokratische Terrorist', release:1992})
 				""";
 
-		try (var connection = getConnection(true, true)) {
-			try (var stmt = connection.createStatement()) {
+		try (var con = getConnection(true, true)) {
+			try (var stmt = con.createStatement()) {
 				stmt.execute(graph);
 			}
-			var meta = connection.getMetaData();
+			var meta = con.getMetaData();
 			try (var rs = meta.getColumns(null, null, "Person_ACTED_IN_Movie", null)) {
 				var columnNames = new ArrayList<String>();
 				while (rs.next()) {
@@ -1194,7 +1194,7 @@ abstract class AbstractDatabaseMetadata extends IntegrationTestBase {
 						"release", "title", "role");
 			}
 
-			try (var stmt = connection.createStatement();
+			try (var stmt = con.createStatement();
 					var rs = stmt.executeQuery("SELECT * FROM Person_ACTED_IN_Movie")) {
 				var values = new ArrayList<String>();
 				while (rs.next()) {

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/AbstractDatabaseMetadata.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/AbstractDatabaseMetadata.java
@@ -1194,8 +1194,7 @@ abstract class AbstractDatabaseMetadata extends IntegrationTestBase {
 						"release", "title", "role");
 			}
 
-			try (var stmt = con.createStatement();
-					var rs = stmt.executeQuery("SELECT * FROM Person_ACTED_IN_Movie")) {
+			try (var stmt = con.createStatement(); var rs = stmt.executeQuery("SELECT * FROM Person_ACTED_IN_Movie")) {
 				var values = new ArrayList<String>();
 				while (rs.next()) {
 					values.add(rs.getString("born") + "_" + rs.getString("release"));

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/AbstractDatabaseMetadata.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/AbstractDatabaseMetadata.java
@@ -1167,6 +1167,45 @@ abstract class AbstractDatabaseMetadata extends IntegrationTestBase {
 	}
 
 	@Test
+	void onlyMatchingStartAndEndLabelsMustBeConsideredForProperties() throws SQLException {
+		var graph = """
+					/*+ NEO4J FORCE_CYPHER */
+					CREATE (:Person:A {name: 'Christoph Schlingensief', born: localdatetime({year: 1960})})
+					CREATE (:Person:B {name: 'Per Berglund', born: 1939})
+					CREATE (a1:Person:C {name: 'Alfred Edel', born: "1932"})
+					CREATE (a2:Person:D {name: 'Karina Fallenstein', born: 1961})
+					CREATE (m:Movie {title: 'Das deutsche Kettensägenmassaker', release:"1990"})
+					CREATE (a1)-[:ACTED_IN {role: 'Alfred'}]->(m)
+					CREATE (a2)-[:ACTED_IN {role: 'Clara'}]->(m)
+					CREATE (a1)-[:ACTED_IN {role: 'Polizist im Gewahrsam'}]->(:Movie {title: 'Der demokratische Terrorist', release:1992})
+				""";
+
+		try (var connection = getConnection(true, true)) {
+			try (var stmt = connection.createStatement()) {
+				stmt.execute(graph);
+			}
+			var meta = connection.getMetaData();
+			try (var rs = meta.getColumns(null, null, "Person_ACTED_IN_Movie", null)) {
+				var columnNames = new ArrayList<String>();
+				while (rs.next()) {
+					columnNames.add(rs.getString("COLUMN_NAME"));
+				}
+				assertThat(columnNames).containsExactlyInAnyOrder("v$movie_id", "v$person_id", "v$id", "born", "name",
+						"release", "title", "role");
+			}
+
+			try (var stmt = connection.createStatement();
+					var rs = stmt.executeQuery("SELECT * FROM Person_ACTED_IN_Movie")) {
+				var values = new ArrayList<String>();
+				while (rs.next()) {
+					values.add(rs.getString("born") + "_" + rs.getString("release"));
+				}
+				assertThat(values).containsExactlyInAnyOrder("1932_1992", "1932_1990", "1961_1990");
+			}
+		}
+	}
+
+	@Test
 	void getTablesWithStrictPattern() throws SQLException {
 
 		try (Statement statement = this.connection.createStatement()) {

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/TranslationIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/TranslationIT.java
@@ -231,6 +231,45 @@ class TranslationIT extends IntegrationTestBase {
 		}
 	}
 
+	@Test
+	void onlyMatchingStartAndEndLabelsMustBeConsideredForProperties() throws SQLException {
+		var graph = """
+					/*+ NEO4J FORCE_CYPHER */
+					CREATE (:Person:A {name: 'Christoph Schlingensief', born: localdatetime({year: 1960})})
+					CREATE (:Person:B {name: 'Per Berglund', born: 1939})
+					CREATE (a1:Person {name: 'Alfred Edel', born: "1932"})
+					CREATE (a2:Person {name: 'Karina Fallenstein', born: 1961})
+					CREATE (m:Movie {title: 'Das deutsche Kettensägenmassaker', release:"1990"})
+					CREATE (a1)-[:ACTED_IN {role: 'Alfred'}]->(m)
+					CREATE (a2)-[:ACTED_IN {role: 'Clara'}]->(m)
+					CREATE (a1)-[:ACTED_IN {role: 'Polizist im Gewahrsam'}]->(:Movie {title: 'Der demokratische Terrorist', release:1992})
+				""";
+
+		try (var connection = getConnection(true, true)) {
+			try (var stmt = connection.createStatement()) {
+				stmt.execute(graph);
+			}
+			var meta = connection.getMetaData();
+			try (var rs = meta.getColumns(null, null, "Person_ACTED_IN_Movie", null)) {
+				var columnNames = new ArrayList<String>();
+				while (rs.next()) {
+					columnNames.add(rs.getString("COLUMN_NAME"));
+				}
+				assertThat(columnNames).containsExactlyInAnyOrder("v$movie_id", "v$person_id", "v$id", "born", "name",
+						"release", "title", "role");
+			}
+
+			try (var stmt = connection.createStatement();
+					var rs = stmt.executeQuery("SELECT * FROM Person_ACTED_IN_Movie")) {
+				var values = new ArrayList<String>();
+				while (rs.next()) {
+					values.add(rs.getString("born") + "_" + rs.getString("release"));
+				}
+				assertThat(values).containsExactlyInAnyOrder("1932_1992", "1932_1990", "1961_1990");
+			}
+		}
+	}
+
 	private static void assertMovieAndPersonCreated(Connection connection) throws SQLException {
 		try (var statement = connection.createStatement();
 				var rs = statement.executeQuery(

--- a/neo4j-jdbc/src/main/resources/queries/DatabaseMetadata.properties
+++ b/neo4j-jdbc/src/main/resources/queries/DatabaseMetadata.properties
@@ -248,7 +248,7 @@ getColumns=// First part gets simple node properties \
 \n   // Subquery to unionise the relationship properties with the properties of start and end node \
 \n   WITH from, to, relPropertyName, relPropertyTypes \
 \n   CALL db.schema.nodeTypeProperties() YIELD nodeLabels, propertyName, propertyTypes \
-\n   WITH *, ANY (label IN nodeLabels WHERE label = from) AS is_start, ANY (label IN nodeLabels WHERE label = to) AS is_end  \
+\n   WITH *, ALL (label IN nodeLabels WHERE label = from) AS is_start, ALL (label IN nodeLabels WHERE label = to) AS is_end  \
 \n   WHERE (is_start OR is_end) \
 \n     AND ($column_name IS NULL OR propertyName =~ $column_name) \
 \n   RETURN propertyName, propertyTypes, \

--- a/neo4j-jdbc/src/main/resources/queries/DatabaseMetadata.properties
+++ b/neo4j-jdbc/src/main/resources/queries/DatabaseMetadata.properties
@@ -248,10 +248,10 @@ getColumns=// First part gets simple node properties \
 \n   // Subquery to unionise the relationship properties with the properties of start and end node \
 \n   WITH from, to, relPropertyName, relPropertyTypes \
 \n   CALL db.schema.nodeTypeProperties() YIELD nodeLabels, propertyName, propertyTypes \
-\n   WITH *, ALL (label IN nodeLabels WHERE label = from) AS is_start, ALL (label IN nodeLabels WHERE label = to) AS is_end  \
+\n   WITH *, ANY (label IN nodeLabels WHERE label = from) AS is_start, ANY (label IN nodeLabels WHERE label = to) AS is_end \
 \n   WHERE (is_start OR is_end) \
 \n     AND ($column_name IS NULL OR propertyName =~ $column_name) \
-\n   RETURN propertyName, propertyTypes, \
+\n   RETURN propertyName, reduce(all = [], elem IN collect(propertyTypes) | all + elem) AS propertyTypes, \
 \n          CASE WHEN is_start THEN from \
 \n               WHEN is_end   THEN to   END AS SCOPE_TABLE, \
 \n          CASE WHEN is_start THEN 1 \


### PR DESCRIPTION
Virtual relationship tables such as `Person_ACTED_IN_Movie` do specifically use only *one* label per start and end node.
As such, we must only look for properties on nodes of which that label match, not all the others.
