### PR TITLE
feat: Add support for explicit grouping keys and the `HAVING` and `OFFSET` clauses.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,11 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}
 
-      - name: 'Disable Sonar (Keeps on failing on their side since ~January 2026)'
+      - name: 'Enable Sonar for local PRs not from Dependabot'
+        if:  ${{ github.event.sender.login != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        run: echo "USE_SONAR=sonar" >> $GITHUB_ENV
+      - name: 'Disable Sonar for foreign PRs or from Dependabot'
+        if:  ${{ github.event.sender.login == 'dependabot[bot]' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
         run: echo "USE_SONAR=-sonar" >> $GITHUB_ENV
 
       - name: 'Cache SonarQube packages'

--- a/benchkit/pom.xml
+++ b/benchkit/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-benchkit</artifactId>
 

--- a/bundles/neo4j-jdbc-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/bundles/neo4j-jdbc-full-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-full-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/bundles/neo4j-jdbc-text2cypher-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-text2cypher-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-dist</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-docs</artifactId>

--- a/docs/src/main/asciidoc/modules/ROOT/pages/sql2cypher.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/pages/sql2cypher.adoc
@@ -172,6 +172,8 @@ include::translator/predicates.adoc[leveloffset=+2]
 
 include::translator/joins.adoc[leveloffset=+2]
 
+include::translator/grouping.adoc[leveloffset=+2]
+
 include::translator/dml.adoc[leveloffset=+2]
 
 [#s2c_manipulating_relationships]

--- a/neo4j-jdbc-authn/kc/pom.xml
+++ b/neo4j-jdbc-authn/kc/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-authn</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-authn-kc</artifactId>

--- a/neo4j-jdbc-authn/pom.xml
+++ b/neo4j-jdbc-authn/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-authn</artifactId>
 

--- a/neo4j-jdbc-authn/spi/pom.xml
+++ b/neo4j-jdbc-authn/spi/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-authn</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-authn-spi</artifactId>

--- a/neo4j-jdbc-bom/pom.xml
+++ b/neo4j-jdbc-bom/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-bom</artifactId>

--- a/neo4j-jdbc-it/hibernate-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-hibernate-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/mybatis-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/mybatis-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-mybatis-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-cp</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/TranslationIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/TranslationIT.java
@@ -834,7 +834,7 @@ class TranslationIT extends IntegrationTestBase {
 					INNER JOIN `public`.`Person_DIRECTED_Movie` `Person_DIRECTED_Movie`
 					ON (`Movie`.`v$id` = `Person_DIRECTED_Movie`.`v$id`) GROUP BY `name`, `v_movie_id`""");
 			assertThat(cypher).isEqualTo(
-					"MATCH (_start:Person)-[person_directed_movie:DIRECTED]->(movie:Movie) RETURN movie.title AS title, elementId(movie) AS v_movie_id");
+					"MATCH (_start:Person)-[person_directed_movie:DIRECTED]->(movie:Movie) WITH movie.title AS title, elementId(movie) AS v_movie_id, _start.name AS __group_col_0 RETURN title, v_movie_id");
 		}
 
 	}

--- a/neo4j-jdbc-it/neo4j-jdbc-it-mp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-mp/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-mp</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-sso/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-sso/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-sso</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-stub/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-stub/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-stub</artifactId>
 

--- a/neo4j-jdbc-it/pom.xml
+++ b/neo4j-jdbc-it/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it</artifactId>
 

--- a/neo4j-jdbc-it/quarkus-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/quarkus-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-quarkus-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/spring-boot-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/spring-boot-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-spring-boot-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-test-results/pom.xml
+++ b/neo4j-jdbc-test-results/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-test-results</artifactId>

--- a/neo4j-jdbc-tracing/micrometer/pom.xml
+++ b/neo4j-jdbc-tracing/micrometer/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-tracing</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-tracing-micrometer</artifactId>

--- a/neo4j-jdbc-tracing/pom.xml
+++ b/neo4j-jdbc-tracing/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-tracing</artifactId>
 

--- a/neo4j-jdbc-translator/impl/pom.xml
+++ b/neo4j-jdbc-translator/impl/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-impl</artifactId>

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/Aggregates.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/Aggregates.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.translator.impl;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.jooq.Condition;
+import org.jooq.Field;
+import org.jooq.impl.QOM;
+
+final class Aggregates implements Iterable<Field<?>> {
+
+	/**
+	 * Walks a jOOQ {@link Condition} tree and collects all aggregate sub-expressions
+	 * found within it. Handles logical connectives ({@code AND}, {@code OR}, {@code XOR},
+	 * {@code NOT}), comparison operators ({@code >}, {@code >=}, {@code <}, {@code <=},
+	 * {@code =}, {@code <>}, {@code IS DISTINCT FROM}, {@code IS NOT DISTINCT FROM}),
+	 * {@code BETWEEN}, {@code IS NULL}, {@code IS NOT NULL}, {@code IN}, {@code NOT IN},
+	 * {@code LIKE}, {@code NOT LIKE}, {@code LIKE} (case-insensitive), {@code NOT LIKE}
+	 * (case-insensitive), and arithmetic expressions ({@code +}, {@code -}, {@code *},
+	 * {@code /}) that may contain nested aggregates.
+	 * @param condition the condition tree to walk
+	 * @return a list of all aggregate {@link Field} instances found (may contain
+	 * duplicates)
+	 */
+	static Aggregates of(Condition condition) {
+		var result = new ArrayList<Field<?>>();
+		collectAggregatesFromCondition(condition, result);
+		return new Aggregates(result);
+	}
+
+	static boolean isAggregate(Field<?> f) {
+		return f instanceof QOM.Count || f instanceof QOM.Sum || f instanceof QOM.Min || f instanceof QOM.Max
+				|| f instanceof QOM.Avg || f instanceof QOM.StddevSamp || f instanceof QOM.StddevPop;
+	}
+
+	private static void collectAggregatesFromCondition(Condition condition, List<Field<?>> result) {
+		if (condition instanceof QOM.And and) {
+			collectAggregatesFromCondition(and.$arg1(), result);
+			collectAggregatesFromCondition(and.$arg2(), result);
+		}
+		else if (condition instanceof QOM.Or or) {
+			collectAggregatesFromCondition(or.$arg1(), result);
+			collectAggregatesFromCondition(or.$arg2(), result);
+		}
+		else if (condition instanceof QOM.Xor xor) {
+			collectAggregatesFromCondition(xor.$arg1(), result);
+			collectAggregatesFromCondition(xor.$arg2(), result);
+		}
+		else if (condition instanceof QOM.Not not) {
+			collectAggregatesFromCondition(not.$arg1(), result);
+		}
+		else if (condition instanceof QOM.Gt<?> gt) {
+			collectAggregatesFromField(gt.$arg1(), result);
+			collectAggregatesFromField(gt.$arg2(), result);
+		}
+		else if (condition instanceof QOM.Ge<?> ge) {
+			collectAggregatesFromField(ge.$arg1(), result);
+			collectAggregatesFromField(ge.$arg2(), result);
+		}
+		else if (condition instanceof QOM.Lt<?> lt) {
+			collectAggregatesFromField(lt.$arg1(), result);
+			collectAggregatesFromField(lt.$arg2(), result);
+		}
+		else if (condition instanceof QOM.Le<?> le) {
+			collectAggregatesFromField(le.$arg1(), result);
+			collectAggregatesFromField(le.$arg2(), result);
+		}
+		else if (condition instanceof QOM.Eq<?> eq) {
+			collectAggregatesFromField(eq.$arg1(), result);
+			collectAggregatesFromField(eq.$arg2(), result);
+		}
+		else if (condition instanceof QOM.Ne<?> ne) {
+			collectAggregatesFromField(ne.$arg1(), result);
+			collectAggregatesFromField(ne.$arg2(), result);
+		}
+		else if (condition instanceof QOM.Between<?> between) {
+			collectAggregatesFromField(between.$arg1(), result);
+			collectAggregatesFromField(between.$arg2(), result);
+			collectAggregatesFromField(between.$arg3(), result);
+		}
+		else if (condition instanceof QOM.IsNull isNull) {
+			collectAggregatesFromField(isNull.$arg1(), result);
+		}
+		else if (condition instanceof QOM.IsNotNull isNotNull) {
+			collectAggregatesFromField(isNotNull.$arg1(), result);
+		}
+		else if (condition instanceof QOM.InList<?> inList) {
+			collectAggregatesFromField(inList.$field(), result);
+			for (var element : inList.$list()) {
+				collectAggregatesFromField(element, result);
+			}
+		}
+		else if (condition instanceof QOM.Like like) {
+			collectAggregatesFromField(like.$arg1(), result);
+			collectAggregatesFromField(like.$arg2(), result);
+		}
+		else if (condition instanceof QOM.NotLike notLike) {
+			collectAggregatesFromField(notLike.$arg1(), result);
+			collectAggregatesFromField(notLike.$arg2(), result);
+		}
+		else if (condition instanceof QOM.LikeIgnoreCase likeIc) {
+			collectAggregatesFromField(likeIc.$arg1(), result);
+			collectAggregatesFromField(likeIc.$arg2(), result);
+		}
+		else if (condition instanceof QOM.NotLikeIgnoreCase notLikeIc) {
+			collectAggregatesFromField(notLikeIc.$arg1(), result);
+			collectAggregatesFromField(notLikeIc.$arg2(), result);
+		}
+		else if (condition instanceof QOM.NotInList<?> notInList) {
+			collectAggregatesFromField(notInList.$field(), result);
+			for (var element : notInList.$list()) {
+				collectAggregatesFromField(element, result);
+			}
+		}
+		else if (condition instanceof QOM.IsDistinctFrom<?> isDistinctFrom) {
+			collectAggregatesFromField(isDistinctFrom.$arg1(), result);
+			collectAggregatesFromField(isDistinctFrom.$arg2(), result);
+		}
+		else if (condition instanceof QOM.IsNotDistinctFrom<?> isNotDistinctFrom) {
+			collectAggregatesFromField(isNotDistinctFrom.$arg1(), result);
+			collectAggregatesFromField(isNotDistinctFrom.$arg2(), result);
+		}
+	}
+
+	private static void collectAggregatesFromField(Field<?> field, List<Field<?>> result) {
+		if (field == null) {
+			return;
+		}
+		if (isAggregate(field)) {
+			result.add(field);
+		}
+		else if (field instanceof QOM.Add<?> add) {
+			collectAggregatesFromField(add.$arg1(), result);
+			collectAggregatesFromField(add.$arg2(), result);
+		}
+		else if (field instanceof QOM.Sub<?> sub) {
+			collectAggregatesFromField(sub.$arg1(), result);
+			collectAggregatesFromField(sub.$arg2(), result);
+		}
+		else if (field instanceof QOM.Mul<?> mul) {
+			collectAggregatesFromField(mul.$arg1(), result);
+			collectAggregatesFromField(mul.$arg2(), result);
+		}
+		else if (field instanceof QOM.Div<?> div) {
+			collectAggregatesFromField(div.$arg1(), result);
+			collectAggregatesFromField(div.$arg2(), result);
+		}
+	}
+
+	private final List<Field<?>> value;
+
+	private Aggregates(List<Field<?>> value) {
+		this.value = value;
+	}
+
+	@Override
+	public Iterator<Field<?>> iterator() {
+		return this.value.iterator();
+	}
+
+}

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/Aggregates.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/Aggregates.java
@@ -52,6 +52,7 @@ final class Aggregates implements Iterable<Field<?>> {
 				|| f instanceof QOM.Avg || f instanceof QOM.StddevSamp || f instanceof QOM.StddevPop;
 	}
 
+	@SuppressWarnings("squid:S3776") // Yep, this is complex.
 	private static void collectAggregatesFromCondition(Condition condition, List<Field<?>> result) {
 		if (condition instanceof QOM.And and) {
 			collectAggregatesFromCondition(and.$arg1(), result);

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/AliasRegistry.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/AliasRegistry.java
@@ -21,6 +21,7 @@ package org.neo4j.jdbc.translator.impl;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.jooq.Field;
@@ -50,7 +51,7 @@ final class AliasRegistry {
 	void register(Field<?> field, String alias) {
 		var unwrapped = unwrap(field);
 		this.entries.add(new AliasEntry(unwrapped, alias));
-		this.aliasByName.putIfAbsent(alias.toUpperCase(), alias);
+		this.aliasByName.putIfAbsent(alias.toUpperCase(Locale.ROOT), alias);
 	}
 
 	/**
@@ -73,8 +74,7 @@ final class AliasRegistry {
 		}
 
 		// 2. Name-based matching (field.getName() against registered alias strings)
-		var nameKey = unwrapped.getName().toUpperCase();
-		return this.aliasByName.get(nameKey);
+		return this.aliasByName.get(unwrapped.getName().toUpperCase(Locale.ROOT));
 	}
 
 	private static Field<?> unwrap(Field<?> field) {

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/AliasRegistry.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/AliasRegistry.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.translator.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jooq.Field;
+import org.jooq.impl.QOM;
+
+/**
+ * Registry that maps jOOQ field expressions to their WITH clause aliases. Supports two
+ * lookup modes: structural matching (for aggregate expressions) and name-based matching
+ * (for alias references that jOOQ does not resolve).
+ *
+ * @author Ryan Knight
+ * @author Michael J. Simons
+ */
+final class AliasRegistry {
+
+	private final List<AliasEntry> entries = new ArrayList<>();
+
+	private final Map<String, String> aliasByName = new HashMap<>();
+
+	/**
+	 * Registers a field expression with its alias. The field is unwrapped from any
+	 * {@link QOM.FieldAlias} wrapper before storage. First registration wins if the same
+	 * expression is registered twice.
+	 * @param field the field expression
+	 * @param alias the alias string
+	 */
+	void register(Field<?> field, String alias) {
+		var unwrapped = unwrap(field);
+		this.entries.add(new AliasEntry(unwrapped, alias));
+		this.aliasByName.putIfAbsent(alias.toUpperCase(), alias);
+	}
+
+	/**
+	 * Looks up the alias for a given field. Tries structural matching first (for
+	 * aggregates), then falls back to name-based matching (for unresolved alias
+	 * references like {@code HAVING cnt > 5} or {@code ORDER BY cnt}). Returns
+	 * {@code null} if no match is found.
+	 * @param field the field to look up
+	 * @return the alias, or {@code null} if no match is found
+	 */
+	String resolve(Field<?> field) {
+		var unwrapped = unwrap(field);
+
+		// 1. Structural matching against all registered entries
+		var equivalence = new FieldEquivalencePredicate();
+		for (var entry : this.entries) {
+			if (equivalence.test(entry.field(), unwrapped)) {
+				return entry.alias();
+			}
+		}
+
+		// 2. Name-based matching (field.getName() against registered alias strings)
+		var nameKey = unwrapped.getName().toUpperCase();
+		return this.aliasByName.get(nameKey);
+	}
+
+	private static Field<?> unwrap(Field<?> field) {
+		if (field instanceof QOM.FieldAlias<?> fa) {
+			return fa.$field();
+		}
+		return field;
+	}
+
+	private record AliasEntry(Field<?> field, String alias) {
+	}
+
+}

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/FieldEquivalencePredicate.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/FieldEquivalencePredicate.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.translator.impl;
+
+import java.util.function.BiPredicate;
+
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.QOM;
+
+/**
+ * Structural field equivalence matcher for jOOQ QOM fields. Determines whether two jOOQ
+ * Field objects represent the same expression, ignoring alias wrappers. Used by the alias
+ * registry for GROUP BY, HAVING, and ORDER BY alias resolution.
+ *
+ * @author Ryan Knight
+ * @author Michael J. Simons
+ */
+final class FieldEquivalencePredicate implements BiPredicate<Field<?>, Field<?>> {
+
+	/**
+	 * Determines whether two jOOQ {@link Field} objects represent the same expression.
+	 * Alias wrappers are stripped before comparison. Supports aggregate functions
+	 * ({@code count}, {@code sum}, {@code min}, {@code max}, {@code avg},
+	 * {@code stddev_samp}, {@code stddev_pop}), simple column references (with or without
+	 * table qualifiers), and combinations thereof.
+	 * @param a the first field
+	 * @param b the second field
+	 * @return {@code true} if the fields are structurally equivalent
+	 */
+	@Override
+	public boolean test(Field<?> a, Field<?> b) {
+		if (a == null || b == null) {
+			return false;
+		}
+
+		// Case 1: Alias unwrapping — aliases are presentation, not identity
+		if (a instanceof QOM.FieldAlias<?> fa) {
+			return test(fa.$field(), b);
+		}
+		if (b instanceof QOM.FieldAlias<?> fb) {
+			return test(a, fb.$field());
+		}
+
+		// Case 2: Aggregate function matching
+		if (a instanceof QOM.Count ca && b instanceof QOM.Count cb) {
+			if (ca.$distinct() != cb.$distinct()) {
+				return false;
+			}
+			return test(ca.$field(), cb.$field());
+		}
+		if (a instanceof QOM.Sum sa && b instanceof QOM.Sum sb) {
+			return test(sa.$field(), sb.$field());
+		}
+		if (a instanceof QOM.Min<?> ma && b instanceof QOM.Min<?> mb) {
+			return test(ma.$field(), mb.$field());
+		}
+		if (a instanceof QOM.Max<?> ma && b instanceof QOM.Max<?> mb) {
+			return test(ma.$field(), mb.$field());
+		}
+		if (a instanceof QOM.Avg aa && b instanceof QOM.Avg ab) {
+			return test(aa.$field(), ab.$field());
+		}
+		if (a instanceof QOM.StddevSamp sa && b instanceof QOM.StddevSamp sb) {
+			return test(sa.$field(), sb.$field());
+		}
+		if (a instanceof QOM.StddevPop sa && b instanceof QOM.StddevPop sb) {
+			return test(sa.$field(), sb.$field());
+		}
+
+		// Case 3: Simple column references
+		// Handle the count(*) asterisk case — jOOQ represents this as an SQLField
+		// with toString() = "*", not as org.jooq.Asterisk
+		if ("*".equals(a.toString()) && "*".equals(b.toString())) {
+			return true;
+		}
+
+		// jOOQ's parser produces TableFieldImpl for all column references.
+		// When a column is table-qualified (e.g. c.name), getTable() returns
+		// the table/alias; when unqualified (e.g. name), getTable() is null.
+		var tableA = (a instanceof TableField<?, ?> tfa) ? tfa.getTable() : null;
+		var tableB = (b instanceof TableField<?, ?> tfb) ? tfb.getTable() : null;
+
+		if (tableA != null && tableB != null) {
+			// Both have table qualifiers — compare table name AND column name
+			return tableA.getName().equalsIgnoreCase(tableB.getName()) && a.getName().equalsIgnoreCase(b.getName());
+		}
+
+		// At least one has no table qualifier — match on column name alone
+		// (pragmatic for single-table queries or mixed qualified/unqualified)
+		return a.getName().equalsIgnoreCase(b.getName());
+	}
+
+}

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/FieldEquivalencePredicate.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/FieldEquivalencePredicate.java
@@ -52,10 +52,28 @@ final class FieldEquivalencePredicate implements BiPredicate<Field<?>, Field<?>>
 
 		// Case 1: Alias unwrapping — aliases are presentation, not identity
 		if (a instanceof QOM.FieldAlias<?> fa) {
-			return test(fa.$field(), b);
+			if (test(fa.$field(), b)) {
+				return true;
+			}
+			else if (fa.$field() instanceof TableField<?, ?> tfa && b instanceof TableField<?, ?> tfb
+					&& (tfa.getTable() == null || tfb.getTable() == null)) {
+				return a.getName().equalsIgnoreCase(b.getName());
+			}
+			else {
+				return false;
+			}
 		}
 		if (b instanceof QOM.FieldAlias<?> fb) {
-			return test(a, fb.$field());
+			if (test(a, fb.$field())) {
+				return true;
+			}
+			else if (a instanceof TableField<?, ?> tfa && fb.$field() instanceof TableField<?, ?> tfb
+					&& (tfa.getTable() == null || tfb.getTable() == null)) {
+				return a.getName().equalsIgnoreCase(b.getName());
+			}
+			else {
+				return false;
+			}
 		}
 
 		// Case 2: Aggregate function matching

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/FieldEquivalencePredicate.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/FieldEquivalencePredicate.java
@@ -45,6 +45,7 @@ final class FieldEquivalencePredicate implements BiPredicate<Field<?>, Field<?>>
 	 * @return {@code true} if the fields are structurally equivalent
 	 */
 	@Override
+	@SuppressWarnings("squid:S3776") // Yep, this is complex.
 	public boolean test(Field<?> a, Field<?> b) {
 		if (a == null || b == null) {
 			return false;

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
@@ -58,8 +58,7 @@ import org.jooq.CreateTableElementListStep;
 import org.jooq.DSLContext;
 import org.jooq.False;
 import org.jooq.Field;
-import org.jooq.GroupField;
-import org.jooq.Name;
+transaimport org.jooq.Name;
 import org.jooq.Null;
 import org.jooq.Param;
 import org.jooq.Parser;
@@ -473,42 +472,43 @@ final class SqlToCypher implements Translator {
 					: createOngoingReadingFromViews(selectStatement, cbvs);
 
 			var havingCondition = selectStatement.$having();
-			var groupByFields = selectStatement.$groupBy();
 			boolean needsWithClause = havingCondition != null || requiresWithForGroupBy(selectStatement);
 
-			OngoingReading effectiveReading;
-			Supplier<List<Expression>> finalResultColumnsSupplier;
+			OngoingReading effectiveReading = reading;
 			if (needsWithClause) {
-				var withResult = buildWithClause(reading, selectStatement, groupByFields, havingCondition);
+				var withResult = buildWithClause(reading, selectStatement, havingCondition);
 				effectiveReading = withResult.reading();
-				finalResultColumnsSupplier = withResult.returnExpressionsSupplier();
-			}
-			else {
-				effectiveReading = reading;
-				finalResultColumnsSupplier = resultColumnsSupplier;
+				resultColumnsSupplier = withResult.returnExpressionsSupplier();
 			}
 
 			var projection = selectStatement.$distinct()
-					? effectiveReading.returningDistinct(finalResultColumnsSupplier.get())
-					: effectiveReading.returning(finalResultColumnsSupplier.get());
+					? effectiveReading.returningDistinct(resultColumnsSupplier.get())
+					: effectiveReading.returning(resultColumnsSupplier.get());
 
-			// Fill the alias registry for ORDER BY when not already in WITH scope.
-			// This ensures ORDER BY on SELECT aliases (e.g., ORDER BY cnt where
-			// cnt is an aggregate alias) resolves to the Cypher alias name
-			// rather than being treated as a table property (p.cnt).
-			if (!selectStatement.$orderBy().isEmpty()) {
-				for (var sf : selectStatement.$select()) {
-					if (sf instanceof QOM.FieldAlias<?> fa) {
-						this.aliasRegistry.register(fa, fa.$alias().last());
-					}
-				}
-			}
+			registerOrderByProjections(selectStatement);
 
 			var orderedProjection = projection
 				.orderBy(selectStatement.$orderBy().stream().map(this::expression).toList());
 
 			return addLimit(forceLimit, selectStatement, orderedProjection).build();
+		}
 
+		/**
+		 * Fill the alias registry for ORDER BY when not already in WITH scope. This
+		 * ensures ORDER BY on SELECT aliases (e.g., ORDER BY cnt where cnt is an
+		 * aggregate alias) resolves to the Cypher alias name rather than being treated as
+		 * a table property (p.cnt).
+		 * @param selectStatement the SELECT statement to inspect
+		 */
+		private void registerOrderByProjections(Select<?> selectStatement) {
+			if (selectStatement.$orderBy().isEmpty()) {
+				return;
+			}
+			for (var sf : selectStatement.$select()) {
+				if (sf instanceof QOM.FieldAlias<?> fa) {
+					this.aliasRegistry.register(fa, fa.$alias().last());
+				}
+			}
 		}
 
 		/**
@@ -556,21 +556,45 @@ final class SqlToCypher implements Translator {
 		 * expressions that reference the aliases established in the WITH.
 		 * @param reading the current reading step to attach the WITH to
 		 * @param selectStatement the SELECT statement being translated
-		 * @param groupByFields the GROUP BY fields from the SQL statement
 		 * @param havingCondition the HAVING condition, or null if absent
 		 * @return the WITH clause result containing the reading step and return
 		 * expressions
 		 */
 		private WithClauseResult buildWithClause(OngoingReading reading, Select<?> selectStatement,
-				List<? extends GroupField> groupByFields, org.jooq.Condition havingCondition) {
+				org.jooq.Condition havingCondition) {
 
 			var withExpressions = new ArrayList<IdentifiableElement>();
 			var returnExpressions = new ArrayList<Expression>();
 
-			// Translate each SELECT field and alias it for the WITH clause using the same
-			// name as before
-			// (i.e. how it would have been rendered in the Cypher query without any
-			// post-processing and WITH-projecting)
+			processProjections(selectStatement, withExpressions, returnExpressions);
+
+			var aliasCounter = new AtomicInteger(0);
+			processGroupingKeys(selectStatement, withExpressions, aliasCounter);
+			processHaving(selectStatement, withExpressions, aliasCounter);
+
+			var withStep = reading.with(withExpressions);
+
+			OngoingReading afterWith;
+			if (havingCondition != null) {
+				afterWith = withStep.where(havingCondition(havingCondition));
+			}
+			else {
+				afterWith = withStep;
+			}
+
+			return new WithClauseResult(afterWith, () -> returnExpressions);
+		}
+
+		/**
+		 * Translate each SELECT field and alias it for the WITH clause using the same
+		 * name as before (i.e. how it would have been rendered in the Cypher query
+		 * without any post-processing and WITH-projecting).
+		 * @param selectStatement the statement being worked on
+		 * @param withExpressions the list of expressions that need to be WITH projected
+		 * @param returnExpressions       expressions from the WITH clause that needs to be passed to RETURN
+		 */
+		private void processProjections(Select<?> selectStatement, ArrayList<IdentifiableElement> withExpressions,
+				ArrayList<Expression> returnExpressions) {
 			for (var selectField : selectStatement.$select()) {
 				var expressions = expression(selectField).toList();
 				for (var expr : expressions) {
@@ -589,11 +613,18 @@ final class SqlToCypher implements Translator {
 					}
 				}
 			}
+		}
 
-			var aliasCounter = new AtomicInteger(0);
-			// Add GROUP BY fields that are not already in the SELECT
+		/**
+		 * Add GROUP BY fields that are not already in the SELECT.
+		 * @param selectStatement the statement being worked on
+		 * @param withExpressions the list of expressions that need to be WITH projected
+		 * @param aliasCounter shared counter to track generated column identifiers
+		 */
+		private void processGroupingKeys(Select<?> selectStatement, ArrayList<IdentifiableElement> withExpressions,
+				AtomicInteger aliasCounter) {
 			var selectFields = selectStatement.$select();
-			for (var gf : groupByFields) {
+			for (var gf : selectStatement.$groupBy()) {
 				if (gf instanceof Field<?> groupField && this.aliasRegistry.resolve(groupField) == null
 						&& !groupByFieldMatchesAnySelectField(groupField, selectFields)) {
 					var expr = expression(groupField);
@@ -602,33 +633,31 @@ final class SqlToCypher implements Translator {
 					this.aliasRegistry.register(groupField, alias);
 				}
 			}
+		}
 
-			// Inject HAVING-only aggregates as hidden WITH columns.
-			// These are aggregates referenced in HAVING but not in SELECT — they need
-			// to be projected in the WITH so the post-WITH WHERE can reference them,
-			// but they are NOT added to returnExpressions (excluded from final RETURN).
-			if (havingCondition != null) {
-				for (var agg : Aggregates.of(havingCondition)) {
-					if (this.aliasRegistry.resolve(agg) == null) {
-						var expr = expression(agg);
-						var alias = "__having_col_" + aliasCounter.getAndIncrement();
-						withExpressions.add(expr.as(alias));
-						this.aliasRegistry.register(agg, alias);
-					}
+		/**
+		 * Inject HAVING-only aggregates as hidden WITH columns. These are aggregates
+		 * referenced in HAVING but not in SELECT — they need to be projected in the WITH
+		 * so the post-WITH WHERE can reference them, but they are NOT added to
+		 * returnExpressions (excluded from final RETURN).
+		 * @param selectStatement the statement being worked on
+		 * @param withExpressions the list of expressions that need to be WITH projected
+		 * @param aliasCounter shared counter to track generated column identifiers
+		 */
+		private void processHaving(Select<?> selectStatement, ArrayList<IdentifiableElement> withExpressions,
+				AtomicInteger aliasCounter) {
+			var havingCondition = selectStatement.$having();
+			if (havingCondition == null) {
+				return;
+			}
+			for (var agg : Aggregates.of(havingCondition)) {
+				if (this.aliasRegistry.resolve(agg) == null) {
+					var expr = expression(agg);
+					var alias = "__having_col_" + aliasCounter.getAndIncrement();
+					withExpressions.add(expr.as(alias));
+					this.aliasRegistry.register(agg, alias);
 				}
 			}
-
-			var withStep = reading.with(withExpressions);
-
-			OngoingReading afterWith;
-			if (havingCondition != null) {
-				afterWith = withStep.where(havingCondition(havingCondition));
-			}
-			else {
-				afterWith = withStep;
-			}
-
-			return new WithClauseResult(afterWith, () -> returnExpressions);
 		}
 
 		/**

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
@@ -532,7 +532,8 @@ final class SqlToCypher implements Translator {
 			}
 			var selectFields = selectStatement.$select();
 			for (var gf : groupByFields) {
-				if (gf instanceof Field<?> groupField && !groupByFieldMatchesAnySelectField(groupField, selectFields)) {
+				if (gf instanceof Field<?> groupField && this.aliasRegistry.resolve(groupField) == null
+						&& !groupByFieldMatchesAnySelectField(groupField, selectFields)) {
 					return true;
 				}
 			}
@@ -573,16 +574,16 @@ final class SqlToCypher implements Translator {
 			for (var selectField : selectStatement.$select()) {
 				var expressions = expression(selectField).toList();
 				for (var expr : expressions) {
-					String alias;
+					String alias = null;
 					if (expr instanceof AliasedExpression aliased) {
 						alias = aliased.getAlias();
 					}
-					else {
+					else if (!(expr instanceof org.neo4j.cypherdsl.core.Asterisk)) {
 						alias = selectField.toString();
 						expr = expr.as(alias);
 					}
 					withExpressions.add((IdentifiableElement) expr);
-					returnExpressions.add(Cypher.name(alias));
+					returnExpressions.add((alias != null) ? Cypher.name(alias) : expr);
 					if (selectField instanceof Field<?> f) {
 						this.aliasRegistry.register(f, alias);
 					}
@@ -593,12 +594,12 @@ final class SqlToCypher implements Translator {
 			// Add GROUP BY fields that are not already in the SELECT
 			var selectFields = selectStatement.$select();
 			for (var gf : groupByFields) {
-				if (gf instanceof Field<?> groupField && !groupByFieldMatchesAnySelectField(groupField, selectFields)) {
+				if (gf instanceof Field<?> groupField && this.aliasRegistry.resolve(groupField) == null
+						&& !groupByFieldMatchesAnySelectField(groupField, selectFields)) {
 					var expr = expression(groupField);
 					var alias = "__group_col_" + aliasCounter.getAndIncrement();
 					withExpressions.add(expr.as(alias));
 					this.aliasRegistry.register(groupField, alias);
-					// GROUP BY-only fields are not added to returnExpressions
 				}
 			}
 

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
@@ -58,6 +58,7 @@ import org.jooq.CreateTableElementListStep;
 import org.jooq.DSLContext;
 import org.jooq.False;
 import org.jooq.Field;
+import org.jooq.GroupField;
 import org.jooq.Name;
 import org.jooq.Null;
 import org.jooq.Param;
@@ -78,6 +79,7 @@ import org.jooq.impl.DSL;
 import org.jooq.impl.ParserException;
 import org.jooq.impl.QOM;
 import org.jooq.impl.QOM.TableAlias;
+import org.neo4j.cypherdsl.core.AliasedExpression;
 import org.neo4j.cypherdsl.core.Case;
 import org.neo4j.cypherdsl.core.Condition;
 import org.neo4j.cypherdsl.core.Cypher;
@@ -108,8 +110,6 @@ import org.neo4j.cypherdsl.core.StatementBuilder.OngoingReading;
 import org.neo4j.cypherdsl.core.StatementBuilder.OngoingReadingWithWhere;
 import org.neo4j.cypherdsl.core.StatementBuilder.OngoingReadingWithoutWhere;
 import org.neo4j.cypherdsl.core.SymbolicName;
-import org.neo4j.cypherdsl.core.renderer.Configuration;
-import org.neo4j.cypherdsl.core.renderer.Dialect;
 import org.neo4j.cypherdsl.core.renderer.GeneralizedRenderer;
 import org.neo4j.cypherdsl.core.renderer.Renderer;
 import org.neo4j.jdbc.translator.spi.Cache;
@@ -162,8 +162,6 @@ final class SqlToCypher implements Translator {
 
 	private final SqlToCypherConfig config;
 
-	private final Configuration rendererConfig;
-
 	private final Cache<Query, String> cache = Cache.getInstance(STATEMENT_CACHE_SIZE);
 
 	private final Map<String, View> views;
@@ -173,12 +171,6 @@ final class SqlToCypher implements Translator {
 	private SqlToCypher(SqlToCypherConfig config) {
 
 		this.config = config;
-		this.rendererConfig = Configuration.newConfig()
-			.withPrettyPrint(this.config.isPrettyPrint())
-			.alwaysEscapeNames(this.config.isAlwaysEscapeNames())
-			.withDialect(Dialect.NEO4J_5)
-			.build();
-
 		if (this.config.getViewDefinitions() == null) {
 			this.views = Map.of();
 		}
@@ -235,7 +227,8 @@ final class SqlToCypher implements Translator {
 			Parser parser = dsl.parser();
 			query = parser.parseQuery(sql);
 			if (query == null && sql != null && sql.trim().startsWith("//")) {
-				return Renderer.getRenderer(this.rendererConfig, GeneralizedRenderer.class).render(Finish.create());
+				return Renderer.getRenderer(this.config.getRendererConfig(), GeneralizedRenderer.class)
+					.render(Finish.create());
 			}
 		}
 		catch (ParserException pe) {
@@ -290,7 +283,7 @@ final class SqlToCypher implements Translator {
 	}
 
 	private String render(Statement statement) {
-		return Renderer.getRenderer(this.rendererConfig).render(statement);
+		return Renderer.getRenderer(this.config.getRendererConfig()).render(statement);
 	}
 
 	record JoinDetails(QOM.QualifiedJoin<?, ?> join, QOM.Eq<?> eq) {
@@ -337,6 +330,12 @@ final class SqlToCypher implements Translator {
 		private final Map<SymbolicName, RelationshipPattern> resolvedRelationships = new HashMap<>();
 
 		private final AtomicBoolean useAliasForVColumn = new AtomicBoolean(true);
+
+		/**
+		 * Registry mapping jOOQ field expressions to their Cypher WITH and ORDER BY
+		 * clause aliases.
+		 */
+		private final AliasRegistry aliasRegistry = new AliasRegistry();
 
 		private final Map<String, View> views;
 
@@ -472,34 +471,208 @@ final class SqlToCypher implements Translator {
 
 			var reading = cbvs.isEmpty() ? createOngoingReadingFromSources(selectStatement)
 					: createOngoingReadingFromViews(selectStatement, cbvs);
-			var projection = selectStatement.$distinct() ? reading.returningDistinct(resultColumnsSupplier.get())
-					: reading.returning(resultColumnsSupplier.get());
+
+			var havingCondition = selectStatement.$having();
+			var groupByFields = selectStatement.$groupBy();
+			boolean needsWithClause = havingCondition != null || requiresWithForGroupBy(selectStatement);
+
+			OngoingReading effectiveReading;
+			Supplier<List<Expression>> finalResultColumnsSupplier;
+			if (needsWithClause) {
+				var withResult = buildWithClause(reading, selectStatement, groupByFields, havingCondition);
+				effectiveReading = withResult.reading();
+				finalResultColumnsSupplier = withResult.returnExpressionsSupplier();
+			}
+			else {
+				effectiveReading = reading;
+				finalResultColumnsSupplier = resultColumnsSupplier;
+			}
+
+			var projection = selectStatement.$distinct()
+					? effectiveReading.returningDistinct(finalResultColumnsSupplier.get())
+					: effectiveReading.returning(finalResultColumnsSupplier.get());
+
+			// Fill the alias registry for ORDER BY when not already in WITH scope.
+			// This ensures ORDER BY on SELECT aliases (e.g., ORDER BY cnt where
+			// cnt is an aggregate alias) resolves to the Cypher alias name
+			// rather than being treated as a table property (p.cnt).
+			if (!selectStatement.$orderBy().isEmpty()) {
+				for (var sf : selectStatement.$select()) {
+					if (sf instanceof QOM.FieldAlias<?> fa) {
+						this.aliasRegistry.register(fa, fa.$alias().last());
+					}
+				}
+			}
+
 			var orderedProjection = projection
 				.orderBy(selectStatement.$orderBy().stream().map(this::expression).toList());
 
 			return addLimit(forceLimit, selectStatement, orderedProjection).build();
+
+		}
+
+		/**
+		 * Determines whether a GROUP BY clause requires a WITH-based translation because
+		 * the grouping fields contain entries not present in the SELECT list. When all
+		 * GROUP BY fields also appear in SELECT, Cypher's implicit aggregation produces
+		 * the correct result without an intermediate WITH clause.
+		 * <p>
+		 * Design decision: this method does not validate that every non-aggregated SELECT
+		 * expression appears in the GROUP BY list. Queries where non-aggregated SELECT
+		 * columns are missing from GROUP BY are silently translated. Cypher's implicit
+		 * grouping will group by all non-aggregated columns in the RETURN, which may
+		 * differ from the SQL GROUP BY.
+		 * @param selectStatement the SELECT statement to inspect
+		 * @return true if a WITH clause is needed for correct GROUP BY translation
+		 */
+		private boolean requiresWithForGroupBy(Select<?> selectStatement) {
+			var groupByFields = selectStatement.$groupBy();
+			if (groupByFields.isEmpty()) {
+				return false;
+			}
+			var selectFields = selectStatement.$select();
+			for (var gf : groupByFields) {
+				if (gf instanceof Field<?> groupField && !groupByFieldMatchesAnySelectField(groupField, selectFields)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		private static boolean groupByFieldMatchesAnySelectField(Field<?> groupField,
+				List<? extends SelectFieldOrAsterisk> selectFields) {
+			Predicate<SelectFieldOrAsterisk> isFieldAndEquivalentToGroupBy = sf -> sf instanceof Field<?>;
+			isFieldAndEquivalentToGroupBy = isFieldAndEquivalentToGroupBy
+				.and(f -> new FieldEquivalencePredicate().test(groupField, (Field<?>) f));
+			return selectFields.stream().anyMatch(isFieldAndEquivalentToGroupBy);
+		}
+
+		/**
+		 * Builds a WITH clause for GROUP BY translation. The WITH includes all grouping
+		 * expressions and all aggregate expressions from the SELECT list, triggering
+		 * Cypher's implicit grouping. If a HAVING condition is present, it is applied as
+		 * a WHERE after the WITH. The returned supplier provides the final RETURN
+		 * expressions that reference the aliases established in the WITH.
+		 * @param reading the current reading step to attach the WITH to
+		 * @param selectStatement the SELECT statement being translated
+		 * @param groupByFields the GROUP BY fields from the SQL statement
+		 * @param havingCondition the HAVING condition, or null if absent
+		 * @return the WITH clause result containing the reading step and return
+		 * expressions
+		 */
+		private WithClauseResult buildWithClause(OngoingReading reading, Select<?> selectStatement,
+				List<? extends GroupField> groupByFields, org.jooq.Condition havingCondition) {
+
+			var withExpressions = new ArrayList<IdentifiableElement>();
+			var returnExpressions = new ArrayList<Expression>();
+
+			// Translate each SELECT field and alias it for the WITH clause using the same
+			// name as before
+			// (i.e. how it would have been rendered in the Cypher query without any
+			// post-processing and WITH-projecting)
+			for (var selectField : selectStatement.$select()) {
+				var expressions = expression(selectField).toList();
+				for (var expr : expressions) {
+					String alias;
+					if (expr instanceof AliasedExpression aliased) {
+						alias = aliased.getAlias();
+					}
+					else {
+						alias = selectField.toString();
+						expr = expr.as(alias);
+					}
+					withExpressions.add((IdentifiableElement) expr);
+					returnExpressions.add(Cypher.name(alias));
+					if (selectField instanceof Field<?> f) {
+						this.aliasRegistry.register(f, alias);
+					}
+				}
+			}
+
+			var aliasCounter = new AtomicInteger(0);
+			// Add GROUP BY fields that are not already in the SELECT
+			var selectFields = selectStatement.$select();
+			for (var gf : groupByFields) {
+				if (gf instanceof Field<?> groupField && !groupByFieldMatchesAnySelectField(groupField, selectFields)) {
+					var expr = expression(groupField);
+					var alias = "__group_col_" + aliasCounter.getAndIncrement();
+					withExpressions.add(expr.as(alias));
+					this.aliasRegistry.register(groupField, alias);
+					// GROUP BY-only fields are not added to returnExpressions
+				}
+			}
+
+			// Inject HAVING-only aggregates as hidden WITH columns.
+			// These are aggregates referenced in HAVING but not in SELECT — they need
+			// to be projected in the WITH so the post-WITH WHERE can reference them,
+			// but they are NOT added to returnExpressions (excluded from final RETURN).
+			if (havingCondition != null) {
+				for (var agg : Aggregates.of(havingCondition)) {
+					if (this.aliasRegistry.resolve(agg) == null) {
+						var expr = expression(agg);
+						var alias = "__having_col_" + aliasCounter.getAndIncrement();
+						withExpressions.add(expr.as(alias));
+						this.aliasRegistry.register(agg, alias);
+					}
+				}
+			}
+
+			var withStep = reading.with(withExpressions);
+
+			OngoingReading afterWith;
+			if (havingCondition != null) {
+				afterWith = withStep.where(havingCondition(havingCondition));
+			}
+			else {
+				afterWith = withStep;
+			}
+
+			return new WithClauseResult(afterWith, () -> returnExpressions);
+		}
+
+		/**
+		 * Translates a HAVING condition to a Cypher condition that references the aliases
+		 * established in the WITH clause. Aggregate expressions and column references in
+		 * the HAVING are resolved to their WITH aliases by the unified interception in
+		 * {@code expression(Field<?>)} via the active {@code aliasRegistry}.
+		 * @param c the jOOQ HAVING condition to translate
+		 * @return the equivalent Cypher condition referencing WITH aliases
+		 */
+		private Condition havingCondition(org.jooq.Condition c) {
+			return condition(c);
 		}
 
 		// Again, Sonar thinks sql and matcher are uselessly assigned
 		@SuppressWarnings("squid:S1854")
 		private StatementBuilder.BuildableStatement<ResultStatement> addLimit(boolean force, Select<?> selectStatement,
 				StatementBuilder.OngoingMatchAndReturnWithOrder projection) {
-			StatementBuilder.BuildableStatement<ResultStatement> buildableStatement;
-			if (!(selectStatement.$limit() instanceof Param<?> param)) {
-				var forceLimit = force;
-				var sql = Optional.ofNullable(selectStatement.$limit()).map(Object::toString).orElse("");
-				var matcher = LIMIT_STAR_FROM_PATTERN.matcher(sql);
-				var limit = 1;
-				if (matcher.matches()) {
-					forceLimit = true;
-					limit = Integer.parseInt(matcher.group(1));
-				}
-				buildableStatement = forceLimit ? projection.limit(limit) : projection;
+
+			// Apply OFFSET (SKIP) first — Cypher requires SKIP before LIMIT.
+			// skip() narrows the type to TerminalExposesLimit, so we branch here:
+			// if offset is present, apply skip first then limit on the result;
+			// otherwise use the original projection which supports both skip and limit.
+			var offset = selectStatement.$offset();
+			if (offset != null) {
+				var afterSkip = projection.skip(expression(offset));
+				return applyLimit(force, selectStatement, afterSkip);
 			}
-			else {
-				buildableStatement = projection.limit(expression(param));
+			return applyLimit(force, selectStatement, projection);
+		}
+
+		private StatementBuilder.BuildableStatement<ResultStatement> applyLimit(boolean force,
+				Select<?> selectStatement, StatementBuilder.TerminalExposesLimit target) {
+			if (selectStatement.$limit() instanceof Param<?> param) {
+				return target.limit(expression(param));
 			}
-			return buildableStatement;
+			var forceLimit = force;
+			var sql = Optional.ofNullable(selectStatement.$limit()).map(Object::toString).orElse("");
+			var matcher = LIMIT_STAR_FROM_PATTERN.matcher(sql);
+			var limit = 1;
+			if (matcher.matches()) {
+				forceLimit = true;
+				limit = Integer.parseInt(matcher.group(1));
+			}
+			return forceLimit ? target.limit(limit) : target;
 		}
 
 		private OngoingReading createOngoingReadingFromViews(Select<?> selectStatement, ArrayList<CbvPointer> cbvs) {
@@ -734,7 +907,7 @@ final class SqlToCypher implements Translator {
 				}
 				else if (!(lhsProperties.containsKey(targetColumn) || rhsProperties.containsKey(targetColumn))) {
 					UnaryOperator<String> toLower = s -> s.toLowerCase(Locale.ROOT);
-					if (relationshipColumns.isEmpty() && lastName.contains("_")) {
+					if (relationshipColumns.isEmpty() && (lastName != null && lastName.contains("_"))) {
 						var indexOf_ = lastName.indexOf("_");
 						var prefix = lastName.substring(0, indexOf_).toLowerCase(Locale.ROOT);
 						if (isLabelOfNode(relationship.getLeft(), prefix, toLower)) {
@@ -1473,6 +1646,14 @@ final class SqlToCypher implements Translator {
 
 		@SuppressWarnings({ "NestedIfDepth", "squid:S3776", "squid:S138" })
 		private Expression expression(Field<?> f, boolean turnUnknownIntoNames) {
+
+			// Registry interception — resolve fields to WITH aliases when in WITH scope
+			if ((f instanceof TableField<?, ?> || Aggregates.isAggregate(f) || f instanceof QOM.FieldAlias<?>)) {
+				String alias = this.aliasRegistry.resolve(f);
+				if (alias != null) {
+					return Cypher.name(alias);
+				}
+			}
 
 			if (f instanceof Param<?> p) {
 				if (p.$inline()) {
@@ -2408,10 +2589,6 @@ final class SqlToCypher implements Translator {
 				.anyMatch(needle::equalsIgnoreCase);
 		}
 
-		private static boolean isLabelOfNode(Node node, String needle) {
-			return isLabelOfNode(node, needle, UnaryOperator.identity());
-		}
-
 		private static boolean isLabelOfNode(Node node, String needle, UnaryOperator<String> transformer) {
 			if (needle == null) {
 				return false;
@@ -2476,6 +2653,9 @@ final class SqlToCypher implements Translator {
 			return (this.scopeTable != null) ? this.name.replace(this.scopeTable.toLowerCase(Locale.ROOT) + "_", "")
 					: this.name;
 		}
+	}
+
+	record WithClauseResult(OngoingReading reading, Supplier<List<Expression>> returnExpressionsSupplier) {
 	}
 
 }

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
@@ -591,7 +591,8 @@ final class SqlToCypher implements Translator {
 		 * without any post-processing and WITH-projecting).
 		 * @param selectStatement the statement being worked on
 		 * @param withExpressions the list of expressions that need to be WITH projected
-		 * @param returnExpressions       expressions from the WITH clause that needs to be passed to RETURN
+		 * @param returnExpressions expressions from the WITH clause that needs to be
+		 * passed to RETURN
 		 */
 		private void processProjections(Select<?> selectStatement, ArrayList<IdentifiableElement> withExpressions,
 				ArrayList<Expression> returnExpressions) {

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
@@ -58,7 +58,7 @@ import org.jooq.CreateTableElementListStep;
 import org.jooq.DSLContext;
 import org.jooq.False;
 import org.jooq.Field;
-transaimport org.jooq.Name;
+import org.jooq.Name;
 import org.jooq.Null;
 import org.jooq.Param;
 import org.jooq.Parser;

--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypherConfig.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypherConfig.java
@@ -35,6 +35,8 @@ import org.jooq.conf.ParseWithMetaLookups;
 import org.jooq.conf.RenderNameCase;
 import org.jooq.conf.Settings;
 import org.jooq.impl.DefaultConfiguration;
+import org.neo4j.cypherdsl.core.renderer.Configuration;
+import org.neo4j.cypherdsl.core.renderer.Dialect;
 import org.neo4j.jdbc.translator.spi.Translator;
 
 /**
@@ -254,6 +256,8 @@ public final class SqlToCypherConfig {
 
 	private final String relationshipPattern;
 
+	private final Configuration rendererConfig;
+
 	private SqlToCypherConfig(Builder builder) {
 
 		this.parseNameCase = builder.parseNameCase;
@@ -269,6 +273,18 @@ public final class SqlToCypherConfig {
 		this.precedence = builder.precedence;
 		this.viewDefinitions = builder.viewDefinitions;
 		this.relationshipPattern = builder.relationshipPattern;
+		this.rendererConfig = Configuration.newConfig()
+			.withPrettyPrint(this.isPrettyPrint())
+			.alwaysEscapeNames(this.isAlwaysEscapeNames())
+			.withDialect(Dialect.NEO4J_5)
+			.build();
+	}
+
+	/**
+	 * {@return a configuration for Cypher-DSL rendering matching this translation config}
+	 */
+	Configuration getRendererConfig() {
+		return this.rendererConfig;
 	}
 
 	/**

--- a/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/AggregatesTests.java
+++ b/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/AggregatesTests.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.translator.impl;
+
+import org.jooq.impl.QOM;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Michael J. Simons
+ */
+final class AggregatesTests {
+
+	@Test
+	@DisplayName("Simple: HAVING count(*) > 5 returns 1 aggregate")
+	void simpleCountStar() {
+		var select = TestUtils.parseSelect("SELECT name, count(*) FROM People GROUP BY name HAVING count(*) > 5");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Count.class);
+	}
+
+	@Test
+	@DisplayName("Compound AND: HAVING count(*) > 5 AND max(age) > 50 returns 2 aggregates")
+	void compoundAnd() {
+		var select = TestUtils.parseSelect(
+				"SELECT name, count(*) AS cnt, max(age) AS mx FROM People GROUP BY name HAVING count(*) > 5 AND max(age) > 50");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(2);
+	}
+
+	@Test
+	@DisplayName("Compound OR: HAVING count(*) > 2 OR min(age) < 18 returns 2 aggregates")
+	void compoundOr() {
+		var select = TestUtils.parseSelect(
+				"SELECT name, count(*) AS cnt, min(age) AS mn FROM People GROUP BY name HAVING count(*) > 2 OR min(age) < 18");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(2);
+	}
+
+	@Test
+	@DisplayName("Arithmetic: HAVING max(salary) > 2 * avg(salary) returns 2 aggregates")
+	void arithmetic() {
+		var select = TestUtils.parseSelect(
+				"SELECT department, max(salary) AS mx, avg(salary) AS av FROM Employees GROUP BY department HAVING max(salary) > 2 * avg(salary)");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(2);
+		assertThat(aggregates).anyMatch(f -> f instanceof QOM.Max);
+		assertThat(aggregates).anyMatch(f -> f instanceof QOM.Avg);
+	}
+
+	@Test
+	@DisplayName("Nested arithmetic: HAVING sum(age) + sum(salary) > 100 returns 2 aggregates")
+	void nestedArithmetic() {
+		var select = TestUtils.parseSelect(
+				"SELECT department, sum(age) AS sa, sum(salary) AS ss FROM Employees GROUP BY department HAVING sum(age) + sum(salary) > 100");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(2);
+		assertThat(aggregates).allMatch(f -> f instanceof QOM.Sum);
+	}
+
+	@Test
+	@DisplayName("No aggregates: HAVING name = 'Alice' returns empty list")
+	void noAggregates() {
+		var select = TestUtils.parseSelect("SELECT name, count(*) FROM People GROUP BY name HAVING name = 'Alice'");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Mixed: HAVING count(*) > 5 AND name = 'Alice' returns 1 aggregate")
+	void mixed() {
+		var select = TestUtils.parseSelect(
+				"SELECT name, count(*) AS cnt FROM People GROUP BY name HAVING count(*) > 5 AND name = 'Alice'");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Count.class);
+	}
+
+	@Test
+	@DisplayName("Duplicate aggregates: HAVING count(*) > 5 OR count(*) < 100 returns 2 entries")
+	void duplicateAggregates() {
+		var select = TestUtils.parseSelect(
+				"SELECT name, count(*) AS cnt FROM People GROUP BY name HAVING count(*) > 5 OR count(*) < 100");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(2);
+		assertThat(aggregates).allMatch(f -> f instanceof QOM.Count);
+	}
+
+	@Test
+	@DisplayName("BETWEEN: HAVING count(*) BETWEEN 5 AND 10 returns 1 aggregate")
+	void between() {
+		var select = TestUtils
+			.parseSelect("SELECT name, count(*) AS cnt FROM People GROUP BY name HAVING count(*) BETWEEN 5 AND 10");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Count.class);
+	}
+
+	@Test
+	@DisplayName("IsNull: HAVING count(*) IS NULL returns 1 aggregate")
+	void isNull() {
+		var select = TestUtils.parseSelect("SELECT name, count(*) FROM People GROUP BY name HAVING count(*) IS NULL");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Count.class);
+	}
+
+	@Test
+	@DisplayName("IsNotNull: HAVING max(age) IS NOT NULL returns 1 aggregate")
+	void isNotNull() {
+		var select = TestUtils
+			.parseSelect("SELECT name, max(age) FROM People GROUP BY name HAVING max(age) IS NOT NULL");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Max.class);
+	}
+
+	@Test
+	@DisplayName("InList: HAVING count(*) IN (1, 2, 3) returns 1 aggregate")
+	void inList() {
+		var select = TestUtils
+			.parseSelect("SELECT name, count(*) FROM People GROUP BY name HAVING count(*) IN (1, 2, 3)");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Count.class);
+	}
+
+	@Test
+	@DisplayName("Like: HAVING max(name) LIKE 'A%' returns 1 aggregate")
+	void like() {
+		var select = TestUtils
+			.parseSelect("SELECT department, max(name) FROM Employees GROUP BY department HAVING max(name) LIKE 'A%'");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Max.class);
+	}
+
+	@Test
+	@DisplayName("NotLike: HAVING max(name) NOT LIKE 'A%' returns 1 aggregate")
+	void notLike() {
+		var select = TestUtils.parseSelect(
+				"SELECT department, max(name) FROM Employees GROUP BY department HAVING max(name) NOT LIKE 'A%'");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Max.class);
+	}
+
+	@Test
+	@DisplayName("NotInList: HAVING count(*) NOT IN (1, 2, 3) returns 1 aggregate")
+	void notInList() {
+		var select = TestUtils
+			.parseSelect("SELECT name, count(*) FROM People GROUP BY name HAVING count(*) NOT IN (1, 2, 3)");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Count.class);
+	}
+
+	@Test
+	@DisplayName("IsDistinctFrom: HAVING count(*) IS DISTINCT FROM 0 returns 1 aggregate")
+	void isDistinctFrom() {
+		var select = TestUtils
+			.parseSelect("SELECT name, count(*) FROM People GROUP BY name HAVING count(*) IS DISTINCT FROM 0");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Count.class);
+	}
+
+	@Test
+	@DisplayName("IsNotDistinctFrom: HAVING count(*) IS NOT DISTINCT FROM 5 returns 1 aggregate")
+	void isNotDistinctFrom() {
+		var select = TestUtils
+			.parseSelect("SELECT name, count(*) FROM People GROUP BY name HAVING count(*) IS NOT DISTINCT FROM 5");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Count.class);
+	}
+
+	@Test
+	@DisplayName("LikeIgnoreCase: HAVING max(name) ILIKE 'a%' returns 1 aggregate")
+	void likeIgnoreCase() {
+		var select = TestUtils
+			.parseSelect("SELECT department, max(name) FROM Employees GROUP BY department HAVING max(name) ILIKE 'a%'");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Max.class);
+	}
+
+	@Test
+	@DisplayName("NotLikeIgnoreCase: HAVING max(name) NOT ILIKE 'a%' returns 1 aggregate")
+	void notLikeIgnoreCase() {
+		var select = TestUtils.parseSelect(
+				"SELECT department, max(name) FROM Employees GROUP BY department HAVING max(name) NOT ILIKE 'a%'");
+		var aggregates = Aggregates.of(select.$having());
+
+		assertThat(aggregates).hasSize(1);
+		assertThat(aggregates).first().isInstanceOf(QOM.Max.class);
+	}
+
+}

--- a/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/AliasRegistryTests.java
+++ b/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/AliasRegistryTests.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.translator.impl;
+
+import java.util.Objects;
+
+import org.jooq.Field;
+import org.jooq.impl.QOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the alias registry that maps jOOQ expressions to WITH clause aliases. All
+ * inputs are parsed through jOOQ's SQL parser.
+ *
+ * @author Ryan Knight
+ * @author Michael J. Simons
+ */
+class AliasRegistryTests {
+
+	@Nested
+	@DisplayName("Structural lookup")
+	class StructuralLookupTests {
+
+		private AliasRegistry registry;
+
+		@BeforeEach
+		void setUp() {
+			this.registry = new AliasRegistry();
+		}
+
+		@Test
+		@DisplayName("Register count(*) → cnt, lookup count(*) → cnt")
+		void lookupCountStar() {
+			var select = TestUtils.parseSelect("SELECT count(*) AS cnt FROM People GROUP BY name");
+			var selectFields = select.$select();
+
+			// Register count(*) with alias "cnt"
+			var countField = selectFields.get(0);
+			this.registry.register(TestUtils.unwrapAlias(countField), TestUtils.getAliasName(countField));
+
+			// Now parse a separate query with count(*) in HAVING to get a fresh count(*)
+			var havingSelect = TestUtils
+				.parseSelect("SELECT name, count(*) AS cnt FROM People GROUP BY name HAVING count(*) > 5");
+			var gt = (QOM.Gt<?>) havingSelect.$having();
+			assertThat(gt).isNotNull();
+			var havingCount = (Field<?>) gt.$arg1();
+
+			assertThat(this.registry.resolve(havingCount)).isEqualToIgnoringCase("cnt");
+		}
+
+		@Test
+		@DisplayName("Register sum(age) → total, lookup sum(salary) → null (different column)")
+		void lookupSumDifferentColumn() {
+			var select = TestUtils.parseSelect("SELECT sum(age) AS total FROM People GROUP BY name");
+			var sumField = select.$select().get(0);
+			this.registry.register(TestUtils.unwrapAlias(sumField), TestUtils.getAliasName(sumField));
+
+			// Parse a query with sum(salary) — different column
+			var otherSelect = TestUtils
+				.parseSelect("SELECT name, sum(salary) AS sal FROM People GROUP BY name HAVING sum(salary) > 100");
+			var gt = (QOM.Gt<?>) otherSelect.$having();
+			var havingSum = (Field<?>) Objects.requireNonNull(gt).$arg1();
+
+			assertThat(this.registry.resolve(havingSum)).isNull();
+		}
+
+		@Test
+		@DisplayName("Register sum(age) → total, lookup sum(age) → total")
+		void lookupSumSameColumn() {
+			var select = TestUtils.parseSelect("SELECT sum(age) AS total FROM People GROUP BY name");
+			var sumField = select.$select().get(0);
+			this.registry.register(TestUtils.unwrapAlias(sumField), TestUtils.getAliasName(sumField));
+
+			// Parse a query with sum(age) in HAVING
+			var havingSelect = TestUtils
+				.parseSelect("SELECT name, sum(age) AS total FROM People GROUP BY name HAVING sum(age) > 100");
+			var gt = (QOM.Gt<?>) havingSelect.$having();
+			var havingSum = (Field<?>) Objects.requireNonNull(gt).$arg1();
+
+			assertThat(this.registry.resolve(havingSum)).isEqualToIgnoringCase("total");
+		}
+
+		@Test
+		@DisplayName("Register count(*), sum(age), max(age) with distinct aliases, lookup each → correct alias")
+		void lookupMultipleAggregates() {
+			var select = TestUtils
+				.parseSelect("SELECT count(*) AS cnt, sum(age) AS total, max(age) AS oldest FROM People GROUP BY name");
+			var selectFields = select.$select();
+
+			for (var sf : selectFields) {
+				this.registry.register(TestUtils.unwrapAlias(sf), TestUtils.getAliasName(sf));
+			}
+
+			// Parse queries to get fresh aggregates for lookup
+			var countSelect = TestUtils.parseSelect("SELECT name FROM People GROUP BY name HAVING count(*) > 5");
+			var countGt = (QOM.Gt<?>) countSelect.$having();
+			assertThat(this.registry.resolve(Objects.requireNonNull(countGt).$arg1())).isEqualToIgnoringCase("cnt");
+
+			var sumSelect = TestUtils.parseSelect("SELECT name FROM People GROUP BY name HAVING sum(age) > 100");
+			var sumGt = (QOM.Gt<?>) sumSelect.$having();
+			assertThat(this.registry.resolve(Objects.requireNonNull(sumGt).$arg1())).isEqualToIgnoringCase("total");
+
+			var maxSelect = TestUtils.parseSelect("SELECT name FROM People GROUP BY name HAVING max(age) > 80");
+			var maxGt = (QOM.Gt<?>) maxSelect.$having();
+			assertThat(this.registry.resolve(Objects.requireNonNull(maxGt).$arg1())).isEqualToIgnoringCase("oldest");
+		}
+
+		@Test
+		@DisplayName("Lookup unregistered field → null")
+		void lookupUnregisteredField() {
+			// Registry is empty
+			var select = TestUtils.parseSelect("SELECT name FROM People GROUP BY name HAVING count(*) > 5");
+			var gt = (QOM.Gt<?>) select.$having();
+
+			assertThat(this.registry.resolve(Objects.requireNonNull(gt).$arg1())).isNull();
+		}
+
+		@Test
+		@DisplayName("Duplicate registration — first registration wins")
+		void duplicateRegistrationFirstWins() {
+			var select1 = TestUtils.parseSelect("SELECT count(*) AS first_alias FROM People GROUP BY name");
+			var field1 = select1.$select().get(0);
+			this.registry.register(TestUtils.unwrapAlias(field1), "first_alias");
+
+			var select2 = TestUtils.parseSelect("SELECT count(*) AS second_alias FROM People GROUP BY name");
+			var field2 = select2.$select().get(0);
+			this.registry.register(TestUtils.unwrapAlias(field2), "second_alias");
+
+			// Structural lookup should return the first registered alias
+			var lookupSelect = TestUtils.parseSelect("SELECT name FROM People GROUP BY name HAVING count(*) > 5");
+			var gt = (QOM.Gt<?>) lookupSelect.$having();
+			assertThat(this.registry.resolve(Objects.requireNonNull(gt).$arg1())).isEqualToIgnoringCase("first_alias");
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Name-based lookup")
+	class NameBasedLookupTests {
+
+		private AliasRegistry registry;
+
+		@BeforeEach
+		void setUp() {
+			this.registry = new AliasRegistry();
+		}
+
+		@Test
+		@DisplayName("Register count(*) → cnt, lookup plain Field(cnt) → cnt")
+		void lookupByAliasNameForCount() {
+			var select = TestUtils.parseSelect("SELECT count(*) AS cnt FROM People GROUP BY name");
+			var countField = select.$select().get(0);
+			this.registry.register(TestUtils.unwrapAlias(countField), TestUtils.getAliasName(countField));
+
+			// Parse ORDER BY cnt — jOOQ keeps "cnt" as unresolved field reference
+			var orderSelect = TestUtils
+				.parseSelect("SELECT name, count(*) AS cnt FROM People GROUP BY name ORDER BY cnt");
+			var orderField = orderSelect.$orderBy().get(0).$field();
+
+			// This should match by name, not structurally
+			assertThat(orderField).isNotInstanceOf(QOM.Count.class);
+			assertThat(this.registry.resolve(orderField)).isEqualToIgnoringCase("cnt");
+		}
+
+		@Test
+		@DisplayName("Register sum(age) → total, lookup plain Field(total) → total")
+		void lookupByAliasNameForSum() {
+			var select = TestUtils.parseSelect("SELECT sum(age) AS total FROM People GROUP BY name");
+			var sumField = select.$select().get(0);
+			this.registry.register(TestUtils.unwrapAlias(sumField), TestUtils.getAliasName(sumField));
+
+			// Parse ORDER BY total — jOOQ keeps "total" as unresolved field reference
+			var orderSelect = TestUtils
+				.parseSelect("SELECT name, sum(age) AS total FROM People GROUP BY name ORDER BY total");
+			var orderField = orderSelect.$orderBy().get(0).$field();
+
+			assertThat(orderField).isNotInstanceOf(QOM.Sum.class);
+			assertThat(this.registry.resolve(orderField)).isEqualToIgnoringCase("total");
+		}
+
+		@Test
+		@DisplayName("Lookup plain Field(unknown) → null")
+		void lookupByUnknownName() {
+			var select = TestUtils.parseSelect("SELECT count(*) AS cnt FROM People GROUP BY name");
+			var countField = select.$select().get(0);
+			this.registry.register(TestUtils.unwrapAlias(countField), TestUtils.getAliasName(countField));
+
+			// Parse ORDER BY unknown — should not match anything
+			var orderSelect = TestUtils.parseSelect("SELECT name FROM People ORDER BY unknown");
+			var orderField = orderSelect.$orderBy().get(0).$field();
+
+			assertThat(this.registry.resolve(orderField)).isNull();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Combined mode — structural + name-based")
+	class CombinedModeTests {
+
+		private AliasRegistry registry;
+
+		@BeforeEach
+		void setUp() {
+			this.registry = new AliasRegistry();
+
+			// Register count(*) → "cnt" and name → "name"
+			var select = TestUtils.parseSelect("SELECT name, count(*) AS cnt FROM People GROUP BY name");
+			var selectFields = select.$select();
+			for (var sf : selectFields) {
+				this.registry.register(TestUtils.unwrapAlias(sf), TestUtils.getAliasName(sf));
+			}
+		}
+
+		@Test
+		@DisplayName("Lookup count(*) structurally → cnt")
+		void lookupCountStructurally() {
+			var select = TestUtils.parseSelect("SELECT name FROM People GROUP BY name HAVING count(*) > 5");
+			var gt = (QOM.Gt<?>) select.$having();
+
+			assertThat(this.registry.resolve(Objects.requireNonNull(gt).$arg1())).isEqualToIgnoringCase("cnt");
+		}
+
+		@Test
+		@DisplayName("Lookup Field(cnt) by name → cnt")
+		void lookupCntByName() {
+			var select = TestUtils.parseSelect("SELECT name, count(*) AS cnt FROM People GROUP BY name ORDER BY cnt");
+			var orderField = select.$orderBy().get(0).$field();
+
+			assertThat(this.registry.resolve(orderField)).isEqualToIgnoringCase("cnt");
+		}
+
+		@Test
+		@DisplayName("Lookup Field(name) by name → name")
+		void lookupNameByName() {
+			var select = TestUtils.parseSelect("SELECT name, count(*) AS cnt FROM People GROUP BY name ORDER BY name");
+			var orderField = select.$orderBy().get(0).$field();
+
+			assertThat(this.registry.resolve(orderField)).isEqualToIgnoringCase("name");
+		}
+
+		@Test
+		@DisplayName("Lookup sum(age) → null (not registered)")
+		void lookupUnregisteredAggregate() {
+			var select = TestUtils.parseSelect("SELECT name FROM People GROUP BY name HAVING sum(age) > 100");
+			var gt = (QOM.Gt<?>) select.$having();
+
+			assertThat(this.registry.resolve(Objects.requireNonNull(gt).$arg1())).isNull();
+		}
+
+		@Test
+		@DisplayName("Lookup Field(bogus) → null")
+		void lookupBogusName() {
+			var select = TestUtils.parseSelect("SELECT name FROM People ORDER BY bogus");
+			var orderField = select.$orderBy().get(0).$field();
+
+			assertThat(this.registry.resolve(orderField)).isNull();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Round-trip from parsed SQL")
+	class RoundTripTests {
+
+		@Test
+		@DisplayName("count(*) round-trip: register from SELECT, lookup from HAVING (structural) and ORDER BY (name)")
+		void countStarRoundTrip() {
+			var select = TestUtils
+				.parseSelect("SELECT name, count(*) AS cnt FROM People GROUP BY name HAVING count(*) > 5 ORDER BY cnt");
+
+			// Build registry from SELECT fields
+			var registry = new AliasRegistry();
+			for (var sf : select.$select()) {
+				registry.register(TestUtils.unwrapAlias(sf), TestUtils.getAliasName(sf));
+			}
+
+			// Lookup from HAVING: count(*) → "cnt" (structural match)
+			var gt = (QOM.Gt<?>) select.$having();
+			var havingField = (Field<?>) Objects.requireNonNull(gt).$arg1();
+			assertThat(havingField).isInstanceOf(QOM.Count.class);
+			assertThat(registry.resolve(havingField)).isEqualToIgnoringCase("cnt");
+
+			// Lookup from ORDER BY: Field("cnt") → "cnt" (name-based match)
+			var orderField = select.$orderBy().get(0).$field();
+			assertThat(orderField).isNotInstanceOf(QOM.Count.class);
+			assertThat(registry.resolve(orderField)).isEqualToIgnoringCase("cnt");
+		}
+
+		@Test
+		@DisplayName("sum(age) round-trip: register from SELECT, lookup from ORDER BY (structural)")
+		void sumAgeRoundTrip() {
+			var select = TestUtils
+				.parseSelect("SELECT name, sum(age) AS total FROM People GROUP BY name ORDER BY sum(age)");
+
+			// Build registry from SELECT fields
+			var registry = new AliasRegistry();
+			for (var sf : select.$select()) {
+				registry.register(TestUtils.unwrapAlias(sf), TestUtils.getAliasName(sf));
+			}
+
+			// Lookup from ORDER BY: sum(age) → "total" (structural match)
+			var orderField = select.$orderBy().get(0).$field();
+			assertThat(orderField).isInstanceOf(QOM.Sum.class);
+			assertThat(registry.resolve(orderField)).isEqualToIgnoringCase("total");
+		}
+
+	}
+
+}

--- a/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/FieldEquivalencePredicateTests.java
+++ b/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/FieldEquivalencePredicateTests.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.translator.impl;
+
+import java.util.Objects;
+
+import org.jooq.Field;
+import org.jooq.impl.QOM;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the structural field equivalence matcher. All inputs are parsed through
+ * jOOQ's SQL parser to ensure we test against the exact types the production code will
+ * encounter.
+ *
+ * @author Ryan Knight
+ * @author Michael J. Simons
+ */
+class FieldEquivalencePredicateTests {
+
+	private static final FieldEquivalencePredicate PREDICATE_UNDER_TEST = new FieldEquivalencePredicate();
+
+	@Nested
+	@DisplayName("Column reference matching")
+	class ColumnReferenceTests {
+
+		@Test
+		@DisplayName("Same table, same column -> true")
+		void sameTableSameColumn() {
+			var select = TestUtils
+				.parseSelect("SELECT c.name FROM Customers c JOIN Orders o ON c.id = o.customer_id GROUP BY c.name");
+
+			// Extract c.name from SELECT and GROUP BY
+			var selectField = TestUtils.unwrapAlias(select.$select().get(0));
+			var groupField = (Field<?>) select.$groupBy().get(0);
+
+			assertThat(PREDICATE_UNDER_TEST.test(selectField, groupField)).isTrue();
+		}
+
+		@Test
+		@DisplayName("Same table, different column -> false")
+		void sameTableDifferentColumn() {
+			var select = TestUtils
+				.parseSelect("SELECT c.name, c.age FROM Customers c JOIN Orders o ON c.id = o.customer_id");
+
+			var field1 = TestUtils.unwrapAlias(select.$select().get(0));
+			var field2 = TestUtils.unwrapAlias(select.$select().get(1));
+
+			assertThat(PREDICATE_UNDER_TEST.test(field1, field2)).isFalse();
+		}
+
+		@Test
+		@DisplayName("Different table, same column name -> false")
+		void differentTableSameColumn() {
+			var select = TestUtils
+				.parseSelect("SELECT c.id, o.id FROM Customers c JOIN Orders o ON c.id = o.customer_id");
+
+			var field1 = TestUtils.unwrapAlias(select.$select().get(0));
+			var field2 = TestUtils.unwrapAlias(select.$select().get(1));
+
+			assertThat(PREDICATE_UNDER_TEST.test(field1, field2)).isFalse();
+		}
+
+		@Test
+		@DisplayName("Unqualified field matches qualified field -> true")
+		void unqualifiedMatchesQualified() {
+			// Use two separate queries: one with table qualifier, one without
+			var qualifiedSelect = TestUtils
+				.parseSelect("SELECT c.name FROM Customers c JOIN Orders o ON c.id = o.customer_id");
+			var unqualifiedSelect = TestUtils.parseSelect("SELECT name FROM Customers");
+
+			var qualified = TestUtils.unwrapAlias(qualifiedSelect.$select().get(0));
+			var unqualified = TestUtils.unwrapAlias(unqualifiedSelect.$select().get(0));
+
+			assertThat(PREDICATE_UNDER_TEST.test(qualified, unqualified)).isTrue();
+		}
+
+		@Test
+		@DisplayName("Case-insensitive matching -> true")
+		void caseInsensitiveMatching() {
+			var select1 = TestUtils.parseSelect("SELECT name FROM People");
+			var select2 = TestUtils.parseSelect("SELECT NAME FROM People");
+
+			var field1 = TestUtils.unwrapAlias(select1.$select().get(0));
+			var field2 = TestUtils.unwrapAlias(select2.$select().get(0));
+
+			assertThat(PREDICATE_UNDER_TEST.test(field1, field2)).isTrue();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Aggregate function matching")
+	class AggregateFunctionTests {
+
+		@Test
+		@DisplayName("count(*) vs count(*) -> true")
+		void countStarVsCountStar() {
+			var select = TestUtils.parseSelect("SELECT count(*) AS cnt FROM People GROUP BY name HAVING count(*) > 5");
+
+			var selectCount = TestUtils.unwrapAlias(select.$select().get(0));
+			var havingCount = ((QOM.Gt<?>) Objects.requireNonNull(select.$having())).$arg1();
+
+			assertThat(PREDICATE_UNDER_TEST.test(selectCount, havingCount)).isTrue();
+		}
+
+		@Test
+		@DisplayName("count(*) vs sum(age) -> false")
+		void countStarVsSumAge() {
+			var select1 = TestUtils.parseSelect("SELECT count(*) FROM People");
+			var select2 = TestUtils.parseSelect("SELECT sum(age) FROM People");
+
+			var count = TestUtils.unwrapAlias(select1.$select().get(0));
+			var sum = TestUtils.unwrapAlias(select2.$select().get(0));
+
+			assertThat(PREDICATE_UNDER_TEST.test(count, sum)).isFalse();
+		}
+
+		@Test
+		@DisplayName("count(name) vs count(age) -> false")
+		void countNameVsCountAge() {
+			var select = TestUtils.parseSelect("SELECT count(name) AS cn, count(age) AS ca FROM People");
+
+			var countName = TestUtils.unwrapAlias(select.$select().get(0));
+			var countAge = TestUtils.unwrapAlias(select.$select().get(1));
+
+			assertThat(PREDICATE_UNDER_TEST.test(countName, countAge)).isFalse();
+		}
+
+		@Test
+		@DisplayName("sum(age) vs sum(age) -> true")
+		void sumVsSum() {
+			var select = TestUtils
+				.parseSelect("SELECT sum(age) AS total FROM People GROUP BY name HAVING sum(age) > 100");
+
+			var selectSum = TestUtils.unwrapAlias(select.$select().get(0));
+			var havingSum = ((QOM.Gt<?>) Objects.requireNonNull(select.$having())).$arg1();
+
+			assertThat(PREDICATE_UNDER_TEST.test(selectSum, havingSum)).isTrue();
+		}
+
+		@Test
+		@DisplayName("min(salary) vs min(salary) -> true")
+		void minVsMin() {
+			var select = TestUtils
+				.parseSelect("SELECT min(salary) AS mn FROM Employees GROUP BY department HAVING min(salary) > 50000");
+
+			var selectMin = TestUtils.unwrapAlias(select.$select().get(0));
+			var havingMin = ((QOM.Gt<?>) Objects.requireNonNull(select.$having())).$arg1();
+
+			assertThat(PREDICATE_UNDER_TEST.test(selectMin, havingMin)).isTrue();
+		}
+
+		@Test
+		@DisplayName("max(age) vs max(age) -> true")
+		void maxVsMax() {
+			var select = TestUtils.parseSelect("SELECT max(age) AS mx FROM People GROUP BY name HAVING max(age) > 60");
+
+			var selectMax = TestUtils.unwrapAlias(select.$select().get(0));
+			var havingMax = ((QOM.Gt<?>) Objects.requireNonNull(select.$having())).$arg1();
+
+			assertThat(PREDICATE_UNDER_TEST.test(selectMax, havingMax)).isTrue();
+		}
+
+		@Test
+		@DisplayName("avg(score) vs avg(score) -> true")
+		void avgVsAvg() {
+			var select = TestUtils
+				.parseSelect("SELECT avg(score) AS av FROM Results GROUP BY name HAVING avg(score) > 75");
+
+			var selectAvg = TestUtils.unwrapAlias(select.$select().get(0));
+			var havingAvg = ((QOM.Gt<?>) Objects.requireNonNull(select.$having())).$arg1();
+
+			assertThat(PREDICATE_UNDER_TEST.test(selectAvg, havingAvg)).isTrue();
+		}
+
+		@Test
+		@DisplayName("count(name) vs count(DISTINCT name) -> false")
+		void countVsCountDistinct() {
+			var select = TestUtils.parseSelect("SELECT count(name) AS cn, count(DISTINCT name) AS cdn FROM People");
+
+			var countAll = TestUtils.unwrapAlias(select.$select().get(0));
+			var countDistinct = TestUtils.unwrapAlias(select.$select().get(1));
+
+			assertThat(PREDICATE_UNDER_TEST.test(countAll, countDistinct)).isFalse();
+		}
+
+		@Test
+		@DisplayName("count(DISTINCT name) vs count(DISTINCT name) -> true")
+		void countDistinctVsCountDistinct() {
+			var select = TestUtils.parseSelect(
+					"SELECT count(DISTINCT name) AS cdn FROM People GROUP BY age HAVING count(DISTINCT name) > 3");
+
+			var selectCountDistinct = TestUtils.unwrapAlias(select.$select().get(0));
+			var havingCountDistinct = ((QOM.Gt<?>) select.$having()).$arg1();
+
+			assertThat(PREDICATE_UNDER_TEST.test(selectCountDistinct, havingCountDistinct)).isTrue();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Alias transparency")
+	class AliasTransparencyTests {
+
+		@Test
+		@DisplayName("count(*) AS cnt vs count(*) -> true")
+		void aliasedCountVsUnaliasedCount() {
+			var select1 = TestUtils.parseSelect("SELECT count(*) AS cnt FROM People");
+			var select2 = TestUtils.parseSelect("SELECT count(*) FROM People");
+
+			// The first is aliased, the second is not
+			var aliasedCount = TestUtils.asField(select1.$select().get(0));
+			assertThat(aliasedCount).isInstanceOf(QOM.FieldAlias.class);
+
+			var unaliasedCount = TestUtils.asField(select2.$select().get(0));
+
+			assertThat(PREDICATE_UNDER_TEST.test(aliasedCount, unaliasedCount)).isTrue();
+		}
+
+		@Test
+		@DisplayName("sum(age) AS total vs sum(age) -> true")
+		void aliasedSumVsUnaliasedSum() {
+			var select1 = TestUtils.parseSelect("SELECT sum(age) AS total FROM People");
+			var select2 = TestUtils.parseSelect("SELECT sum(age) FROM People");
+
+			var aliasedSum = TestUtils.asField(select1.$select().get(0));
+			assertThat(aliasedSum).isInstanceOf(QOM.FieldAlias.class);
+
+			var unaliasedSum = TestUtils.asField(select2.$select().get(0));
+
+			assertThat(PREDICATE_UNDER_TEST.test(aliasedSum, unaliasedSum)).isTrue();
+		}
+
+		@Test
+		@DisplayName("name AS n vs name -> true")
+		void aliasedFieldVsUnaliasedField() {
+			var select1 = TestUtils.parseSelect("SELECT name AS n FROM People");
+			var select2 = TestUtils.parseSelect("SELECT name FROM People");
+
+			var aliasedField = TestUtils.asField(select1.$select().get(0));
+			assertThat(aliasedField).isInstanceOf(QOM.FieldAlias.class);
+
+			var unaliasedField = TestUtils.asField(select2.$select().get(0));
+
+			assertThat(PREDICATE_UNDER_TEST.test(aliasedField, unaliasedField)).isTrue();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Cross-parse matching")
+	class CrossParseTests {
+
+		@Test
+		@DisplayName("count(*) from SELECT vs count(*) from HAVING of the same query -> true")
+		void countFromSelectVsHaving() {
+			var select = TestUtils
+				.parseSelect("SELECT name, count(*) AS cnt FROM People GROUP BY name HAVING count(*) > 5");
+
+			// Extract count(*) from SELECT (aliased)
+			var selectCount = TestUtils.asField(select.$select().get(1));
+			assertThat(selectCount).isInstanceOf(QOM.FieldAlias.class);
+
+			// Extract count(*) from HAVING
+			var havingCount = ((QOM.Gt<?>) Objects.requireNonNull(select.$having())).$arg1();
+			assertThat(havingCount).isInstanceOf(QOM.Count.class);
+
+			assertThat(PREDICATE_UNDER_TEST.test(selectCount, havingCount)).isTrue();
+		}
+
+		@Test
+		@DisplayName("sum(age) from SELECT vs sum(age) from ORDER BY of the same query -> true")
+		void sumFromSelectVsOrderBy() {
+			var select = TestUtils
+				.parseSelect("SELECT name, sum(age) AS total FROM People GROUP BY name ORDER BY sum(age)");
+
+			// Extract sum(age) from SELECT (aliased)
+			var selectSum = TestUtils.asField(select.$select().get(1));
+			assertThat(selectSum).isInstanceOf(QOM.FieldAlias.class);
+
+			// Extract sum(age) from ORDER BY
+			var orderByField = select.$orderBy().get(0).$field();
+			assertThat(orderByField).isInstanceOf(QOM.Sum.class);
+
+			assertThat(PREDICATE_UNDER_TEST.test(selectSum, orderByField)).isTrue();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Negative and false-positive cases")
+	class NonMatchingAndFalsePositiveCasesTests {
+
+		@Test
+		@DisplayName("count(*) vs count(name) -> false")
+		void countStarVsCountName() {
+			var select = TestUtils.parseSelect("SELECT count(*) AS c1, count(name) AS c2 FROM People");
+
+			var countStar = TestUtils.unwrapAlias(select.$select().get(0));
+			var countName = TestUtils.unwrapAlias(select.$select().get(1));
+
+			assertThat(PREDICATE_UNDER_TEST.test(countStar, countName)).isFalse();
+		}
+
+		@Test
+		@DisplayName("sum(age) vs avg(age) -> false")
+		void sumVsAvg() {
+			var select = TestUtils.parseSelect("SELECT sum(age) AS s, avg(age) AS a FROM People");
+
+			var sum = TestUtils.unwrapAlias(select.$select().get(0));
+			var avg = TestUtils.unwrapAlias(select.$select().get(1));
+
+			assertThat(PREDICATE_UNDER_TEST.test(sum, avg)).isFalse();
+		}
+
+		@Test
+		@DisplayName("min(x) vs max(x) -> false")
+		void minVsMax() {
+			var select = TestUtils.parseSelect("SELECT min(score) AS mn, max(score) AS mx FROM Results");
+
+			var min = TestUtils.unwrapAlias(select.$select().get(0));
+			var max = TestUtils.unwrapAlias(select.$select().get(1));
+
+			assertThat(PREDICATE_UNDER_TEST.test(min, max)).isFalse();
+		}
+
+		@Test
+		@DisplayName("count(x) vs count(DISTINCT x) -> false")
+		void countVsCountDistinctNegative() {
+			var select = TestUtils.parseSelect("SELECT count(name) AS cn, count(DISTINCT name) AS cdn FROM People");
+
+			var countAll = TestUtils.unwrapAlias(select.$select().get(0));
+			var countDistinct = TestUtils.unwrapAlias(select.$select().get(1));
+
+			assertThat(PREDICATE_UNDER_TEST.test(countAll, countDistinct)).isFalse();
+		}
+
+		@Test
+		@DisplayName("null vs field -> false")
+		void nullVsField() {
+			var select = TestUtils.parseSelect("SELECT name FROM People");
+			var field = TestUtils.unwrapAlias(select.$select().get(0));
+
+			assertThat(PREDICATE_UNDER_TEST.test(null, field)).isFalse();
+			assertThat(PREDICATE_UNDER_TEST.test(field, null)).isFalse();
+			assertThat(PREDICATE_UNDER_TEST.test(null, null)).isFalse();
+		}
+
+	}
+
+}

--- a/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/SqlToCypherTests.java
+++ b/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/SqlToCypherTests.java
@@ -560,11 +560,19 @@ class SqlToCypherTests {
 	}
 
 	@ParameterizedTest
-	@CsvSource(delimiterString = "|", textBlock = """
-			SELECT name FROM Movie GROUP BY name | MATCH (movie:Movie) RETURN movie.name AS name
-			SELECT c.name FROM Customers c JOIN Orders o ON c.id = o.customer_id GROUP BY c.name | MATCH (c:Customers)<-[customer_id:CUSTOMER_ID]-(o:Orders) RETURN c.name
-			SELECT * FROM `public`.`Person` `Person` INNER JOIN `public`.`Person_DIRECTED_Movie` `Person_DIRECTED_Movie` ON (`Person`.`v$id` = `Person_DIRECTED_Movie`.`v$id`) GROUP BY `name`, `v_movie_id` | f
-			""")
+	@CsvSource(delimiterString = "|",
+			textBlock = """
+					SELECT name FROM Movie GROUP BY name                  | MATCH (movie:Movie) RETURN movie.name AS name
+					SELECT name AS x FROM Movie GROUP BY x                | MATCH (movie:Movie) RETURN movie.name AS x
+					SELECT v$id FROM Movie GROUP BY title                 | MATCH (movie:Movie) WITH elementId(movie) AS `v$id`, movie.title AS __group_col_0 RETURN `v$id`
+					SELECT v$id, count(*) FROM Movie GROUP BY v$id        | MATCH (movie:Movie) RETURN elementId(movie) AS `v$id`, count(*)
+					SELECT v$id, count(*) FROM Movie GROUP BY v$id, title | MATCH (movie:Movie) WITH elementId(movie) AS `v$id`, count(*) AS `count(*)`, movie.title AS __group_col_0 RETURN `v$id`, `count(*)`
+					SELECT * FROM Movie GROUP BY title                    | MATCH (movie:Movie) WITH *, movie.title AS __group_col_0 RETURN *
+					SELECT Movie.name AS x FROM Movie GROUP BY x          | MATCH (movie:Movie) RETURN movie.name AS x
+					SELECT `Person`.`name` AS `name`, `Person_DIRECTED_Movie`.`v$movie_id` AS `v_movie_id` FROM `public`.`Person` `Person` INNER JOIN `public`.`Person_DIRECTED_Movie` `Person_DIRECTED_Movie` ON (`Person`.`v$id` = `Person_DIRECTED_Movie`.`v$id`) GROUP BY `name`, `v_movie_id` | MATCH (person:Person)-[person_directed_movie:DIRECTED WHERE elementId(person) = elementId(person_directed_movie)]->(_end:Movie) RETURN person.name AS name, elementId(_end) AS v_movie_id
+					SELECT Person.name AS name, Person_DIRECTED_Movie.v$movie_id AS v_movie_id FROM Person Person INNER JOIN Person_DIRECTED_Movie Person_DIRECTED_Movie ON (Person.v$id = Person_DIRECTED_Movie.v$id) GROUP BY name, v_movie_id | MATCH (person:Person)-[person_directed_movie:DIRECTED WHERE elementId(person) = elementId(person_directed_movie)]->(_end:Movie) RETURN person.name AS name, elementId(_end) AS v_movie_id
+					SELECT Movie.title AS title, Person_DIRECTED_Movie.v$movie_id AS v_movie_id FROM public.Movie Movie INNER JOIN public.Person_DIRECTED_Movie Person_DIRECTED_Movie ON (Movie.v$id = Person_DIRECTED_Movie.v$id) INNER JOIN Person ON (Person.v$id = Person_DIRECTED_Movie.v$person_in) GROUP BY Person.name, v_movie_id | MATCH (person:Person)-[person_directed_movie:DIRECTED WHERE elementId(person) = elementId(person_directed_movie)]->(movie:Movie) WITH movie.title AS title, elementId(movie) AS v_movie_id, person.name AS __group_col_0 RETURN title, v_movie_id
+					""")
 	void groupByWithoutAggregate(String sql, String cypher) {
 
 		var translator = SqlToCypher

--- a/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/SqlToCypherTests.java
+++ b/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/SqlToCypherTests.java
@@ -19,29 +19,17 @@
 package org.neo4j.jdbc.translator.impl;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.Options;
-import org.asciidoctor.ast.Block;
-import org.asciidoctor.ast.ContentNode;
-import org.asciidoctor.ast.Document;
-import org.asciidoctor.extension.Treeprocessor;
 import org.jooq.impl.ParserException;
 import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.DynamicTest;
@@ -77,21 +65,6 @@ class SqlToCypherTests {
 
 	private static final Translator NON_PRETTY_PRINTING_TRANSLATOR = SqlToCypher
 		.with(SqlToCypherConfig.builder().withPrettyPrint(false).withAlwaysEscapeNames(false).build());
-
-	private static ResultSet makeColumns(String firstName, String... names) throws SQLException {
-		var personColumns = mock(ResultSet.class);
-		if (firstName == null) {
-			given(personColumns.next()).willReturn(false);
-			return personColumns;
-		}
-		Boolean[] results = new Boolean[names.length + 1];
-		for (int i = 0; i < results.length; i++) {
-			results[i] = i != results.length - 1;
-		}
-		given(personColumns.next()).willReturn(true, results);
-		given(personColumns.getString("COLUMN_NAME")).willReturn(firstName, names);
-		return personColumns;
-	}
 
 	static Stream<Arguments> concatShouldWork() {
 		return Stream.of(Arguments.of("SELECT 'a' || 'b'", "RETURN ('a' + 'b')"),
@@ -177,11 +150,11 @@ class SqlToCypherTests {
 
 		DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
 		given(databaseMetaData.getTables(any(), any(), any(), any())).willReturn(mock(ResultSet.class));
-		var resultSet = makeColumns("title");
+		var resultSet = TestUtils.makeColumns("title");
 		given(databaseMetaData.getColumns(null, null, "Movie", null)).willReturn(resultSet);
-		resultSet = makeColumns("foobar");
+		resultSet = TestUtils.makeColumns("foobar");
 		given(databaseMetaData.getColumns(null, null, "HAS", null)).willReturn(resultSet);
-		resultSet = makeColumns("name");
+		resultSet = TestUtils.makeColumns("name");
 		given(databaseMetaData.getColumns(null, null, "Genre", null)).willReturn(resultSet);
 
 		var renderer = Renderer.getRenderer(Configuration.newConfig()
@@ -207,23 +180,23 @@ class SqlToCypherTests {
 
 		DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
 		given(databaseMetaData.getTables(any(), any(), any(), any())).willReturn(mock(ResultSet.class));
-		var resultSet1 = makeColumns("title", "released");
-		var resultSet2 = makeColumns("title", "released");
-		var resultSet3 = makeColumns("title", "released");
-		var resultSet4 = makeColumns("title", "released");
+		var resultSet1 = TestUtils.makeColumns("title", "released");
+		var resultSet2 = TestUtils.makeColumns("title", "released");
+		var resultSet3 = TestUtils.makeColumns("title", "released");
+		var resultSet4 = TestUtils.makeColumns("title", "released");
 		given(databaseMetaData.getColumns(null, null, "Movie", null)).willReturn(resultSet1)
 			.willReturn(resultSet2)
 			.willReturn(resultSet3)
 			.willReturn(resultSet4);
-		resultSet1 = makeColumns(null);
-		resultSet2 = makeColumns(null);
-		resultSet3 = makeColumns(null);
+		resultSet1 = TestUtils.makeColumns(null);
+		resultSet2 = TestUtils.makeColumns(null);
+		resultSet3 = TestUtils.makeColumns(null);
 		given(databaseMetaData.getColumns(null, null, "HAS", null)).willReturn(resultSet1)
 			.willReturn(resultSet2)
 			.willReturn(resultSet3);
-		resultSet1 = makeColumns("name");
-		resultSet2 = makeColumns("name");
-		resultSet3 = makeColumns("name");
+		resultSet1 = TestUtils.makeColumns("name");
+		resultSet2 = TestUtils.makeColumns("name");
+		resultSet3 = TestUtils.makeColumns("name");
 		given(databaseMetaData.getColumns(null, null, "Genre", null)).willReturn(resultSet1)
 			.willReturn(resultSet2)
 			.willReturn(resultSet3);
@@ -548,25 +521,6 @@ class SqlToCypherTests {
 		assertThat(cypher).isEqualTo("FINISH");
 	}
 
-	@ParameterizedTest
-	@CsvSource(delimiterString = "|", textBlock = """
-			SELECT name, count(*) FROM People p GROUP BY name|MATCH (p:People) RETURN p.name AS name, count(*)
-			SELECT name, max(age) FROM People p GROUP BY name|MATCH (p:People) RETURN p.name AS name, max(p.age)
-			SELECT name, min(age) FROM People p GROUP BY name|MATCH (p:People) RETURN p.name AS name, min(p.age)
-			SELECT sum(age) FROM People p GROUP BY name|MATCH (p:People) RETURN sum(p.age)
-			SELECT avg(age) FROM People p GROUP BY name|MATCH (p:People) RETURN avg(p.age)
-			SELECT percentileCont(age) FROM People p GROUP BY name|MATCH (p:People) RETURN percentileCont(p.age)
-			SELECT percentileDisc(age) FROM People p GROUP BY name|MATCH (p:People) RETURN percentileDisc(p.age)
-			SELECT stDev(age) FROM People p GROUP BY name|MATCH (p:People) RETURN stDev(p.age)
-			SELECT stDevP(age) FROM People p GROUP BY name|MATCH (p:People) RETURN stDevP(p.age)
-			""")
-	void aggregates(String sql, String cypher) {
-
-		var translator = SqlToCypher.defaultTranslator();
-		assertThat(translator.translate(sql)).isEqualTo(cypher);
-
-	}
-
 	@Test
 	void outerSelectStarShouldBeRemoved() {
 
@@ -605,20 +559,6 @@ class SqlToCypherTests {
 		assertThat(translator.translate(in)).isEqualTo(expected);
 	}
 
-	static List<TestData> getTestData(Path path) {
-		try (var asciidoctor = Asciidoctor.Factory.create()) {
-			var collector = new TestDataExtractor();
-			asciidoctor.javaExtensionRegistry().treeprocessor(collector);
-
-			var content = Files.readString(path);
-			asciidoctor.load(content, Options.builder().build());
-			return collector.testData;
-		}
-		catch (IOException ioe) {
-			throw new RuntimeException("Error reading TCK file " + path, ioe);
-		}
-	}
-
 	@TestFactory
 	Stream<DynamicContainer> tck() {
 
@@ -634,26 +574,35 @@ class SqlToCypherTests {
 		}
 
 		return Arrays.stream(files).map(file -> {
-			var tests = getTestData(file.toPath()).stream()
+			var tests = TestUtils.getTestData(file.toPath())
+				.stream()
 				.map(t -> DynamicTest.dynamicTest(
-						Optional.ofNullable(t.name).filter(Predicate.not(String::isBlank)).orElse(t.id),
-						() -> assertThatSqlIsTranslatedAsExpected(t.sql, t.cypher, t.tableMappings,
-								t.joinColumnsMappings, t.prettyPrint, t.databaseMetaData)))
+						Optional.ofNullable(t.name()).filter(Predicate.not(String::isBlank)).orElse(t.id()),
+						() -> assertThatSqlIsTranslatedAsExpected(t.sql(), t.cypher(), t.tableMappings(),
+								t.joinColumnsMappings(), t.prettyPrint(), t.forceDefaults(), t.databaseMetaData())))
 				.toList();
 			return DynamicContainer.dynamicContainer(file.getName(), tests);
 		});
 	}
 
 	void assertThatSqlIsTranslatedAsExpected(String sql, String expected, Map<String, String> tableMappings,
-			Map<String, String> join_columns_mappings, boolean prettyPrint, DatabaseMetaData databaseMetaData) {
-		assertThat(SqlToCypher
-			.with(SqlToCypherConfig.builder()
+			Map<String, String> join_columns_mappings, boolean prettyPrint, boolean forceDefaults,
+			DatabaseMetaData databaseMetaData) {
+
+		Translator translator;
+		if (forceDefaults) {
+			translator = SqlToCypher.defaultTranslator();
+
+		}
+		else {
+			translator = SqlToCypher.with(SqlToCypherConfig.builder()
 				.withPrettyPrint(prettyPrint)
 				.withAlwaysEscapeNames(!prettyPrint)
 				.withTableToLabelMappings(tableMappings)
 				.withJoinColumnsToTypeMappings(join_columns_mappings)
-				.build())
-			.translate(sql, databaseMetaData)).isEqualTo(expected);
+				.build());
+		}
+		assertThat(translator.translate(sql, databaseMetaData)).isEqualTo(expected);
 	}
 
 	@ParameterizedTest
@@ -817,6 +766,41 @@ class SqlToCypherTests {
 		assertThat(translator.translate(sqlAndCypher.sql())).isEqualTo(sqlAndCypher.cypher());
 	}
 
+	@ParameterizedTest
+	@CsvSource(delimiterString = "|", quoteCharacter = '"', textBlock = """
+			SELECT * FROM People p
+			SELECT name FROM People p
+			SELECT name FROM People p ORDER BY name DESC LIMIT 10
+			SELECT count(*) FROM People p
+			SELECT sum(age) FROM People p
+			SELECT min(age), max(age) FROM People p
+			SELECT avg(age) FROM People p
+			INSERT INTO People (name, age) VALUES ('Alice', 30)
+			UPDATE People SET age = 31 WHERE name = 'Alice'
+			DELETE FROM People WHERE name = 'Alice'
+			""")
+	void nonGroupByPathNeverProducesWithClause(String sql) {
+
+		var translator = SqlToCypher.defaultTranslator();
+		var result = translator.translate(sql);
+		assertThat(result).doesNotContainPattern("\\bWITH\\b");
+	}
+
+	@Test
+	void registryDoesNotLeakBetweenTranslations() {
+
+		var translator = SqlToCypher.defaultTranslator();
+		// First: query with HAVING (activates registry)
+		var havingResult = translator.translate("SELECT name FROM People p GROUP BY name HAVING count(*) > 5");
+		assertThat(havingResult).contains("WITH").contains("__having_col_0");
+		// Second: simple query (should NOT have WITH or alias references)
+		var result = translator.translate("SELECT name FROM People p");
+		assertThat(result).doesNotContainPattern("\\bWITH\\b");
+		assertThat(result).doesNotContain("__with_col_");
+		assertThat(result).doesNotContain("__having_col_");
+		assertThat(result).isEqualTo("MATCH (p:People) RETURN p.name AS name");
+	}
+
 	private record SqlAndCypher(String name, String sql, String cypher) {
 		static SqlAndCypher of(String name, String sql, String cypher) {
 			return new SqlAndCypher(name, sql, cypher);
@@ -830,82 +814,6 @@ class SqlToCypherTests {
 		String displayName() {
 			return Optional.ofNullable(this.name).orElse(this.sql);
 		}
-	}
-
-	private static class TestDataExtractor extends Treeprocessor {
-
-		private final List<TestData> testData = new ArrayList<>();
-
-		TestDataExtractor() {
-			super(new HashMap<>()); // Must be mutable
-		}
-
-		@Override
-		public Document process(Document document) {
-
-			var blocks = document.findBy(Map.of("context", ":listing", "style", "source"))
-				.stream()
-				.map(Block.class::cast)
-				.filter(b -> b.hasAttribute("id"))
-				.collect(Collectors.toMap(ContentNode::getId, Function.identity()));
-
-			blocks.values().stream().filter(b -> "sql".equals(b.getAttribute("language"))).map(sqlBlock -> {
-				var name = (String) sqlBlock.getAttribute("name");
-				var sql = String.join("\n", sqlBlock.getLines());
-				var cypherBlock = blocks.get(sqlBlock.getId() + "_expected");
-				var cypher = String.join("\n", cypherBlock.getLines());
-				DatabaseMetaData databaseMetaData = null;
-				Map<String, String> tableMappings = new HashMap<>();
-				Map<String, String> join_columns_mappings = new HashMap<>();
-				if (sqlBlock.getAttribute("table_mappings") != null) {
-					tableMappings = SqlToCypherConfig.buildMap((String) sqlBlock.getAttribute("table_mappings"));
-				}
-				if (sqlBlock.getAttribute("join_column_mappings") != null) {
-					join_columns_mappings = SqlToCypherConfig
-						.buildMap((String) sqlBlock.getAttribute("join_column_mappings"));
-				}
-				if (sqlBlock.getAttribute("metaData") != null) {
-					String metaData = (String) sqlBlock.getAttribute("metaData");
-
-					databaseMetaData = mock(DatabaseMetaData.class);
-					try {
-						given(databaseMetaData.getTables(any(), any(), any(), any())).willReturn(mock(ResultSet.class));
-					}
-					catch (SQLException ex) {
-						throw new RuntimeException(ex);
-					}
-					for (String m : metaData.split(";")) {
-						var endIndex = m.indexOf(":");
-						String label = m.substring(0, endIndex);
-						String[] properties = m.substring(endIndex + 1).split("\\|");
-						try {
-							var columns = (properties.length > 1)
-									? makeColumns(properties[0], Arrays.copyOfRange(properties, 1, properties.length))
-									: makeColumns(properties[0]);
-							given(databaseMetaData.getColumns(null, null, label, null)).willReturn(columns);
-						}
-						catch (SQLException ex) {
-							throw new RuntimeException(ex);
-						}
-					}
-				}
-				boolean parseCypher = Boolean.parseBoolean(((String) cypherBlock.getAttribute("parseCypher", "true")));
-				boolean prettyPrint = true;
-				if (parseCypher) {
-					var renderer = Renderer.getRenderer(Configuration.newConfig().withDialect(Dialect.NEO4J_5).build());
-					cypher = renderer.render(CypherParser.parse(cypher));
-					prettyPrint = false;
-				}
-				return new TestData(sqlBlock.getId(), name, sql, cypher, tableMappings, join_columns_mappings,
-						prettyPrint, databaseMetaData);
-			}).forEach(this.testData::add);
-			return document;
-		}
-
-	}
-
-	private record TestData(String id, String name, String sql, String cypher, Map<String, String> tableMappings,
-			Map<String, String> joinColumnsMappings, boolean prettyPrint, DatabaseMetaData databaseMetaData) {
 	}
 
 	private record Rel(String source, String rel, String target) {

--- a/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/SqlToCypherTests.java
+++ b/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/SqlToCypherTests.java
@@ -559,6 +559,19 @@ class SqlToCypherTests {
 		assertThat(translator.translate(in)).isEqualTo(expected);
 	}
 
+	@ParameterizedTest
+	@CsvSource(delimiterString = "|", textBlock = """
+			SELECT name FROM Movie GROUP BY name | MATCH (movie:Movie) RETURN movie.name AS name
+			SELECT c.name FROM Customers c JOIN Orders o ON c.id = o.customer_id GROUP BY c.name | MATCH (c:Customers)<-[customer_id:CUSTOMER_ID]-(o:Orders) RETURN c.name
+			SELECT * FROM `public`.`Person` `Person` INNER JOIN `public`.`Person_DIRECTED_Movie` `Person_DIRECTED_Movie` ON (`Person`.`v$id` = `Person_DIRECTED_Movie`.`v$id`) GROUP BY `name`, `v_movie_id` | f
+			""")
+	void groupByWithoutAggregate(String sql, String cypher) {
+
+		var translator = SqlToCypher
+			.with(SqlToCypherConfig.builder().withPrettyPrint(false).withAlwaysEscapeNames(false).build());
+		assertThat(translator.translate(sql)).isEqualTo(cypher);
+	}
+
 	@TestFactory
 	Stream<DynamicContainer> tck() {
 

--- a/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/TestUtils.java
+++ b/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/TestUtils.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.translator.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
+import org.asciidoctor.ast.Block;
+import org.asciidoctor.ast.Cell;
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.Table;
+import org.asciidoctor.extension.Treeprocessor;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Parser;
+import org.jooq.Select;
+import org.jooq.SelectFieldOrAsterisk;
+import org.jooq.impl.DSL;
+import org.jooq.impl.QOM;
+import org.neo4j.cypherdsl.core.renderer.Configuration;
+import org.neo4j.cypherdsl.core.renderer.Dialect;
+import org.neo4j.cypherdsl.core.renderer.Renderer;
+import org.neo4j.cypherdsl.parser.CypherParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Shared setup and helpers for tests that parse SQL through jOOQ and inspect the Query
+ * Object Model (QOM). Provides parser initialization, field unwrapping, and alias
+ * extraction utilities.
+ *
+ * @author Michael J. Simons
+ */
+final class TestUtils {
+
+	private static final DSLContext DSL_CONTEXT;
+
+	private static final Parser PARSER;
+
+	static {
+		Logger.getLogger("org.jooq.Constants").setLevel(Level.WARNING);
+		Logger.getLogger("org.neo4j.jdbc.internal.shaded.jooq.Constants").setLevel(Level.WARNING);
+		System.setProperty("org.jooq.no-logo", "true");
+		System.setProperty("org.jooq.no-tips", "true");
+
+		DSL_CONTEXT = DSL.using(org.jooq.SQLDialect.DEFAULT);
+		PARSER = DSL_CONTEXT.parser();
+	}
+
+	static Select<?> parseSelect(String sql) {
+		var query = PARSER.parseQuery(sql);
+		assertThat(query).isInstanceOf(Select.class);
+		return (Select<?>) query;
+	}
+
+	static Field<?> unwrapAlias(SelectFieldOrAsterisk sfa) {
+		if (sfa instanceof QOM.FieldAlias<?> fa) {
+			return fa.$field();
+		}
+		return (Field<?>) sfa;
+	}
+
+	static Field<?> asField(SelectFieldOrAsterisk sfa) {
+		return (Field<?>) sfa;
+	}
+
+	static String getAliasName(SelectFieldOrAsterisk sfa) {
+		return ((Field<?>) sfa).getName();
+	}
+
+	static ResultSet makeColumns(String firstName, String... names) throws SQLException {
+		var personColumns = mock(ResultSet.class);
+		if (firstName == null) {
+			given(personColumns.next()).willReturn(false);
+			return personColumns;
+		}
+		Boolean[] results = new Boolean[names.length + 1];
+		for (int i = 0; i < results.length; i++) {
+			results[i] = i != results.length - 1;
+		}
+		given(personColumns.next()).willReturn(true, results);
+		given(personColumns.getString("COLUMN_NAME")).willReturn(firstName, names);
+		return personColumns;
+	}
+
+	static List<TestData> getTestData(Path path) {
+		try (var asciidoctor = Asciidoctor.Factory.create()) {
+			var collector = new TestDataExtractor();
+			asciidoctor.javaExtensionRegistry().treeprocessor(collector);
+
+			var content = Files.readString(path);
+			asciidoctor.load(content, Options.builder().build());
+			return collector.testData;
+		}
+		catch (IOException ioe) {
+			throw new RuntimeException("Error reading TCK file " + path, ioe);
+		}
+	}
+
+	private TestUtils() {
+	}
+
+	/** Extracts test data from asciidoctor files. */
+	static class TestDataExtractor extends Treeprocessor {
+
+		private final List<TestData> testData = new ArrayList<>();
+
+		TestDataExtractor() {
+			super(new HashMap<>()); // Must be mutable
+		}
+
+		String extractCode(Cell cell) {
+			var intermediate = cell.getSource();
+			return intermediate.replaceAll("^`|`$", "").replace("\\`", "`");
+		}
+
+		@Override
+		public Document process(Document document) {
+
+			processTables(document);
+			processSourceBlocks(document);
+
+			return document;
+		}
+
+		private void processTables(Document document) {
+			document.findBy(Map.of("context", ":table", "style", "translation_table"))
+				.stream()
+				.map(Table.class::cast)
+				.<TestData>mapMulti((table, consumer) -> {
+					var id = table.getId();
+					var cnt = 1;
+					for (var row : table.getBody()) {
+						var name = "%s_%d".formatted(id, cnt++);
+						var cells = row.getCells();
+						consumer.accept(new TestData(name, name, extractCode(cells.get(0)), extractCode(cells.get(1))));
+					}
+				})
+				.forEach(this.testData::add);
+		}
+
+		private void processSourceBlocks(Document document) {
+			var blocks = document.findBy(Map.of("context", ":listing", "style", "source"))
+				.stream()
+				.map(Block.class::cast)
+				.filter(b -> b.hasAttribute("id"))
+				.collect(Collectors.toMap(ContentNode::getId, Function.identity()));
+
+			blocks.values().stream().filter(b -> "sql".equals(b.getAttribute("language"))).map(sqlBlock -> {
+				var name = (String) sqlBlock.getAttribute("name");
+				var sql = String.join("\n", sqlBlock.getLines());
+				var cypherBlock = blocks.get(sqlBlock.getId() + "_expected");
+				var cypher = String.join("\n", cypherBlock.getLines());
+				DatabaseMetaData databaseMetaData = null;
+				Map<String, String> tableMappings = new HashMap<>();
+				Map<String, String> join_columns_mappings = new HashMap<>();
+				if (sqlBlock.getAttribute("table_mappings") != null) {
+					tableMappings = SqlToCypherConfig.buildMap((String) sqlBlock.getAttribute("table_mappings"));
+				}
+				if (sqlBlock.getAttribute("join_column_mappings") != null) {
+					join_columns_mappings = SqlToCypherConfig
+						.buildMap((String) sqlBlock.getAttribute("join_column_mappings"));
+				}
+				if (sqlBlock.getAttribute("metaData") != null) {
+					String metaData = (String) sqlBlock.getAttribute("metaData");
+
+					databaseMetaData = mock(DatabaseMetaData.class);
+					try {
+						given(databaseMetaData.getTables(any(), any(), any(), any())).willReturn(mock(ResultSet.class));
+					}
+					catch (SQLException ex) {
+						throw new RuntimeException(ex);
+					}
+					for (String m : metaData.split(";")) {
+						var endIndex = m.indexOf(":");
+						String label = m.substring(0, endIndex);
+						String[] properties = m.substring(endIndex + 1).split("\\|");
+						try {
+							var columns = (properties.length > 1)
+									? makeColumns(properties[0], Arrays.copyOfRange(properties, 1, properties.length))
+									: makeColumns(properties[0]);
+							given(databaseMetaData.getColumns(null, null, label, null)).willReturn(columns);
+						}
+						catch (SQLException ex) {
+							throw new RuntimeException(ex);
+						}
+					}
+				}
+				boolean parseCypher = Boolean.parseBoolean(((String) cypherBlock.getAttribute("parseCypher", "true")));
+				boolean prettyPrint = true;
+				if (parseCypher) {
+					var renderer = Renderer.getRenderer(Configuration.newConfig().withDialect(Dialect.NEO4J_5).build());
+					cypher = renderer.render(CypherParser.parse(cypher));
+					prettyPrint = false;
+				}
+				return new TestData(sqlBlock.getId(), name, sql, cypher, tableMappings, join_columns_mappings,
+						prettyPrint, databaseMetaData);
+			}).forEach(this.testData::add);
+		}
+
+	}
+
+	public record TestData(String id, String name, String sql, String cypher, Map<String, String> tableMappings,
+			Map<String, String> joinColumnsMappings, boolean prettyPrint, DatabaseMetaData databaseMetaData,
+			boolean forceDefaults) {
+
+		TestData(String id, String name, String sql, String cypher, Map<String, String> tableMappings,
+				Map<String, String> joinColumnsMappings, boolean prettyPrint, DatabaseMetaData databaseMetaData) {
+			this(id, name, sql, cypher, tableMappings, joinColumnsMappings, prettyPrint, databaseMetaData, false);
+		}
+
+		TestData(String id, String name, String sql, String cypher) {
+			this(id, name, sql, cypher, Map.of(), Map.of(), false, null, true);
+		}
+	}
+
+}

--- a/neo4j-jdbc-translator/impl/src/test/resources/grouping.adoc
+++ b/neo4j-jdbc-translator/impl/src/test/resources/grouping.adoc
@@ -13,7 +13,7 @@ The following functionality is supported:
 - `ORDER BY` after `WITH` clause
 - `DISTINCT` with `GROUP BY` / `HAVING`
 - `LIMIT` and `OFFSET with `WITH` clauses
-- `WHERE` and `GROUP BY` combinations`
+- `WHERE` and `GROUP BY` combinations
 - `JOIN` and `GROUP BY`: aggregation across relationships, with and without `WITH` clauses
 
 == `WITH` clause generation

--- a/neo4j-jdbc-translator/impl/src/test/resources/grouping.adoc
+++ b/neo4j-jdbc-translator/impl/src/test/resources/grouping.adoc
@@ -1,0 +1,194 @@
+[#grouping]
+= Using aggregates and `GROUP BY`
+
+Cypher does by default implicit grouping. Cypher 5 does and will not have explicit grouping and as of March 2026, explicit grouping in Cypher 25 is in the making.
+
+For the common case (`GROUP BY` columns matching the projected columns), the translator continues to emit simple `MATCH ... RETURN` statements because Cypher's implicit grouping produces the correct result. When the `GROUP BY` contains columns absent from the projection, or when a `HAVING` clause is present, the translator introduces a Cypher `WITH` clause to make grouping explicit and to support post-aggregation filtering.
+
+The following functionality is supported:
+
+- `GROUP BY`: implicit and explicit grouping
+- `HAVING`: simple conditions and compound conditions
+- `ORDER BY` on aggregate aliases
+- `ORDER BY` after `WITH` clause
+- `DISTINCT` with `GROUP BY` / `HAVING`
+- `LIMIT` and `OFFSET with `WITH` clauses
+- `WHERE` and `GROUP BY` combinations`
+- `JOIN` and `GROUP BY`: aggregation across relationships, with and without `WITH` clauses
+
+== `WITH` clause generation
+
+[translation_table,id=withClauseGeneration]
+|===
+|SQL | Cypher equivalent
+
+| `SELECT name, sum(age) FROM People p GROUP BY name, department`
+| `MATCH (p:People) WITH p.name AS name, sum(p.age) AS \`sum(age)\`, p.department AS __group_col_0 RETURN name, \`sum(age)\``
+
+| `SELECT count(*) FROM Customers c JOIN Orders o ON c.id = o.customer_id GROUP BY c.name`
+| `MATCH (c:Customers)<-[customer_id:CUSTOMER_ID]-(o:Orders) WITH count(*) AS \`count(*)\`, c.name AS __group_col_0 RETURN \`count(*)\``
+
+| `SELECT c.name, count(*) FROM Customers c JOIN Orders o ON c.id = o.customer_id GROUP BY c.name`
+| `MATCH (c:Customers)<-[customer_id:CUSTOMER_ID]-(o:Orders) RETURN c.name, count(*)`
+
+| `SELECT name, count(*), sum(age), avg(age) FROM People p GROUP BY name`
+| `MATCH (p:People) RETURN p.name AS name, count(*), sum(p.age), avg(p.age)`
+
+| `SELECT count(*), sum(age) FROM People p GROUP BY name`
+| `MATCH (p:People) WITH count(*) AS \`count(*)\`, sum(p.age) AS \`sum(age)\`, p.name AS __group_col_0 RETURN \`count(*)\`, \`sum(age)\``
+
+| `SELECT sum(age) FROM People p GROUP BY name HAVING sum(age) > 100`
+| `MATCH (p:People) WITH sum(p.age) AS \`sum(age)\`, p.name AS __group_col_0 WHERE \`sum(age)\` > 100 RETURN \`sum(age)\``
+
+| `SELECT sum(age) FROM People p GROUP BY name ORDER BY sum(age)`
+| `MATCH (p:People) WITH sum(p.age) AS \`sum(age)\`, p.name AS __group_col_0 RETURN \`sum(age)\` ORDER BY \`sum(age)\``
+|===
+
+== Filtering aggregates with the `HAVING` clause
+
+[translation_table,id=havingConditionTranslation]
+|===
+|SQL | Cypher equivalent
+
+| `SELECT name FROM People p GROUP BY name HAVING count(*) > 5`
+| `MATCH (p:People) WITH p.name AS name, count(*) AS __having_col_0 WHERE __having_col_0 > 5 RETURN name`
+
+| `SELECT count(*) FROM People p HAVING count(*) > 5`
+| `MATCH (p:People) WITH count(*) AS \`count(*)\` WHERE \`count(*)\` > 5 RETURN \`count(*)\``
+
+| `SELECT count(*) FROM People p GROUP BY name HAVING name = 'Alice'`
+| `MATCH (p:People) WITH count(*) AS \`count(*)\`, p.name AS __group_col_0 WHERE __group_col_0 = 'Alice' RETURN \`count(*)\``
+
+| `SELECT name, count(*) AS cnt FROM People p GROUP BY name HAVING cnt > 5`
+| `MATCH (p:People) WITH p.name AS name, count(*) AS cnt WHERE cnt > 5 RETURN name, cnt`
+
+| `SELECT name FROM People p GROUP BY name HAVING count(*) > 5 AND max(age) > 50`
+| `MATCH (p:People) WITH p.name AS name, count(*) AS __having_col_0, max(p.age) AS __having_col_1 WHERE (__having_col_0 > 5 AND __having_col_1 > 50) RETURN name`
+
+| `SELECT name, sum(age) FROM People p GROUP BY name HAVING sum(age) > 100 AND count(*) > 2`
+| `MATCH (p:People) WITH p.name AS name, sum(p.age) AS \`sum(age)\`, count(*) AS __having_col_0 WHERE (\`sum(age)\` > 100 AND __having_col_0 > 2) RETURN name, \`sum(age)\``
+
+| `SELECT name FROM People p GROUP BY name HAVING count(*) > 5 ORDER BY name`
+| `MATCH (p:People) WITH p.name AS name, count(*) AS __having_col_0 WHERE __having_col_0 > 5 RETURN name ORDER BY name`
+
+| `SELECT name FROM People p GROUP BY name HAVING count(DISTINCT age) > 3`
+| `MATCH (p:People) WITH p.name AS name, count(DISTINCT p.age) AS __having_col_0 WHERE __having_col_0 > 3 RETURN name`
+|===
+
+
+== Ordering the result set by an aggregate
+
+[translation_table,id=orderByAggregate]
+|===
+|SQL | Cypher equivalent
+
+| `SELECT name, count(*) AS cnt FROM People p GROUP BY name ORDER BY cnt`
+| `MATCH (p:People) RETURN p.name AS name, count(*) AS cnt ORDER BY cnt`
+
+| `SELECT name, count(*) AS cnt FROM People p GROUP BY name ORDER BY cnt DESC`
+| `MATCH (p:People) RETURN p.name AS name, count(*) AS cnt ORDER BY cnt DESC`
+| `SELECT department, sum(age) AS total FROM People p GROUP BY department ORDER BY total`
+| `MATCH (p:People) RETURN p.department AS department, sum(p.age) AS total ORDER BY total`
+| `SELECT department, count(*) AS cnt, avg(age) AS average FROM People p GROUP BY department ORDER BY cnt DESC, average`
+| `MATCH (p:People) RETURN p.department AS department, count(*) AS cnt, avg(p.age) AS average ORDER BY cnt DESC, average`
+|===
+
+
+== Supported aggregate functions
+
+[translation_table,id=aggregates]
+|===
+|SQL | Cypher equivalent
+
+| `SELECT name, count(*) FROM People p GROUP BY name`
+| `MATCH (p:People) RETURN p.name AS name, count(*)`
+
+| `SELECT name, max(age) FROM People p GROUP BY name`
+| `MATCH (p:People) RETURN p.name AS name, max(p.age)`
+
+| `SELECT name, min(age) FROM People p GROUP BY name`
+| `MATCH (p:People) RETURN p.name AS name, min(p.age)`
+
+| `SELECT sum(age) FROM People p GROUP BY name`
+| `MATCH (p:People) WITH sum(p.age) AS \`sum(age)\`, p.name AS __group_col_0 RETURN \`sum(age)\``
+
+| `SELECT avg(age) FROM People p GROUP BY name`
+| `MATCH (p:People) WITH avg(p.age) AS \`avg(age)\`, p.name AS __group_col_0 RETURN \`avg(age)\``
+
+| `SELECT percentileCont(age) FROM People p GROUP BY name`
+| `MATCH (p:People) WITH percentileCont(p.age) AS \`percentileCont(age)\`, p.name AS __group_col_0 RETURN \`percentileCont(age)\``
+
+| `SELECT percentileDisc(age) FROM People p GROUP BY name`
+| `MATCH (p:People) WITH percentileDisc(p.age) AS \`percentileDisc(age)\`, p.name AS __group_col_0 RETURN \`percentileDisc(age)\``
+
+| `SELECT stDev(age) FROM People p GROUP BY name`
+| `MATCH (p:People) WITH stDev(p.age) AS \`stddev_samp(age)\`, p.name AS __group_col_0 RETURN \`stddev_samp(age)\``
+
+| `SELECT stDevP(age) FROM People p GROUP BY name`
+| `MATCH (p:People) WITH stDevP(p.age) AS \`stddev_pop(age)\`, p.name AS __group_col_0 RETURN \`stddev_pop(age)\``
+
+| `SELECT stDev(age) AS x FROM People p GROUP BY name`
+| `MATCH (p:People) WITH stDev(p.age) AS x, p.name AS __group_col_0 RETURN x`
+
+| `SELECT stDevP(age) AS x FROM People p GROUP BY name`
+| `MATCH (p:People) WITH stDevP(p.age) AS x, p.name AS __group_col_0 RETURN x`
+|===
+
+== Limit and offset are supported with aggregations
+
+[translation_table,id=limitAndOffsetWithWithClause]
+|===
+|SQL | Cypher equivalent
+
+| `SELECT sum(age) FROM People p GROUP BY name LIMIT 5`
+| `MATCH (p:People) WITH sum(p.age) AS \`sum(age)\`, p.name AS __group_col_0 RETURN \`sum(age)\` LIMIT 5`
+
+| `SELECT name FROM People p GROUP BY name HAVING count(*) > 5 LIMIT 10`
+| `MATCH (p:People) WITH p.name AS name, count(*) AS __having_col_0 WHERE __having_col_0 > 5 RETURN name LIMIT 10`
+
+| `SELECT name FROM People p GROUP BY name HAVING count(*) > 5 ORDER BY name LIMIT 10 OFFSET 2`
+| `MATCH (p:People) WITH p.name AS name, count(*) AS __having_col_0 WHERE __having_col_0 > 5 RETURN name ORDER BY name SKIP 2 LIMIT 10`
+|===
+
+== `DISTINCT` in the context of `GROUP BY`and `HAVING`
+
+`DISTINCT` applies to the final RETURN, not the `WITH`, across all `GROUP BY` / `HAVING` paths.
+
+[translation_table,id=distinctWithGroupByAndHaving]
+|===
+|SQL | Cypher equivalent
+
+| `SELECT DISTINCT name, count(*) FROM People p GROUP BY name`
+| `MATCH (p:People) RETURN DISTINCT p.name AS name, count(*)`
+
+| `SELECT DISTINCT count(*) FROM People p GROUP BY name`
+| `MATCH (p:People) WITH count(*) AS \`count(*)\`, p.name AS __group_col_0 RETURN DISTINCT \`count(*)\``
+
+| `SELECT DISTINCT name FROM People p GROUP BY name HAVING count(*) > 5`
+| `MATCH (p:People) WITH p.name AS name, count(*) AS __having_col_0 WHERE __having_col_0 > 5 RETURN DISTINCT name`
+|===
+
+== All supported clauses combined
+
+[translation_table,id=groupingCombinations]
+|===
+|SQL | Cypher equivalent
+
+| `SELECT DISTINCT name, sum(age) FROM People p GROUP BY name, department HAVING sum(age) > 100 ORDER BY name LIMIT 5`
+| `MATCH (p:People) WITH p.name AS name, sum(p.age) AS \`sum(age)\`, p.department AS __group_col_0 WHERE \`sum(age)\` > 100 RETURN DISTINCT name, \`sum(age)\` ORDER BY name LIMIT 5`
+
+| `SELECT DISTINCT name FROM People p GROUP BY name HAVING count(*) > 5 ORDER BY name LIMIT 10 OFFSET 5`
+| `MATCH (p:People) WITH p.name AS name, count(*) AS __having_col_0 WHERE __having_col_0 > 5 RETURN DISTINCT name ORDER BY name SKIP 5 LIMIT 10`
+
+| `SELECT DISTINCT department, count(*) AS cnt, max(age) AS max_age FROM People p WHERE age > 18 GROUP BY department HAVING count(*) > 1 AND max(age) > 25 ORDER BY cnt DESC LIMIT 10 OFFSET 2`
+| `MATCH (p:People) WHERE p.age > 18 WITH p.department AS department, count(*) AS cnt, max(p.age) AS max_age WHERE (cnt > 1 AND max_age > 25) RETURN DISTINCT department, cnt, max_age ORDER BY cnt DESC SKIP 2 LIMIT 10`
+
+| `SELECT department, count(*) AS cnt FROM People p WHERE age > 18 GROUP BY department`
+| `MATCH (p:People) WHERE p.age > 18 RETURN p.department AS department, count(*) AS cnt`
+
+| `SELECT count(*) AS cnt FROM People p WHERE age > 18 GROUP BY department`
+| `MATCH (p:People) WHERE p.age > 18 WITH count(*) AS cnt, p.department AS __group_col_0 RETURN cnt`
+
+| `SELECT count(*) AS cnt FROM People p ORDER BY cnt`
+| `MATCH (p:People) RETURN count(*) AS cnt ORDER BY cnt`
+|===

--- a/neo4j-jdbc-translator/impl/src/test/resources/grouping.adoc
+++ b/neo4j-jdbc-translator/impl/src/test/resources/grouping.adoc
@@ -1,7 +1,7 @@
 [#grouping]
 = Using aggregates and `GROUP BY`
 
-Cypher does by default implicit grouping. Cypher 5 does and will not have explicit grouping and as of March 2026, explicit grouping in Cypher 25 is in the making.
+Cypher uses implicit grouping by default. Cypher 5 does not have explicit grouping and will not gain it; as of March 2026, explicit grouping is being developed for Cypher 25.
 
 For the common case (`GROUP BY` columns matching the projected columns), the translator continues to emit simple `MATCH ... RETURN` statements because Cypher's implicit grouping produces the correct result. When the `GROUP BY` contains columns absent from the projection, or when a `HAVING` clause is present, the translator introduces a Cypher `WITH` clause to make grouping explicit and to support post-aggregation filtering.
 

--- a/neo4j-jdbc-translator/impl/src/test/resources/grouping.adoc
+++ b/neo4j-jdbc-translator/impl/src/test/resources/grouping.adoc
@@ -25,6 +25,9 @@ The following functionality is supported:
 | `SELECT name, sum(age) FROM People p GROUP BY name, department`
 | `MATCH (p:People) WITH p.name AS name, sum(p.age) AS \`sum(age)\`, p.department AS __group_col_0 RETURN name, \`sum(age)\``
 
+| `SELECT name AS x, sum(age) AS y FROM People p GROUP BY x, department`
+| `MATCH (p:People) WITH p.name AS x, sum(p.age) AS y, p.department AS __group_col_0 RETURN x, y`
+
 | `SELECT count(*) FROM Customers c JOIN Orders o ON c.id = o.customer_id GROUP BY c.name`
 | `MATCH (c:Customers)<-[customer_id:CUSTOMER_ID]-(o:Orders) WITH count(*) AS \`count(*)\`, c.name AS __group_col_0 RETURN \`count(*)\``
 

--- a/neo4j-jdbc-translator/impl/src/test/resources/simple.adoc
+++ b/neo4j-jdbc-translator/impl/src/test/resources/simple.adoc
@@ -383,7 +383,23 @@ MATCH (p:Product)
 RETURN p.productName, p.unitPrice ORDER BY p.unitPrice DESC LIMIT 10
 ----
 
-'''
+In the same fashion, we do support `OFFSET` queries:
+
+[translation_table,id=offset_queries]
+|===
+|SQL | Cypher equivalent
+
+|`SELECT name, age FROM People p ORDER BY name LIMIT 5 OFFSET 10`
+|`MATCH (p:People) RETURN p.name AS name, p.age AS age ORDER BY p.name SKIP 10 LIMIT 5`
+
+|`SELECT name FROM People p ORDER BY name LIMIT 3 OFFSET 0`
+|`MATCH (p:People) RETURN p.name AS name ORDER BY p.name SKIP 0 LIMIT 3`
+
+|`SELECT department, count(*) AS cnt FROM People p GROUP BY department ORDER BY department LIMIT 2 OFFSET 1`
+|`MATCH (p:People) RETURN p.department AS department, count(*) AS cnt ORDER BY p.department SKIP 1 LIMIT 2`
+
+|===
+
 
 The default order direction will be translated as is:
 

--- a/neo4j-jdbc-translator/pom.xml
+++ b/neo4j-jdbc-translator/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-translator</artifactId>
 

--- a/neo4j-jdbc-translator/sparkcleaner/pom.xml
+++ b/neo4j-jdbc-translator/sparkcleaner/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-sparkcleaner</artifactId>

--- a/neo4j-jdbc-translator/spi/pom.xml
+++ b/neo4j-jdbc-translator/spi/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-spi</artifactId>

--- a/neo4j-jdbc-translator/text2cypher/pom.xml
+++ b/neo4j-jdbc-translator/text2cypher/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-text2cypher-translator</artifactId>

--- a/neo4j-jdbc/pom.xml
+++ b/neo4j-jdbc/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.11.1-SNAPSHOT</version>
+		<version>6.12.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc</artifactId>

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ConnectionImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ConnectionImpl.java
@@ -64,7 +64,6 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 
 import org.neo4j.bolt.connection.AccessMode;
 import org.neo4j.bolt.connection.BasicResponseHandler;
@@ -103,8 +102,7 @@ final class ConnectionImpl implements Neo4jConnection {
 	// Adding the comment /*+ NEO4J FORCE_CYPHER */ to your Cypher statement will make the
 	// JDBC driver opt-out from translating it to Cypher, even if the driver has been
 	// configured for automatic translation.
-	private static final Pattern PATTERN_ENFORCE_CYPHER = Pattern
-		.compile("(['`\"])?[^'`\"]*/\\*\\+ NEO4J FORCE_CYPHER \\*/[^'`\"]*(['`\"])?");
+	private static final String FORCE_CYPHER_HINT = "/*+ NEO4J FORCE_CYPHER */";
 
 	static final Logger LOGGER = Logger.getLogger("org.neo4j.jdbc.connection");
 
@@ -1072,12 +1070,25 @@ final class ConnectionImpl implements Neo4jConnection {
 	}
 
 	static boolean forceCypher(String sql) {
-		var matcher = PATTERN_ENFORCE_CYPHER.matcher(sql);
-		while (matcher.find()) {
-			if (matcher.group(1) != null && matcher.group(1).equals(matcher.group(2))) {
-				continue;
+		int idx = sql.indexOf(FORCE_CYPHER_HINT);
+		while (idx >= 0) {
+			if (!isInsideQuotedLiteral(sql, idx, idx + FORCE_CYPHER_HINT.length())) {
+				return true;
 			}
-			return true;
+			idx = sql.indexOf(FORCE_CYPHER_HINT, idx + FORCE_CYPHER_HINT.length());
+		}
+		return false;
+	}
+
+	private static boolean isInsideQuotedLiteral(String sql, int matchStart, int matchEnd) {
+		for (char q : new char[] { '\'', '`', '"' }) {
+			int before = sql.lastIndexOf(q, matchStart - 1);
+			if (before >= 0) {
+				int after = sql.indexOf(q, matchEnd);
+				if (after >= 0) {
+					return true;
+				}
+			}
 		}
 		return false;
 	}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
@@ -2014,6 +2014,13 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 		public int hashCode() {
 			return Objects.hash(this.catalog, this.schemaPattern, this.tableNamePattern, Arrays.hashCode(this.types));
 		}
+
+		@Override
+		public String toString() {
+			return "GetTablesCacheKey{" + "catalog='" + this.catalog + '\'' + ", schemaPattern='" + this.schemaPattern
+					+ '\'' + ", tableNamePattern='" + this.tableNamePattern + '\'' + ", types="
+					+ Arrays.toString(this.types) + '}';
+		}
 	}
 
 	private record GetTablesCacheValue(RunResponse runResponse, PullResponse pullResponse) {

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jConversions.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jConversions.java
@@ -160,11 +160,8 @@ final class Neo4jConversions {
 	}
 
 	private static ZoneOffset getZoneOffsetFrom(Calendar cal) {
-		return Objects.requireNonNullElseGet(cal, Calendar::getInstance)
-			.getTimeZone()
-			.toZoneId()
-			.getRules()
-			.getOffset(cal.toInstant());
+		var nullSafeCal = Objects.requireNonNullElseGet(cal, Calendar::getInstance);
+		return nullSafeCal.getTimeZone().toZoneId().getRules().getOffset(nullSafeCal.toInstant());
 	}
 
 	static Value asValue(Time time, Calendar calendar) {

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.neo4j</groupId>
 	<artifactId>neo4j-jdbc-parent</artifactId>
-	<version>6.11.1-SNAPSHOT</version>
+	<version>6.12.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>Neo4j JDBC Driver</name>


### PR DESCRIPTION
This change adds support for explicit grouping keys used with aggregate function. Until now any grouping key was just dropped. While cypher is happy with implicit group bys, the result is different. This change now will generate intermediate `WITH` clauses being used with the grouping keys, basically the poor-mans solution of group by, and then return only the originally projected columns and values.

This change also allows simulating the `HAVING` clause, which is used to filter on aggregates in SQL, by adding predicates to the introduced `WITH` clause.

The implementation tracks all aggregates in a registry mapping aggregates by aliases, so that a projection can be reconstructed. The `WITH` clause will only be generated if the SQL `GROUP BY` contains a field that is not projected. If the field is already projected, Cyphers implicit grouping will do.

Unrelated to the changes described above, the TCK test generator has been extracted from the actual test classes and enhanced in a way that it can also read tables containing SQL and Cypher comparisions.

The implementation was in huge parts contributed by Ryan Knight; vetted, tested and integrated by Michael Simons.