### PR TITLE
fix: Make sure to set the time of the calendar that used for determining zones to the time of the value passed.

### DIFF
--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/PreparedStatementIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/PreparedStatementIT.java
@@ -308,9 +308,9 @@ class PreparedStatementIT extends IntegrationTestBase {
 						LocalTime.of(0, 0).atOffset(ZoneId.systemDefault().getRules().getOffset(Instant.now()))),
 				Arguments.of(
 						java.util.Date
-							.from(LocalDateTime.of(2001, 2, 3, 21, 46).atZone(ZoneId.systemDefault()).toInstant()),
+							.from(LocalDateTime.of(2001, 2, 3, 21, 48).atZone(ZoneId.systemDefault()).toInstant()),
 						OptionalInt.of(Types.TIME_WITH_TIMEZONE), null,
-						LocalDateTime.of(2001, 2, 3, 21, 46)
+						LocalDateTime.of(2001, 2, 3, 21, 48)
 							.atZone(ZoneId.systemDefault())
 							.toOffsetDateTime()
 							.toOffsetTime()),

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/PreparedStatementImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/PreparedStatementImpl.java
@@ -671,12 +671,20 @@ sealed class PreparedStatementImpl extends StatementImpl implements Neo4jPrepare
 				GQLError.$22N37.withTemplatedMessage(value.getClass().getName(), Time.class.getName()));
 	}
 
-	@SuppressWarnings("squid:S2143") // We need the darn calendar
+	@SuppressWarnings({ "squid:S2143", "MagicConstant" })
+	// We need the darn calendar
 	Calendar makeCalendar(Object value) {
 		if (value instanceof ZonedDateTime zonedDateTime) {
-			return Calendar.getInstance(TimeZone.getTimeZone(zonedDateTime.getZone()));
+			var instance = Calendar.getInstance(TimeZone.getTimeZone(zonedDateTime.getZone()));
+			instance.set(zonedDateTime.getYear(), zonedDateTime.getMonthValue() - 1, zonedDateTime.getDayOfMonth(),
+					zonedDateTime.getHour(), zonedDateTime.getMinute(), zonedDateTime.getSecond());
+			return instance;
 		}
-		return Calendar.getInstance(TimeZone.getTimeZone(ZoneId.systemDefault()));
+		var cal = Calendar.getInstance(TimeZone.getTimeZone(ZoneId.systemDefault()));
+		if (value instanceof java.util.Date date) {
+			cal.setTime(date);
+		}
+		return cal;
 	}
 
 	Timestamp makeTimestamp(Object value) throws Neo4jException {

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ResultSetImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ResultSetImpl.java
@@ -46,6 +46,7 @@ import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.util.Calendar;
 import java.util.EnumSet;
 import java.util.GregorianCalendar;
@@ -1333,6 +1334,9 @@ final class ResultSetImpl implements Neo4jResultSet {
 			}
 			else if (type == OffsetDateTime.class) {
 				result = value.asZonedDateTime().toOffsetDateTime();
+			}
+			else if (type == OffsetTime.class) {
+				result = value.asOffsetTime();
 			}
 			if (result != null) {
 				return type.cast(result);


### PR DESCRIPTION
Tests failed on a non-us system March 2026.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
