### PR TITLE
feat: Add support for Bolt v6.1 and with that, the native ´UUID` type.

### DIFF
--- a/benchkit/pom.xml
+++ b/benchkit/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-benchkit</artifactId>
 

--- a/bundles/neo4j-jdbc-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/bundles/neo4j-jdbc-full-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-full-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/bundles/neo4j-jdbc-text2cypher-bundle/pom.xml
+++ b/bundles/neo4j-jdbc-text2cypher-bundle/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-dist</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-docs</artifactId>

--- a/neo4j-jdbc-authn/kc/pom.xml
+++ b/neo4j-jdbc-authn/kc/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-authn</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-authn-kc</artifactId>

--- a/neo4j-jdbc-authn/pom.xml
+++ b/neo4j-jdbc-authn/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-authn</artifactId>
 

--- a/neo4j-jdbc-authn/spi/pom.xml
+++ b/neo4j-jdbc-authn/spi/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-authn</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-authn-spi</artifactId>

--- a/neo4j-jdbc-bom/pom.xml
+++ b/neo4j-jdbc-bom/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-bom</artifactId>

--- a/neo4j-jdbc-it/hibernate-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-hibernate-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/mybatis-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/mybatis-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-mybatis-smoke-tests</artifactId>
 
@@ -37,6 +37,16 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<!-- :sad-panda: Now we have exactly that scenario about which Spring Boot folks warned: Importing other
+				boms in a bom is causing trouble (Spring Boot imports Neo4j Java Driver bom which in turn imports that bom,
+				and here we are… clashes, because now the JDBC driver is on a higher bolt version than the Java driver in Boot -->
+				<groupId>org.neo4j.bolt</groupId>
+				<artifactId>neo4j-bolt-connection-bom</artifactId>
+				<version>${neo4j-bolt-connection.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 			<dependency>
 				<!-- Import dependency management from Spring Boot -->
 				<groupId>org.springframework.boot</groupId>

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-cp</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/UUIDBolt61IT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/UUIDBolt61IT.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.it.cp;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import com.github.dockerjava.api.exception.NotFoundException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.neo4j.Neo4jContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * For now only runs in case a local neo4j:boltv61 is available (i.e. the nightly tagged
+ * as such)
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIf(value = "neo4jGreaterThanOrEqual202606Available",
+		disabledReason = "Neo4j 2026.06 or higher is not available")
+class UUIDBolt61IT {
+
+	protected final Neo4jContainer neo4j;
+
+	protected static final String IMAGE_NAME = "neo4j:boltv61";
+
+	// Client must not be closed, otherwise the factory will yell at you:
+	// "You should never close the global DockerClient!"
+	@SuppressWarnings("resource")
+	static boolean neo4jGreaterThanOrEqual202606Available() {
+		var dockerClient = DockerClientFactory.lazyClient();
+		try {
+			dockerClient.inspectImageCmd(IMAGE_NAME).exec();
+		}
+		catch (NotFoundException ex) {
+			return false;
+		}
+		return true;
+	}
+
+	UUIDBolt61IT() {
+		this.neo4j = TestUtils.getNeo4jContainer(IMAGE_NAME, false, false)
+			.withNeo4jConfig("internal.dbms.bolt.max_protocol_version", "6.1")
+			.withNeo4jConfig("db.query.default_language", "CYPHER_25");
+		this.neo4j.start();
+	}
+
+	@AfterAll
+	void stopNeo4j() {
+		this.neo4j.stop();
+	}
+
+	private Connection getConnection() throws SQLException {
+		return DriverManager.getConnection(
+				"jdbc:neo4j://%s:%d".formatted(this.neo4j.getHost(), this.neo4j.getMappedPort(7687)), "neo4j",
+				this.neo4j.getAdminPassword());
+	}
+
+	@Test
+	final void shouldTransportNativeUuid() throws SQLException {
+		try (var connection = getConnection(); var stmt = connection.prepareStatement("""
+				CYPHER 25
+				RETURN $1 AS value""")) {
+
+			var sent = UUID.randomUUID();
+			stmt.setObject(1, sent);
+
+			var rs = stmt.executeQuery();
+			assertThat(rs.next()).isTrue();
+
+			var received = rs.getObject(1);
+			assertThat(received).isEqualTo(sent);
+
+			received = rs.getObject(1, UUID.class);
+			assertThat(received).isEqualTo(sent);
+
+			received = UUID.fromString(rs.getString(1));
+			assertThat(received).isEqualTo(sent);
+		}
+
+	}
+
+	@Test
+	final void shouldTranslateStringUuid() throws SQLException {
+		try (var connection = getConnection(); var stmt = connection.prepareStatement("""
+				CYPHER 25
+				RETURN $1 AS value""")) {
+
+			var sent = UUID.randomUUID();
+
+			stmt.setString(1, sent.toString());
+
+			var rs = stmt.executeQuery();
+			assertThat(rs.next()).isTrue();
+
+			var received = UUID.fromString(rs.getString(1));
+			assertThat(received).isEqualTo(sent);
+
+			received = rs.getObject(1, UUID.class);
+			assertThat(received).isEqualTo(sent);
+		}
+
+	}
+
+}

--- a/neo4j-jdbc-it/neo4j-jdbc-it-mp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-mp/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-mp</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-sso/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-sso/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-sso</artifactId>
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-stub/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-stub/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it-stub</artifactId>
 

--- a/neo4j-jdbc-it/pom.xml
+++ b/neo4j-jdbc-it/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-it</artifactId>
 

--- a/neo4j-jdbc-it/quarkus-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/quarkus-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-quarkus-smoke-tests</artifactId>
 

--- a/neo4j-jdbc-it/spring-boot-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/spring-boot-smoke-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-it</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-spring-boot-smoke-tests</artifactId>
 
@@ -37,6 +37,16 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<!-- :sad-panda: Now we have exactly that scenario about which Spring Boot folks warned: Importing other
+				boms in a bom is causing trouble (Spring Boot imports Neo4j Java Driver bom which in turn imports that bom,
+				and here we are… clashes, because now the JDBC driver is on a higher bolt version than the Java driver in Boot -->
+				<groupId>org.neo4j.bolt</groupId>
+				<artifactId>neo4j-bolt-connection-bom</artifactId>
+				<version>${neo4j-bolt-connection.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 			<dependency>
 				<!-- Import dependency management from Spring Boot -->
 				<groupId>org.springframework.boot</groupId>

--- a/neo4j-jdbc-test-results/pom.xml
+++ b/neo4j-jdbc-test-results/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-test-results</artifactId>

--- a/neo4j-jdbc-tracing/micrometer/pom.xml
+++ b/neo4j-jdbc-tracing/micrometer/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-tracing</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-tracing-micrometer</artifactId>

--- a/neo4j-jdbc-tracing/pom.xml
+++ b/neo4j-jdbc-tracing/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-tracing</artifactId>
 

--- a/neo4j-jdbc-translator/impl/pom.xml
+++ b/neo4j-jdbc-translator/impl/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-impl</artifactId>

--- a/neo4j-jdbc-translator/pom.xml
+++ b/neo4j-jdbc-translator/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>neo4j-jdbc-translator</artifactId>
 

--- a/neo4j-jdbc-translator/sparkcleaner/pom.xml
+++ b/neo4j-jdbc-translator/sparkcleaner/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-sparkcleaner</artifactId>

--- a/neo4j-jdbc-translator/spi/pom.xml
+++ b/neo4j-jdbc-translator/spi/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-translator-spi</artifactId>

--- a/neo4j-jdbc-translator/text2cypher/pom.xml
+++ b/neo4j-jdbc-translator/text2cypher/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-translator</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc-text2cypher-translator</artifactId>

--- a/neo4j-jdbc/pom.xml
+++ b/neo4j-jdbc/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.neo4j</groupId>
 		<artifactId>neo4j-jdbc-parent</artifactId>
-		<version>6.13.2-SNAPSHOT</version>
+		<version>6.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-jdbc</artifactId>

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jConversions.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jConversions.java
@@ -112,7 +112,7 @@ final class Neo4jConversions {
 		// The types in our enum are reflective of Driver 4.4 / Early 5, hence
 		// not fully aligned with Neo4j Cypher 5 / 25, comments inline mitigate that
 		return switch (neo4jType) {
-			case ANY, DURATION, UNSUPPORTED -> Types.OTHER;
+			case ANY, DURATION, UNSUPPORTED, UUID -> Types.OTHER;
 			case BOOLEAN -> Types.BOOLEAN;
 			case BYTES -> Types.BLOB;
 			case STRING -> Types.VARCHAR;

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -266,7 +266,7 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 	private static final BoltProtocolVersion MIN_BOLT_VERSION = new BoltProtocolVersion(5, 1);
 
 	private static final Map<String, Object> BOLT_CONNECTION_OPTIONS = Map.of("eventLoopThreadNamePrefix",
-			"Neo4jJDBCDriverIO", "maxVersion", new BoltProtocolVersion(6, 0));
+			"Neo4jJDBCDriverIO", "maxVersion", new BoltProtocolVersion(6, 1));
 
 	/*
 	 * Register one default instance globally.

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ResultSetImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ResultSetImpl.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
@@ -1337,6 +1338,9 @@ final class ResultSetImpl implements Neo4jResultSet {
 			}
 			else if (type == OffsetTime.class) {
 				result = value.asOffsetTime();
+			}
+			else if (type == UUID.class && value.hasType(Type.STRING)) {
+				result = UUID.fromString(value.asString());
 			}
 			if (result != null) {
 				return type.cast(result);

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ResultSetImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ResultSetImpl.java
@@ -1339,8 +1339,17 @@ final class ResultSetImpl implements Neo4jResultSet {
 			else if (type == OffsetTime.class) {
 				result = value.asOffsetTime();
 			}
+			else if (type == UUID.class && value.hasType(Type.UUID)) {
+				result = value.asUUID();
+			}
 			else if (type == UUID.class && value.hasType(Type.STRING)) {
-				result = UUID.fromString(value.asString());
+				try {
+					result = UUID.fromString(value.asString());
+				}
+				catch (IllegalArgumentException ex) {
+					throw new Neo4jException(
+							GQLError.$22N37.withTemplatedMessage(value.toDisplayString(), type.getName()));
+				}
 			}
 			if (result != null) {
 				return type.cast(result);

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ResultSetMetaDataImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ResultSetMetaDataImpl.java
@@ -46,6 +46,7 @@ import org.neo4j.jdbc.values.RelationshipValue;
 import org.neo4j.jdbc.values.StringValue;
 import org.neo4j.jdbc.values.TimeValue;
 import org.neo4j.jdbc.values.Type;
+import org.neo4j.jdbc.values.UUIDValue;
 import org.neo4j.jdbc.values.UnsupportedType;
 import org.neo4j.jdbc.values.Value;
 import org.neo4j.jdbc.values.VectorValue;
@@ -273,6 +274,9 @@ final class ResultSetMetaDataImpl implements ResultSetMetaData {
 			}
 			case UNSUPPORTED -> {
 				return UnsupportedType.class.getName();
+			}
+			case UUID -> {
+				return UUIDValue.class.getName();
 			}
 		}
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/internal/bolt/ValueFactoryImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/internal/bolt/ValueFactoryImpl.java
@@ -52,6 +52,7 @@ import org.neo4j.jdbc.values.PointValue;
 import org.neo4j.jdbc.values.RelationshipValue;
 import org.neo4j.jdbc.values.StringValue;
 import org.neo4j.jdbc.values.TimeValue;
+import org.neo4j.jdbc.values.UUIDValue;
 import org.neo4j.jdbc.values.UnsupportedDateTimeValue;
 import org.neo4j.jdbc.values.UnsupportedType;
 import org.neo4j.jdbc.values.Values;
@@ -86,6 +87,7 @@ enum ValueFactoryImpl implements ValueFactory {
 		hlp.put(ListValue.class, Type.LIST);
 		hlp.put(BytesValue.class, Type.BYTES);
 		hlp.put(VectorValue.class, Type.VECTOR);
+		hlp.put(UUIDValue.class, Type.UUID);
 		TYPE_MAP = Map.copyOf(hlp);
 	}
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/internal/bolt/ValueImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/internal/bolt/ValueImpl.java
@@ -27,6 +27,7 @@ import java.time.ZonedDateTime;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -190,6 +191,11 @@ final class ValueImpl implements Value, AsValue {
 			}
 		});
 		return new BoltVectorImpl(jdbcVector.elementType().getJavaType(), accessor.apply(jdbcVector));
+	}
+
+	@Override
+	public UUID asUUID() {
+		return this.value.asUUID();
 	}
 
 	@Override

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Type.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Type.java
@@ -158,7 +158,12 @@ public enum Type {
 	 * A datatype that might be known in the server, but is unsupported in this client.
 	 * @since 6.9.0
 	 */
-	UNSUPPORTED;
+	UNSUPPORTED,
+	/**
+	 * Neo4j native UUID Type.
+	 * @since 6.14.0
+	 */
+	UUID;
 
 	/**
 	 * Test if the given value has this type.

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/UUIDValue.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/UUIDValue.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.values;
+
+import java.util.UUID;
+
+/**
+ * Value type wrapping a {@link UUID}.
+ *
+ * @author Michael J. Simons
+ * @since 6.14.0
+ */
+public final class UUIDValue extends AbstractObjectValue<UUID> {
+
+	UUIDValue(UUID adapted) {
+		super(adapted);
+	}
+
+	@Override
+	public UUID asUUID() {
+		return asObject();
+	}
+
+	@Override
+	public Type type() {
+		return Type.UUID;
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Value.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Value.java
@@ -45,6 +45,7 @@ import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Function;
 
 /**
@@ -486,6 +487,16 @@ public interface Value extends MapAccessorWithDefaultValue {
 	 * @since 6.8.0
 	 */
 	default Vector asVector() {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Returns the value as a {@link UUID}, if possible.
+	 * @return the value as a {@link UUID}, if possible.
+	 * @throws UncoercibleException if value types are incompatible.
+	 * @since 6.14.0
+	 */
+	default UUID asUUID() {
 		throw new UnsupportedOperationException();
 	}
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Values.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/Values.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -200,6 +201,9 @@ public final class Values {
 		}
 		if (value instanceof Object[]) {
 			return value(Arrays.asList((Object[]) value));
+		}
+		if (value instanceof UUID uuid) {
+			return new UUIDValue(uuid);
 		}
 
 		throw new ValueException("Unable to convert " + value.getClass().getName() + " to Neo4j Value.");

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ResultSetImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ResultSetImplTests.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -1128,6 +1129,12 @@ class ResultSetImplTests {
 					.of(Arguments.of(vectorValue, Named.<VerificationLogic<Object>>of("verify returns Vector",
 							supplier -> assertThat(supplier.get()).isEqualTo(Vector.of(new int[1]))))));
 
+			var uuid = UUID.randomUUID();
+			var uuidStream = Stream.of(Values.values(uuid))
+				.flatMap(vectorValue -> Stream
+					.of(Arguments.of(vectorValue, Named.<VerificationLogic<Object>>of("verify returns UUID",
+							supplier -> assertThat(supplier.get()).isEqualTo(uuid)))));
+
 			return switch (type) {
 				case ANY, NODE, UNSUPPORTED, RELATIONSHIP, PATH, NUMBER -> Stream.of();
 				case BOOLEAN -> booleanStream;
@@ -1146,6 +1153,7 @@ class ResultSetImplTests {
 				case LOCAL_DATE_TIME -> localDateTimeStream;
 				case DATE_TIME -> dateTimeStream;
 				case DURATION -> durationStream;
+				case UUID -> uuidStream;
 			};
 		}).flatMap(ResultSetImplTests::mapArgumentToBothIndexAndLabelAccess);
 	}

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ResultSetImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ResultSetImplTests.java
@@ -1130,9 +1130,9 @@ class ResultSetImplTests {
 							supplier -> assertThat(supplier.get()).isEqualTo(Vector.of(new int[1]))))));
 
 			var uuid = UUID.randomUUID();
-			var uuidStream = Stream.of(Values.values(uuid))
-				.flatMap(vectorValue -> Stream
-					.of(Arguments.of(vectorValue, Named.<VerificationLogic<Object>>of("verify returns UUID",
+			var uuidStream = Stream.of(Values.value(uuid))
+				.flatMap(uuidValue -> Stream
+					.of(Arguments.of(uuidValue, Named.<VerificationLogic<Object>>of("verify returns UUID",
 							supplier -> assertThat(supplier.get()).isEqualTo(uuid)))));
 
 			return switch (type) {

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<maven.version>3.9.11</maven.version>
 		<micrometer-tracing.version>1.7.0</micrometer-tracing.version>
-		<micrometer.version>1.16.5</micrometer.version>
+		<micrometer.version>1.17.0</micrometer.version>
 		<mockito.version>5.23.0</mockito.version>
 		<moditect-maven-plugin.version>1.3.0.Final</moditect-maven-plugin.version>
 		<native-image-config-transformer.version>1.0.1</native-image-config-transformer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<groupId>org.neo4j</groupId>
 	<artifactId>neo4j-jdbc-parent</artifactId>
-	<version>6.13.2-SNAPSHOT</version>
+	<version>6.14.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>Neo4j JDBC Driver</name>
@@ -192,7 +192,7 @@
 		<moditect-maven-plugin.version>1.3.0.Final</moditect-maven-plugin.version>
 		<native-image-config-transformer.version>1.0.1</native-image-config-transformer.version>
 		<native-maven-plugin.version>1.1.2</native-maven-plugin.version>
-		<neo4j-bolt-connection.version>11.1.0</neo4j-bolt-connection.version>
+		<neo4j-bolt-connection.version>12.0.0</neo4j-bolt-connection.version>
 		<neo4j-cypher-dsl.version>2025.2.7</neo4j-cypher-dsl.version>
 		<neo4j-jdbc.previous.version>6.13.1</neo4j-jdbc.previous.version>
 		<neo4j.image>neo4j:${neo4j.version}</neo4j.image>


### PR DESCRIPTION
Added new value type and tests, plus changed the Spring Boot based integration test build descriptors to also import the
bolt-connection bom, as Boot and this driver now pulls different versions of bolt-connection api.

The integration test requires a dedicated test image, i.e.

```
docker tag aws-registry/build-service/neo4j:2026-enterprise-debian-nightly-bundle-arm64
neo4j:boltv61
```

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
