### PR TITLE
DOCOPS-176 Add page-tabs attributes to antora.yml

### DIFF
--- a/docs/src/main/asciidoc/antora.yml
+++ b/docs/src/main/asciidoc/antora.yml
@@ -29,6 +29,8 @@ nav:
 
 asciidoc:
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 15
     group-id: ${groupId}
     artifact-id: ${mainArtifactId}
     artifact-id-spi: ${mainArtifactId}-translator-spi


### PR DESCRIPTION
Adds `page-tabs` and `page-tabs-index` to `docs/src/main/asciidoc/antora.yml`:

```yaml
page-tabs: drivers-apis@
page-tabs-index: 15
```

Places this docset in the `drivers-apis` tab of the aggregated tabbed navigation. The
index sits between the Java Driver (14) and the JavaScript Driver (16), matching the
order of the JDBC Driver in the Docs menu on neo4j.com/docs.

Set in `antora.yml` rather than the publish playbook because this docset publishes a
single version. `page-tabs` is soft-set with a trailing `@` so it can be overridden.
