### PR TITLE
chore: July / August roundup of dependency upgrades.

### DIFF
--- a/bundles/neo4j-jdbc-full-bundle/src/test/java/org/neo4j/jdbc/bundle/AutomaticTranslationBundleIT.java
+++ b/bundles/neo4j-jdbc-full-bundle/src/test/java/org/neo4j/jdbc/bundle/AutomaticTranslationBundleIT.java
@@ -24,13 +24,14 @@ import java.sql.SQLException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.neo4j.Neo4jContainer;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class AutomaticTranslationBundleIT {
 
 	@SuppressWarnings("resource") // On purpose to reuse this

--- a/bundles/neo4j-jdbc-full-bundle/src/test/java/org/neo4j/jdbc/bundle/CypherBackedViewsBundleIT.java
+++ b/bundles/neo4j-jdbc-full-bundle/src/test/java/org/neo4j/jdbc/bundle/CypherBackedViewsBundleIT.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.neo4j.Neo4jContainer;
 
@@ -35,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class CypherBackedViewsBundleIT {
 
 	@SuppressWarnings("resource") // On purpose to reuse this

--- a/bundles/neo4j-jdbc-full-bundle/src/test/java/org/neo4j/jdbc/bundle/HttpIT.java
+++ b/bundles/neo4j-jdbc-full-bundle/src/test/java/org/neo4j/jdbc/bundle/HttpIT.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.neo4j.jdbc.Neo4jPreparedStatement;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -36,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisabledIfSystemProperty(named = "disableHttpTests", matches = "true")
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class HttpIT {
 
 	@SuppressWarnings("resource") // On purpose to reuse this

--- a/bundles/neo4j-jdbc-full-bundle/src/test/java/org/neo4j/jdbc/bundle/JacksonBundleIT.java
+++ b/bundles/neo4j-jdbc-full-bundle/src/test/java/org/neo4j/jdbc/bundle/JacksonBundleIT.java
@@ -25,13 +25,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.neo4j.Neo4jContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class JacksonBundleIT {
 
 	@SuppressWarnings("resource") // On purpose to reuse this

--- a/neo4j-jdbc-it/hibernate-smoke-tests/pom.xml
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/pom.xml
@@ -32,7 +32,7 @@
 	<name>Neo4j JDBC Driver (Hibernate Smoke tests)</name>
 
 	<properties>
-		<hibernate-platform.version>7.4.5.Final</hibernate-platform.version>
+		<hibernate-platform.version>7.4.6.Final</hibernate-platform.version>
 	</properties>
 
 	<dependencyManagement>

--- a/neo4j-jdbc-it/hibernate-smoke-tests/src/test/java/org/neo4j/jdbc/it/hibernate/HibernateIT.java
+++ b/neo4j-jdbc-it/hibernate-smoke-tests/src/test/java/org/neo4j/jdbc/it/hibernate/HibernateIT.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.neo4j.jdbc.Neo4jDriver;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.neo4j.Neo4jContainer;
@@ -34,7 +35,7 @@ import org.testcontainers.neo4j.Neo4jContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class HibernateIT {
 
 	@SuppressWarnings("resource") // On purpose to reuse this

--- a/neo4j-jdbc-it/mybatis-smoke-tests/src/main/java/org/neo4j/jdbc/it/mybatis/Movie.java
+++ b/neo4j-jdbc-it/mybatis-smoke-tests/src/main/java/org/neo4j/jdbc/it/mybatis/Movie.java
@@ -21,6 +21,7 @@ package org.neo4j.jdbc.it.mybatis;
 import java.math.BigDecimal;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 
-public record Movie(String title, @JsonFormat(shape = JsonFormat.Shape.STRING) BigDecimal length) {
+public record Movie(String title, @JsonFormat(shape = Shape.STRING) BigDecimal length) {
 }

--- a/neo4j-jdbc-it/mybatis-smoke-tests/src/test/java/org/neo4j/jdbc/it/mybatis/ApplicationIT.java
+++ b/neo4j-jdbc-it/mybatis-smoke-tests/src/test/java/org/neo4j/jdbc/it/mybatis/ApplicationIT.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
@@ -39,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Michael J. Simons
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Import(Neo4jTestConfig.class)
 @AutoConfigureTestRestTemplate
 public class ApplicationIT {

--- a/neo4j-jdbc-it/mybatis-smoke-tests/src/test/java/org/neo4j/jdbc/it/mybatis/MoviesTests.java
+++ b/neo4j-jdbc-it/mybatis-smoke-tests/src/test/java/org/neo4j/jdbc/it/mybatis/MoviesTests.java
@@ -31,15 +31,16 @@ import org.mybatis.spring.boot.test.autoconfigure.AutoConfigureMybatis;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@JdbcTest(includeFilters = @ComponentScan.Filter(Repository.class))
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@JdbcTest(includeFilters = @Filter(Repository.class))
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 @AutoConfigureMybatis
 @Import(Neo4jTestConfig.class)
 class MoviesTests {

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/AbstractVectorIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/AbstractVectorIT.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.neo4j.bolt.connection.exception.BoltFailureException;
 import org.neo4j.bolt.connection.exception.BoltGqlErrorException;
 import org.neo4j.jdbc.Neo4jDatabaseMetaData;
@@ -40,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 abstract class AbstractVectorIT {
 
 	protected final Neo4jContainer neo4j;

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/IntegrationTestBase.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/IntegrationTestBase.java
@@ -31,13 +31,14 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.provider.Arguments;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.neo4j.Neo4jContainer;
 import org.testcontainers.utility.MountableFile;
 
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 abstract class IntegrationTestBase {
 
 	// used by several parameterized test classes

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/Neo4jDataSourceIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/Neo4jDataSourceIT.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.neo4j.jdbc.Neo4jDataSource;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.neo4j.Neo4jContainer;
@@ -31,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class Neo4jDataSourceIT {
 
 	@SuppressWarnings("resource") // On purpose to reuse this

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/Neo4jDriverExtensionsIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/Neo4jDriverExtensionsIT.java
@@ -33,6 +33,7 @@ import com.github.stefanbirkner.systemlambda.SystemLambda;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -47,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 @DisabledInNativeImage
 class Neo4jDriverExtensionsIT {
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/Neo4jDriverIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/Neo4jDriverIT.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.neo4j.jdbc.Neo4jDriver;
 import org.neo4j.jdbc.values.IsoDuration;
 import org.neo4j.jdbc.values.PointValue;
@@ -35,7 +36,7 @@ import org.testcontainers.neo4j.Neo4jContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class Neo4jDriverIT {
 
 	@SuppressWarnings("resource") // On purpose to reuse this

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/UUIDBolt61IT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/UUIDBolt61IT.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.neo4j.Neo4jContainer;
@@ -33,7 +34,7 @@ import org.testcontainers.neo4j.Neo4jContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 @DisabledIfSystemProperty(named = "neo4j-jdbc.default-neo4j-image", matches = "neo4j:5\\.26\\..*")
 class UUIDBolt61IT {
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-stub/src/test/java/org/neo4j/jdbc/it/stub/server/IntegrationTestBase.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-stub/src/test/java/org/neo4j/jdbc/it/stub/server/IntegrationTestBase.java
@@ -28,6 +28,7 @@ import com.github.dockerjava.api.exception.NotModifiedException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.OutputFrame;
@@ -36,7 +37,7 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 @ExtendWith({ StubScriptConfigParameterResolver.class, StubServerExecutionExceptionHandler.class })
 public abstract class IntegrationTestBase {
 

--- a/neo4j-jdbc-it/spring-boot-smoke-tests/src/test/java/org/neo4j/jdbc/it/sb/AbstractTracing.java
+++ b/neo4j-jdbc-it/spring-boot-smoke-tests/src/test/java/org/neo4j/jdbc/it/sb/AbstractTracing.java
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
@@ -44,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Michael J. Simons
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Testcontainers(disabledWithoutDocker = true)
 @AutoConfigureTestRestTemplate
 abstract class AbstractTracing {

--- a/neo4j-jdbc-it/spring-boot-smoke-tests/src/test/java/org/neo4j/jdbc/it/sb/ApplicationIT.java
+++ b/neo4j-jdbc-it/spring-boot-smoke-tests/src/test/java/org/neo4j/jdbc/it/sb/ApplicationIT.java
@@ -31,6 +31,7 @@ import org.springframework.boot.micrometer.metrics.actuate.endpoint.MetricsEndpo
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -44,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Michael J. Simons
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Import(Neo4jTestConfig.class)
 @AutoConfigureTestRestTemplate
 @TestPropertySource(properties = { "management.endpoints.jackson.isolated-json-mapper=false" })

--- a/neo4j-jdbc-it/spring-boot-smoke-tests/src/test/java/org/neo4j/jdbc/it/sb/MoviesTests.java
+++ b/neo4j-jdbc-it/spring-boot-smoke-tests/src/test/java/org/neo4j/jdbc/it/sb/MoviesTests.java
@@ -28,15 +28,16 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@JdbcTest(includeFilters = @ComponentScan.Filter(Repository.class))
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@JdbcTest(includeFilters = @Filter(Repository.class))
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 @Import(Neo4jTestConfig.class)
 class MoviesTests {
 

--- a/neo4j-jdbc-it/spring-boot-smoke-tests/src/test/java/org/neo4j/jdbc/it/sb/PeopleTests.java
+++ b/neo4j-jdbc-it/spring-boot-smoke-tests/src/test/java/org/neo4j/jdbc/it/sb/PeopleTests.java
@@ -28,8 +28,9 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.SQLWarningException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -38,8 +39,8 @@ import org.springframework.stereotype.Repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-@JdbcTest(includeFilters = @ComponentScan.Filter(Repository.class))
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@JdbcTest(includeFilters = @Filter(Repository.class))
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 @Import(Neo4jTestConfig.class)
 class PeopleTests {
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jResultSet.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jResultSet.java
@@ -36,7 +36,6 @@ public sealed interface Neo4jResultSet extends ResultSet permits ResultSetImpl {
 	 * Adds a listener to this statement that gets notified on starts and finish of
 	 * iteration and whenever a new batch is pulled from the database.
 	 * @param resultSetListener the lister to add to this result set
-	 * @since 6.3.0
 	 */
 	void addListener(ResultSetListener resultSetListener);
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/MapAccessor.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/values/MapAccessor.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Access the keys, properties and values of an underlying unordered map by key
+ * Access the keys, properties and values of an underlying unordered map by key.
  * <p>
  * This provides only read methods. Subclasses may choose to provide additional methods
  * for changing the underlying map.

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/JacksonJSONMapperImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/JacksonJSONMapperImplTests.java
@@ -47,6 +47,7 @@ import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -58,7 +59,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.BDDMockito.given;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class JacksonJSONMapperImplTests {
 
 	private final JacksonJSONMapperImpl mapper = new JacksonJSONMapperImpl();

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/PackageStructureTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/PackageStructureTests.java
@@ -26,6 +26,7 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.neo4j.jdbc.internal.bolt.BoltAdapters;
@@ -41,7 +42,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.theClass;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class PackageStructureTests {
 
 	private final DescribedPredicate<JavaClass> jdbcModuleClasses = resideInAPackage("..jdbc");

--- a/pom.xml
+++ b/pom.xml
@@ -131,20 +131,20 @@
 
 	<properties>
 		<aggregate.report.dir>neo4j-jdbc-test-results/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
-		<archunit.version>1.4.2</archunit.version>
+		<archunit.version>1.5.0</archunit.version>
 		<asciidoctor-maven-plugin.version>3.2.0</asciidoctor-maven-plugin.version>
 		<asciidoctorj.pdf.version>2.3.23</asciidoctorj.pdf.version>
 		<asciidoctorj.version>3.0.1</asciidoctorj.version>
 		<assertj.version>3.27.7</assertj.version>
 		<awaitility.version>4.3.0</awaitility.version>
 		<build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
-		<checkstyle.version>13.8.0</checkstyle.version>
+		<checkstyle.version>14.0.0</checkstyle.version>
 		<commons-lang3.version>3.20.0</commons-lang3.version>
 		<covered-ratio-complexity>0.05</covered-ratio-complexity>
 		<covered-ratio-instructions>0.05</covered-ratio-instructions>
-		<cyclonedx-maven-plugin.version>2.9.2</cyclonedx-maven-plugin.version>
-		<cypher-v5-antlr-parser.version>5.26.28</cypher-v5-antlr-parser.version>
-		<docker-maven-plugin.version>0.48.1</docker-maven-plugin.version>
+		<cyclonedx-maven-plugin.version>2.9.3</cyclonedx-maven-plugin.version>
+		<cypher-v5-antlr-parser.version>5.26.29</cypher-v5-antlr-parser.version>
+		<docker-maven-plugin.version>0.49.0</docker-maven-plugin.version>
 		<dotenv-java.version>3.2.0</dotenv-java.version>
 		<duckdb_jdbc.version>1.5.5.0</duckdb_jdbc.version>
 		<duplicate-finder-maven-plugin.version>2.0.1</duplicate-finder-maven-plugin.version>
@@ -152,7 +152,7 @@
 		<flatten-maven-plugin.version>1.8.0</flatten-maven-plugin.version>
 		<git-commit-id-maven-plugin.version>10.0.0</git-commit-id-maven-plugin.version>
 		<jackson-databind-nullable.version>0.2.10</jackson-databind-nullable.version>
-		<jackson.version>2.22.1</jackson.version>
+		<jackson.version>2.22.2</jackson.version>
 		<jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
 		<jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
 		<japicmp-maven-plugin.version>0.26.1</japicmp-maven-plugin.version>
@@ -161,13 +161,14 @@
 		<jaxb-api.version>4.0.5</jaxb-api.version>
 		<jboss-logging.version>3.6.3.Final</jboss-logging.version>
 		<jdbi3.version>3.54.0</jdbi3.version>
-		<jooq.version>3.19.36</jooq.version>
+		<jooq.version>3.19.37</jooq.version>
 		<jreleaser-maven-plugin.version>1.25.0</jreleaser-maven-plugin.version>
+		<jspecify.version>1.0.1</jspecify.version>
 		<junit-jupiter.version>6.1.3</junit-jupiter.version>
-		<keycloak-authz-client.version>26.0.11</keycloak-authz-client.version>
+		<keycloak-authz-client.version>26.0.12</keycloak-authz-client.version>
 		<kotlin-stdlib-jdk8.version>2.4.10</kotlin-stdlib-jdk8.version>
 		<langchain4j.version>1.18.0</langchain4j.version>
-		<license-maven-plugin.version>5.0.0</license-maven-plugin.version>
+		<license-maven-plugin.version>5.1.2</license-maven-plugin.version>
 		<mainArtifactId>neo4j-jdbc</mainArtifactId>
 		<maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
 		<maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
@@ -186,18 +187,18 @@
 		<maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<maven.version>3.9.16</maven.version>
-		<micrometer-tracing.version>1.7.0</micrometer-tracing.version>
-		<micrometer.version>1.17.0</micrometer.version>
+		<micrometer-tracing.version>1.7.1</micrometer-tracing.version>
+		<micrometer.version>1.17.1</micrometer.version>
 		<mockito.version>5.23.0</mockito.version>
 		<moditect-maven-plugin.version>1.3.0.Final</moditect-maven-plugin.version>
 		<native-image-config-transformer.version>1.0.2</native-image-config-transformer.version>
-		<native-maven-plugin.version>1.1.4</native-maven-plugin.version>
+		<native-maven-plugin.version>1.1.5</native-maven-plugin.version>
 		<neo4j-bolt-connection.version>12.0.0</neo4j-bolt-connection.version>
 		<neo4j-cypher-dsl.version>2025.3.0</neo4j-cypher-dsl.version>
 		<neo4j-jdbc.previous.version>6.14.0</neo4j-jdbc.previous.version>
 		<neo4j.image>neo4j:${neo4j.version}</neo4j.image>
-		<neo4j.version>2026.06.0</neo4j.version>
-		<netty.version>4.1.136.Final</netty.version>
+		<neo4j.version>2026.07.1</neo4j.version>
+		<netty.version>4.1.137.Final</netty.version>
 		<openapi-generator-maven-plugin.version>7.23.0</openapi-generator-maven-plugin.version>
 		<opencsv.version>5.12.0</opencsv.version>
 		<openpojo.version>0.9.1</openpojo.version>
@@ -210,8 +211,8 @@
 		<slf4j.version>2.0.18</slf4j.version>
 		<sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
 		<sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
-		<spring-boot.version>4.1.0</spring-boot.version>
-		<spring-javaformat.version>0.0.47</spring-javaformat.version>
+		<spring-boot.version>4.1.1</spring-boot.version>
+		<spring-javaformat.version>0.0.48</spring-javaformat.version>
 		<system-lambda.version>1.2.1</system-lambda.version>
 		<testcontainers-keycloak.version>4.3.1</testcontainers-keycloak.version>
 		<testcontainers.version>2.0.5</testcontainers.version>
@@ -356,6 +357,11 @@
 				<groupId>org.jooq</groupId>
 				<artifactId>jooq</artifactId>
 				<version>${jooq.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jspecify</groupId>
+				<artifactId>jspecify</artifactId>
+				<version>${jspecify.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.keycloak</groupId>
@@ -960,6 +966,16 @@
 										<ignoreVersion>
 											<!-- See https://github.com/apache/maven-javadoc-plugin/commit/71a6ca45da32a04483de6baca01f39ca27bec1ed -->
 											<version>3.11.3</version>
+										</ignoreVersion>
+									</ignoreVersions>
+								</rule>
+								<rule>
+									<groupId>org.graalvm.buildtools</groupId>
+									<artifactId>native-maven-plugin</artifactId>
+									<ignoreVersions>
+										<ignoreVersion>
+											<type>range</type>
+											<version>[1.1.6,)</version>
 										</ignoreVersion>
 									</ignoreVersions>
 								</rule>


### PR DESCRIPTION
Changes to source files are due to new rules in Spring Java Format.
Also excluded Native Image Maven plugin from updates, 1.1.5 is the last version that works.
