### PR TITLE
refactor: Harden fallback loading of SQL Translator factories.

### DIFF
--- a/docs/src/main/asciidoc/modules/ROOT/pages/sql2cypher.adoc
+++ b/docs/src/main/asciidoc/modules/ROOT/pages/sql2cypher.adoc
@@ -22,9 +22,16 @@ We believe our assumptions are appropriate for various use cases and instead of 
 The driver will use the standard Java service loader mechanism to find an implementation of the SPI on the module- or classpath.
 
 NOTE: Some tools (like Tableau) use a class-loader that won't let the driver use the standard Java service loader mechanism.
-For these scenarios, we provide an additional configuration property named `translatorFactory`.
-Set this to `DEFAULT` to directly load our default implementation or to a fully-qualified classname for any other factory.
-*Be aware* that either our default implementation or your custom one must be on the classpath.
+ For these scenarios, we provide an additional configuration property named `translatorFactory`.
+ Set this to `DEFAULT` to directly load our default implementation or to a fully-qualified classname for any other factory. +
+ +
+ For security reason, we block all factories that we don't officially ship being loaded through that mechanism.
+ To use a custom translator factory, you must configure the allow list through either a Java system property or an environment variable named `NEO4J_JDBC_ALLOWED_TRANSLATOR_FACTORIES`.
+ You can either use the value `+++*+++` to allow all classes implementing `org.neo4j.jdbc.translator.spi.TranslatorFactory` or use a list of fully qualified classnames, separated by a `,`.
+ If you are building an application that might allow a user to dynamically configure instances of this JDBC driver, be mindful of what you allow here. +
+ +
+ Lastly, any of these options require the configured factory to be on the class path.
+ Our default implementations only ship with the bundled distributions of this driver (the "fat-jar", dependency free distributions).
 
 == Translating SQL to Cypher
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/pom.xml
@@ -124,6 +124,7 @@
 						<configuration combine.self="append">
 							<excludes>
 								<exclude>**/Neo4jDriverExtensionsIT.java</exclude>
+								<exclude>**/TranslatorFactoryConfigIT.java</exclude>
 								<exclude>**/UserAgentIT.java</exclude>
 							</excludes>
 						</configuration>
@@ -137,6 +138,7 @@
 						<configuration>
 							<includes>
 								<include>**/Neo4jDriverExtensionsIT.java</include>
+								<include>**/TranslatorFactoryConfigIT.java</include>
 								<include>**/UserAgentIT.java</include>
 							</includes>
 							<!-- Needed to modify system environment variables in this particular test, don't want to have it everywhere. -->

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/CapturingHandler.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/CapturingHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.it.cp;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+class CapturingHandler extends Handler {
+
+	List<String> messages = new ArrayList<>();
+
+	@Override
+	public void publish(LogRecord record) {
+		this.messages.add(record.getMessage());
+	}
+
+	@Override
+	public void flush() {
+
+	}
+
+	@Override
+	public void close() throws SecurityException {
+
+	}
+
+}

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/ConnectionIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/ConnectionIT.java
@@ -20,12 +20,8 @@ package org.neo4j.jdbc.it.cp;
 
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executors;
-import java.util.logging.Handler;
-import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import org.junit.jupiter.api.Test;
@@ -314,27 +310,6 @@ class ConnectionIT extends IntegrationTestBase {
 		var neo4j = "neo4j".equals(this.protocol);
 		return "jdbc:neo4j%s://%s:%d/neo4j".formatted(neo4j ? "" : ":" + this.protocol, this.neo4j.getHost(),
 				this.neo4j.getMappedPort(neo4j ? 7687 : 7474));
-	}
-
-	static class CapturingHandler extends Handler {
-
-		List<String> messages = new ArrayList<>();
-
-		@Override
-		public void publish(LogRecord record) {
-			this.messages.add(record.getMessage());
-		}
-
-		@Override
-		public void flush() {
-
-		}
-
-		@Override
-		public void close() throws SecurityException {
-
-		}
-
 	}
 
 }

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/FunkyFactory.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/FunkyFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.it.cp;
+
+import java.util.Map;
+
+import org.neo4j.jdbc.translator.spi.Translator;
+import org.neo4j.jdbc.translator.spi.TranslatorFactory;
+
+public class FunkyFactory implements TranslatorFactory {
+
+	static {
+		System.err.println("This could have been a Runtime.getRuntime().exec() call.");
+	}
+
+	@Override
+	public Translator create(Map<String, ?> properties) {
+		return (statement, optionalDatabaseMetaData) -> statement;
+	}
+
+}

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/FunkyFactory2.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/FunkyFactory2.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.it.cp;
+
+import java.util.Map;
+
+import org.neo4j.jdbc.translator.spi.Translator;
+import org.neo4j.jdbc.translator.spi.TranslatorFactory;
+
+public class FunkyFactory2 implements TranslatorFactory {
+
+	@Override
+	public Translator create(Map<String, ?> properties) {
+		return (statement, optionalDatabaseMetaData) -> "I was there";
+	}
+
+}

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/FunkyFactory3.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/FunkyFactory3.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.it.cp;
+
+import java.util.Map;
+
+import org.neo4j.jdbc.translator.spi.Translator;
+import org.neo4j.jdbc.translator.spi.TranslatorFactory;
+
+public class FunkyFactory3 implements TranslatorFactory {
+
+	static {
+		// We need to of them, as we exercise the test twice in the same VM, and the
+		// static
+		// block will only rune once. This is a copy of FunkyFactory
+		System.err.println("This could have been a Runtime.getRuntime().exec() call.");
+	}
+
+	@Override
+	public Translator create(Map<String, ?> properties) {
+		return (statement, optionalDatabaseMetaData) -> statement;
+	}
+
+}

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/FunkyRandomClass.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/FunkyRandomClass.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.it.cp;
+
+public class FunkyRandomClass {
+
+	static {
+		System.err.println("This could have been a Runtime.getRuntime().exec() call.");
+	}
+
+}

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/TranslatorFactoryConfigIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/TranslatorFactoryConfigIT.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.it.cp;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import com.github.stefanbirkner.systemlambda.Statement;
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.neo4j.jdbc.Neo4jDriver;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.neo4j.Neo4jContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers(disabledWithoutDocker = true)
+@TestInstance(Lifecycle.PER_CLASS)
+@DisabledInNativeImage
+class TranslatorFactoryConfigIT {
+
+	@SuppressWarnings("resource") // On purpose to reuse this
+	protected final Neo4jContainer neo4j = TestUtils.getNeo4jContainer();
+
+	@BeforeAll
+	void startNeo4j() {
+		this.neo4j.start();
+	}
+
+	@ParameterizedTest
+	@CsvSource(
+			textBlock = """
+						org.neo4j.jdbc.it.cp.FunkyRandomClass                         | false | n/a                                           | false | false
+						org.neo4j.jdbc.it.cp.FunkyFactory                             | false | n/a                                           | false | false
+						org.neo4j.jdbc.it.cp.FunkyRandomClass                         | false | *                                             | false | false
+						org.neo4j.jdbc.it.cp.FunkyFactory                             | false | *                                             | true  | true
+						org.neo4j.jdbc.it.cp.FunkyFactory2                            | false | n/a                                           | false | false
+						org.neo4j.jdbc.it.cp.FunkyFactory2                            | false | *                                             | true  | false
+						org.neo4j.jdbc.it.cp.FunkyFactory2                            | false | ,org.neo4j.jdbc.it.cp.FunkyFactory2, whatever | true  | false
+						org.neo4j.jdbc.it.cp.FunkyFactory2                            | false | elefant,*,a possum                            | true  | false
+						org.neo4j.jdbc.translator.impl.SqlToCypherTranslatorFactory   | false | n/a                                           | true  | false
+						org.neo4j.jdbc.it.cp.FunkyRandomClass                         | true  | n/a                                           | false | false
+						org.neo4j.jdbc.it.cp.FunkyFactory                             | true  | n/a                                           | false | false
+						org.neo4j.jdbc.it.cp.FunkyRandomClass                         | true  | *                                             | false | false
+						org.neo4j.jdbc.it.cp.FunkyFactory3                            | true  | *                                             | true  | true
+						org.neo4j.jdbc.it.cp.FunkyFactory2                            | true  | n/a                                           | false | false
+						org.neo4j.jdbc.it.cp.FunkyFactory2                            | true  | *                                             | true  | false
+						org.neo4j.jdbc.it.cp.FunkyFactory2                            | true  | ,org.neo4j.jdbc.it.cp.FunkyFactory2, whatever | true  | false
+						org.neo4j.jdbc.it.cp.FunkyFactory2                            | true  | elefant,*,a possum                            | true  | false
+						org.neo4j.jdbc.translator.impl.SqlToCypherTranslatorFactory   | true  | n/a                                           | true  | false
+					""",
+			nullValues = "n/a", delimiterString = "|")
+	void mustNotPrematureInitialiseSQLTranslatorFactories(String fqn, boolean useSystemProperty, String allowList,
+			boolean wasLoaded, boolean producedBogusMessage) throws Exception {
+
+		Statement actualTest = () -> {
+			// Capturing funky classes
+			var output = new ByteArrayOutputStream();
+			var original = System.err;
+			var err = new PrintStream(output, true, StandardCharsets.UTF_8);
+			System.setErr(err);
+
+			// Capturing logger
+			var handler = new CapturingHandler();
+			Logger.getLogger("org.neo4j.jdbc").addHandler(handler);
+
+			try {
+				if (allowList != null && useSystemProperty) {
+					System.setProperty("NEO4J_JDBC_ALLOWED_TRANSLATOR_FACTORIES", allowList);
+				}
+
+				var driver = new Neo4jDriver();
+
+				var properties = new Properties();
+				properties.put("user", "neo4j");
+				properties.put("password", this.neo4j.getAdminPassword());
+				properties.put("translatorFactory", fqn);
+
+				var url = "jdbc:neo4j://%s:%s".formatted(this.neo4j.getHost(), this.neo4j.getMappedPort(7687));
+
+				var connection = driver.connect(url, properties);
+				assertThat(connection).isNotNull();
+				try (var resultSet = connection.createStatement().executeQuery("RETURN 1")) {
+					assertThat(resultSet.next()).isTrue();
+					assertThat(resultSet.next()).isFalse();
+				}
+				if (wasLoaded) {
+					String expected;
+					if (fqn.endsWith("FunkyFactory2")) {
+						expected = "I was there";
+					}
+					else if (fqn.endsWith("SqlToCypherTranslatorFactory")) {
+						expected = "RETURN 1";
+					}
+					else {
+						expected = "SELECT 1";
+					}
+					assertThat(connection.nativeSQL("SELECT 1")).isEqualTo(expected);
+				}
+			}
+			finally {
+				err.flush();
+				System.setErr(original);
+
+				Logger.getLogger("org.neo4j.jdbc.connection").removeHandler(handler);
+			}
+
+			var errorOutput = output.toString(StandardCharsets.UTF_8);
+
+			if (producedBogusMessage) {
+				assertThat(errorOutput).contains("This could have been a Runtime.getRuntime().exec() call.");
+			}
+			else {
+				assertThat(errorOutput).doesNotContain("This could have been a Runtime.getRuntime().exec() call.");
+			}
+			if (wasLoaded) {
+				assertThat(handler.messages).doesNotContain("Class {0} cannot be used as translator factory");
+			}
+			else {
+				assertThat(handler.messages).contains("Class {0} cannot be used as translator factory");
+			}
+		};
+
+		if (useSystemProperty) {
+			SystemLambda.restoreSystemProperties(actualTest);
+		}
+		else {
+			SystemLambda.withEnvironmentVariable("NEO4J_JDBC_ALLOWED_TRANSLATOR_FACTORIES", allowList)
+				.execute(actualTest);
+		}
+
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/module-info.java
+++ b/neo4j-jdbc/src/main/java/module-info.java
@@ -35,6 +35,7 @@ module org.neo4j.jdbc {
 	requires transitive org.neo4j.jdbc.authn.spi;
 	requires org.neo4j.jdbc.translator.spi;
 	requires org.neo4j.cypherdsl.support.schema_name;
+	requires org.jspecify;
 	// end::shaded-dependencies
 
 	// requires jdk.unsupported;

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -21,6 +21,7 @@ package org.neo4j.jdbc;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Serial;
 import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
@@ -52,6 +53,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -244,6 +246,12 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 	public static final String PROPERTY_SSL_MODE = "sslMode";
 
 	/**
+	 * Use this property to allow list additional translator factories we don't ship. This
+	 * property must be set via System properties or environment variables.
+	 */
+	public static final String TRANSLATOR_FACTORY_ALLOW_LIST_ENV_KEY = "NEO4J_JDBC_ALLOWED_TRANSLATOR_FACTORIES";
+
+	/**
 	 * An optional configuration flag to try opening new TCP connections using TCP fast
 	 * oben. TCP fast open requires one of the following libraries to be on the module or
 	 * classpath:
@@ -256,6 +264,15 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 	public static final String PROPERTY_TRY_TCP_FAST_OPEN = "tryTcpFastOpen";
 
 	private static final String URL_REGEX = "^jdbc:neo4j(?:\\+(?<transport>s(?:sc)?)?)?(?::(?<protocol>https?))?://(?<host>[^:/?]+):?(?<port>\\d+)?/?(?<database>[^?]+)?\\??(?<urlParams>\\S+)?$";
+
+	/**
+	 * Those are the translator factories we do ship in official JDBC driver modules and
+	 * as such, always allowed.
+	 */
+	private static final Set<String> ALWAYS_ALLOWED_TRANSLATOR_FACTORIES = Set.of(
+			"org.neo4j.jdbc.translator.impl.SqlToCypherTranslatorFactory",
+			"org.neo4j.jdbc.translator.sparkcleaner.SparkSubqueryCleaningTranslatorFactory",
+			"org.neo4j.jdbc.translator.text2cypher.Text2CypherTranslatorFactory");
 
 	/**
 	 * The URL pattern that this driver supports.
@@ -478,9 +495,13 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 		var bookmarkManager = this.bookmarkManagers.computeIfAbsent(driverConfig,
 				k -> driverConfig.useBookmarks ? new DefaultBookmarkManagerImpl() : new NoopBookmarkManagerImpl());
 
-		Supplier<List<TranslatorFactory>> translatorFactoriesSupplier = this.sqlTranslatorFactories::resolve;
+		Supplier<List<TranslatorFactory>> translatorFactoriesSupplier;
 		if (translatorFactory != null && !translatorFactory.isBlank()) {
-			translatorFactoriesSupplier = () -> getSqlTranslatorFactory(translatorFactory);
+			translatorFactoriesSupplier = () -> getSqlTranslatorFactory(translatorFactory,
+					getTranslatorFactoryAllowList());
+		}
+		else {
+			translatorFactoriesSupplier = this.sqlTranslatorFactories::resolve;
 		}
 
 		var finalAuthenticationSupplier = determineAuthenticationSupplier(authenticationSupplier, driverConfig);
@@ -611,16 +632,29 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 	}
 
 	static String getDefaultUserAgent() {
-		if (System.getProperties().containsKey(USER_AGENT_ENV_KEY)
-				&& !System.getProperties().getProperty(USER_AGENT_ENV_KEY).isBlank()) {
-			return System.getProperties().getProperty(USER_AGENT_ENV_KEY);
-		}
-		if (System.getenv().containsKey(USER_AGENT_ENV_KEY) && !System.getenv().get(USER_AGENT_ENV_KEY).isBlank()) {
-			return System.getenv().get(USER_AGENT_ENV_KEY);
+
+		var userAgent = getSystemPropertyOrEnvVariable(USER_AGENT_ENV_KEY);
+		if (userAgent != null) {
+			return userAgent;
 		}
 
 		return loadUserAgentFromResources("META-INF/neo4j-jdbc-user-agent.txt")
 			.orElseGet(() -> "neo4j-jdbc/%s".formatted(ProductVersion.getValue()));
+	}
+
+	static String getTranslatorFactoryAllowList() {
+		return getSystemPropertyOrEnvVariable(TRANSLATOR_FACTORY_ALLOW_LIST_ENV_KEY);
+	}
+
+	private static String getSystemPropertyOrEnvVariable(String key) {
+		if (System.getProperties().containsKey(key) && !System.getProperties().getProperty(key).isBlank()) {
+			return System.getProperties().getProperty(key);
+		}
+		if (System.getenv().containsKey(key) && !System.getenv().get(key).isBlank()) {
+			return System.getenv().get(key);
+		}
+
+		return null;
 	}
 
 	static Optional<String> loadUserAgentFromResources(String name) {
@@ -922,14 +956,22 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 		return new SSLProperties(sslMode, ssl);
 	}
 
-	private List<TranslatorFactory> getSqlTranslatorFactory(String translatorFactory) {
+	@SuppressWarnings("unchecked")
+	private List<TranslatorFactory> getSqlTranslatorFactory(String translatorFactory, String allowList) {
 
 		var fqn = "DEFAULT".equalsIgnoreCase(translatorFactory)
 				? "org.neo4j.jdbc.translator.impl.SqlToCypherTranslatorFactory" : translatorFactory;
 		try {
-			@SuppressWarnings("unchecked")
-			Class<TranslatorFactory> cls = (Class<TranslatorFactory>) Class.forName(fqn);
-			return List.of(cls.getDeclaredConstructor().newInstance());
+			Class<TranslatorFactory> type = null;
+			if (inAllowList(fqn, allowList)) {
+				type = (Class<TranslatorFactory>) Class.forName(fqn, false, this.getClass().getClassLoader());
+			}
+			if (type != null && TranslatorFactory.class.isAssignableFrom(type)) {
+				return List.of(type.getDeclaredConstructor().newInstance());
+			}
+			else {
+				throw new IllegalTranslatorFactoryException(fqn);
+			}
 		}
 		catch (ClassNotFoundException ex) {
 			getParentLogger().log(Level.WARNING, "Translator factory {0} not found", new Object[] { fqn });
@@ -937,7 +979,27 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 		catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ex) {
 			getParentLogger().log(Level.WARNING, ex, () -> "Could not load translator factory");
 		}
+		catch (IllegalTranslatorFactoryException ex) {
+			getParentLogger().log(Level.SEVERE, "Class {0} cannot be used as translator factory",
+					new Object[] { ex.configuredClassName });
+		}
 		return List.of();
+	}
+
+	private boolean inAllowList(String fqn, String allowList) {
+		if ("*".equalsIgnoreCase(allowList) || ALWAYS_ALLOWED_TRANSLATOR_FACTORIES.contains(fqn)) {
+			return true;
+		}
+		else if (allowList == null || allowList.isBlank()) {
+			return false;
+		}
+		else {
+			var starOrEquals = ((Predicate<String>) "*"::equals).or(fqn::equals);
+			return Arrays.stream(allowList.split(","))
+				.filter(Predicate.not(String::isBlank))
+				.map(String::trim)
+				.anyMatch(starOrEquals);
+		}
 	}
 
 	private <T> List<T> loadServices(Class<T> type) {
@@ -1672,6 +1734,19 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 		public SpecifyEnvStep withSQLTranslation() {
 			this.forceSqlTranslation = true;
 			return this;
+		}
+
+	}
+
+	static class IllegalTranslatorFactoryException extends RuntimeException {
+
+		@Serial
+		private static final long serialVersionUID = 8223467710430721301L;
+
+		private final String configuredClassName;
+
+		IllegalTranslatorFactoryException(String configuredClassName) {
+			this.configuredClassName = configuredClassName;
 		}
 
 	}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -974,10 +974,10 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 			}
 		}
 		catch (ClassNotFoundException ex) {
-			getParentLogger().log(Level.WARNING, "Translator factory {0} not found", new Object[] { fqn });
+			getParentLogger().log(Level.SEVERE, "Translator factory {0} not found", new Object[] { fqn });
 		}
 		catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ex) {
-			getParentLogger().log(Level.WARNING, ex, () -> "Could not load translator factory");
+			getParentLogger().log(Level.SEVERE, ex, () -> "Could not load translator factory");
 		}
 		catch (IllegalTranslatorFactoryException ex) {
 			getParentLogger().log(Level.SEVERE, "Class {0} cannot be used as translator factory",


### PR DESCRIPTION
Normally, SQL Translator factories are loaded per Java service loader mechanics. In some runtime environments and
classpath setups—especially in various etl tools—the class loader has no access to service loaded classes. For that to
cater the JDBC driver does provide a property `translatorFactory` that either can be set to `DEFAULT` to use the default
dynamic translation or to a fully qualified class name of a class implementing `TranslatorFactory`.

The latter is checked after the class is loaded. This can be a possible for a remote code execution if
- an attacker can put a malicious class on the classpath
- execute malicious code in that class static initializer or the default constructor

This change prevents that now by
- Not initialising the class eagerly
- First typechecking before instantiation

As that would leave the constructor attack being a possibility an additional allowlist has been introduced. That
allowlist is by default empty and the driver does only allow known translators being loaded by fall back mechanism
(known translators are all that we ship). It can be set to `*` to restore the previous behaviour (the fixed version
though), or to a list of allowed types.

We do assume that the fallback configuration has been used in ETL tools alone with classes that we ship, so we don't
consider an empty allowlist a breaking change.

This closes #CGE-969.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
