### PR TITLE
fix: Use `Base64.getUrlDecoder()` instead of `Base64.getDecoder()` for decoding JWT tokens.

### DIFF
--- a/neo4j-jdbc-authn/kc/pom.xml
+++ b/neo4j-jdbc-authn/kc/pom.xml
@@ -51,6 +51,16 @@
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-jdbc-authn-spi</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/neo4j-jdbc-authn/kc/src/main/java/org/neo4j/jdbc/authn/kc/KCAuthenticationSupplier.java
+++ b/neo4j-jdbc-authn/kc/src/main/java/org/neo4j/jdbc/authn/kc/KCAuthenticationSupplier.java
@@ -126,13 +126,18 @@ public final class KCAuthenticationSupplier implements Supplier<Authentication> 
 
 	record TokensAndExpirationTime(String accessToken, Instant expiresAt, String refreshToken) {
 
-		static final Base64.Decoder DECODER = Base64.getDecoder();
+		static final Base64.Decoder DECODER = Base64.getUrlDecoder();
 
 		static TokensAndExpirationTime of(AccessTokenResponse accessTokenResponse) throws IOException {
 			var chunks = accessTokenResponse.getToken().split("\\.");
+			if (chunks.length < 2) {
+				throw new IOException("Malformed JWT: expected at least 2 segments");
+			}
 			var payload = JSON.std.mapFrom(DECODER.decode(chunks[1]));
-			var exp = Instant.ofEpochSecond(((Number) payload.get("exp")).longValue());
-			return new TokensAndExpirationTime(accessTokenResponse.getToken(), exp,
+			if (!(payload.get("exp") instanceof Number exp)) {
+				throw new IOException("JWT has no numeric 'exp' claim");
+			}
+			return new TokensAndExpirationTime(accessTokenResponse.getToken(), Instant.ofEpochSecond(exp.longValue()),
 					accessTokenResponse.getRefreshToken());
 		}
 

--- a/neo4j-jdbc-authn/kc/src/test/java/org/neo4j/jdbc/authn/kc/KCAuthenticationSupplierTests.java
+++ b/neo4j-jdbc-authn/kc/src/test/java/org/neo4j/jdbc/authn/kc/KCAuthenticationSupplierTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.authn.kc;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.AccessTokenResponse;
+import org.neo4j.jdbc.authn.kc.KCAuthenticationSupplier.TokensAndExpirationTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KCAuthenticationSupplierTests {
+
+	@Test
+	void shouldDecodeURLSafeJWT() throws IOException {
+
+		var response = new AccessTokenResponse();
+		response.setToken(
+				"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3ODgyMDEwMjUsInN1YiI6IkBsbPCfmIxsbGzwn5iMbEAiLCJuYW1lIjoiVm9ybmFtZfCfmIwg8J-YjCBOYW1lIiwiYWRtaW4iOmZhbHNlfQ.9wC287ShapxShSsxu7L76HIzLd6Z8V5rgnm1x7GnoK8");
+		var tokensAndExpirationTime = TokensAndExpirationTime.of(response);
+		assertThat(tokensAndExpirationTime.expiresAt()).isEqualTo(Instant.parse("2026-08-31T18:30:25Z"));
+	}
+
+}

--- a/neo4j-jdbc-it/neo4j-jdbc-it-sso/src/test/java/org/neo4j/jdbc/it/sso/ReauthenticationIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-sso/src/test/java/org/neo4j/jdbc/it/sso/ReauthenticationIT.java
@@ -36,6 +36,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.http.impl.client.HttpClients;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -196,10 +197,13 @@ class ReauthenticationIT {
 		assertThat(Metrics.globalRegistry.find("org.neo4j.jdbc.authentications").tags("state", "new").counter())
 			.isNotNull()
 			.extracting(Counter::count)
-			.isEqualTo(1.0);
+			.asInstanceOf(InstanceOfAssertFactories.DOUBLE)
+			.isGreaterThanOrEqualTo(1.0);
 		assertThat(Metrics.globalRegistry.find("org.neo4j.jdbc.authentications").tags("state", "refreshed").counter())
+			.isNotNull()
 			.extracting(Counter::count)
-			.isEqualTo(2.0);
+			.asInstanceOf(InstanceOfAssertFactories.DOUBLE)
+			.isGreaterThanOrEqualTo(2.0);
 	}
 
 	@Test


### PR DESCRIPTION
Part of CGE-971.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
