### PR TITLE
refactor: Make `toString()` methods of auth tokens safe for log usage.

### DIFF
--- a/neo4j-jdbc-authn/spi/pom.xml
+++ b/neo4j-jdbc-authn/spi/pom.xml
@@ -38,6 +38,19 @@
 		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/neo4j-jdbc-authn/spi/src/main/java/org/neo4j/jdbc/authn/spi/TokenAuthentication.java
+++ b/neo4j-jdbc-authn/spi/src/main/java/org/neo4j/jdbc/authn/spi/TokenAuthentication.java
@@ -44,4 +44,9 @@ public record TokenAuthentication(String scheme, String value, Instant expiresAt
 		Objects.requireNonNull(scheme, "Scheme can't be null");
 		Objects.requireNonNull(value, "Token can't be null");
 	}
+
+	@Override
+	public String toString() {
+		return "TokenAuthentication{scheme='%s', value='******', expiresAt=%s}".formatted(this.scheme, this.expiresAt);
+	}
 }

--- a/neo4j-jdbc-authn/spi/src/main/java/org/neo4j/jdbc/authn/spi/UsernamePasswordAuthentication.java
+++ b/neo4j-jdbc-authn/spi/src/main/java/org/neo4j/jdbc/authn/spi/UsernamePasswordAuthentication.java
@@ -43,4 +43,10 @@ public record UsernamePasswordAuthentication(String username, String password, S
 		Objects.requireNonNull(username, "Username can't be null");
 		Objects.requireNonNull(password, "Password can't be null");
 	}
+
+	@Override
+	public String toString() {
+		return "UsernamePasswordAuthentication{username='%s', password='******', realm='%s'}".formatted(this.username,
+				this.realm);
+	}
 }

--- a/neo4j-jdbc-authn/spi/src/test/java/org/neo4j/jdbc/authn/spi/TokenAuthenticationTests.java
+++ b/neo4j-jdbc-authn/spi/src/test/java/org/neo4j/jdbc/authn/spi/TokenAuthenticationTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.authn.spi;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenAuthenticationTests {
+
+	@Test
+	void doesNotToStringPassword() {
+		var auth = new TokenAuthentication("foo", "Bar", Instant.parse("2026-09-01T13:25:57.074355Z"));
+		assertThat(auth)
+			.hasToString("TokenAuthentication{scheme='foo', value='******', expiresAt=2026-09-01T13:25:57.074355Z}");
+	}
+
+}

--- a/neo4j-jdbc-authn/spi/src/test/java/org/neo4j/jdbc/authn/spi/UsernamePasswordAuthenticationTests.java
+++ b/neo4j-jdbc-authn/spi/src/test/java/org/neo4j/jdbc/authn/spi/UsernamePasswordAuthenticationTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.jdbc.authn.spi;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsernamePasswordAuthenticationTests {
+
+	@Test
+	void doesNotToStringPassword() {
+		var auth = new UsernamePasswordAuthentication("foo", "Bar", "whatever");
+		assertThat(auth)
+			.hasToString("UsernamePasswordAuthentication{username='foo', password='******', realm='whatever'}");
+	}
+
+}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -596,7 +596,10 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 			return AuthTokens.custom(BoltAdapters.adaptMap(customAuthentication.toMap()));
 		}
 
-		throw new IllegalArgumentException("Unsupported authentication type %s".formatted(authentication));
+		// This can not be thrown, even with custom authentications,
+		// above if/else is exhaustive
+		throw new IllegalArgumentException(
+				"Unsupported authentication type %s".formatted(authentication.getClass().getName()));
 	}
 
 	private BoltConnection establishBoltConnection(DriverConfig driverConfig, String userAgent,
@@ -1368,6 +1371,11 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 			return result;
 		}
 
+		@Override
+		public String toString() {
+			return "DriverConfig{host='%s', protocol='%s', port=%d, database='%s', user='%s'}".formatted(this.host,
+					this.protocol, this.port, this.database, this.user);
+		}
 	}
 
 	/**

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDriverTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDriverTests.java
@@ -227,6 +227,12 @@ class Neo4jDriverTests {
 			return newDriverConfig(Map.of());
 		}
 
+		@Test
+		void driverConfigHasMinimumToString() {
+			assertThat(newDriverConfig())
+				.hasToString("DriverConfig{host='na', protocol='neo4j', port=7687, database='db', user='explicit'}");
+		}
+
 	}
 
 	@Nested


### PR DESCRIPTION
Part of CGE-971.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
