### PR TITLE
refactor: Avoid the use of `AtomicReference#updateAndGet` with methods that have side effects.

### DIFF
--- a/neo4j-jdbc-authn/kc/src/main/java/org/neo4j/jdbc/authn/kc/KCAuthenticationSupplier.java
+++ b/neo4j-jdbc-authn/kc/src/main/java/org/neo4j/jdbc/authn/kc/KCAuthenticationSupplier.java
@@ -23,7 +23,6 @@ import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import com.fasterxml.jackson.jr.ob.JSON;
@@ -66,7 +65,7 @@ public final class KCAuthenticationSupplier implements Supplier<Authentication> 
 
 	private final String url;
 
-	private final AtomicReference<TokensAndExpirationTime> currentToken = new AtomicReference<>();
+	private volatile TokensAndExpirationTime currentToken;
 
 	KCAuthenticationSupplier(String user, String password, Configuration cfg) {
 		this.username = user;
@@ -81,19 +80,27 @@ public final class KCAuthenticationSupplier implements Supplier<Authentication> 
 	 * {@return true if a token has been retrieved and it is still valid}
 	 */
 	public boolean currentTokenIsExpired() {
-		return Optional.ofNullable(this.currentToken.get())
-			.filter(v -> Instant.now().isAfter(v.expiresAt()))
-			.isPresent();
+		return Optional.ofNullable(this.currentToken).filter(v -> Instant.now().isAfter(v.expiresAt())).isPresent();
+	}
+
+	boolean isNullOrExpired(TokensAndExpirationTime tokensAndExpirationTime) {
+		return tokensAndExpirationTime == null || Instant.now().isAfter(tokensAndExpirationTime.expiresAt());
 	}
 
 	@Override
 	public Authentication get() {
-		return this.currentToken.updateAndGet(previous -> {
-			if (previous == null) {
-				return get0();
+
+		TokensAndExpirationTime result = this.currentToken;
+		if (isNullOrExpired(result)) {
+			synchronized (this) {
+				result = this.currentToken;
+				if (isNullOrExpired(result)) {
+					this.currentToken = (result != null) ? refresh0(result.refreshToken()) : get0();
+					result = this.currentToken;
+				}
 			}
-			return refresh0(previous.refreshToken());
-		}).toAuthentication();
+		}
+		return result.toAuthentication();
 	}
 
 	TokensAndExpirationTime get0() {

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DefaultAuthenticationManagerImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DefaultAuthenticationManagerImpl.java
@@ -25,7 +25,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import org.neo4j.jdbc.authn.spi.Authentication;
@@ -39,7 +38,7 @@ final class DefaultAuthenticationManagerImpl implements AuthenticationManager {
 
 	private final Supplier<Authentication> authenticationSupplier;
 
-	private final AtomicReference<AuthenticationAndState> currentAuthentication = new AtomicReference<>();
+	private volatile AuthenticationAndState currentAuthentication;
 
 	private final Clock clock;
 
@@ -76,13 +75,31 @@ final class DefaultAuthenticationManagerImpl implements AuthenticationManager {
 	@Override
 	public Authentication getOrRefresh() {
 
-		var hlp = this.currentAuthentication.updateAndGet(previous -> {
-			if (previous != null && this.isValid(previous.authentication)) {
-				return new AuthenticationAndState(previous.authentication, State.REUSED);
+		var hlp = this.currentAuthentication;
+		boolean isNew = false;
+		if (hlp == null) {
+			synchronized (this) {
+				hlp = this.currentAuthentication;
+				if (hlp == null) {
+					this.currentAuthentication = new AuthenticationAndState(this.authenticationSupplier.get(),
+							State.NEW);
+					hlp = this.currentAuthentication;
+					isNew = true;
+				}
 			}
-			var authentication = this.authenticationSupplier.get();
-			return new AuthenticationAndState(authentication, (previous != null) ? State.REFRESHED : State.NEW);
-		});
+		}
+		if (!isNew) {
+			synchronized (this) {
+				if (isValid(hlp.authentication)) {
+					this.currentAuthentication = new AuthenticationAndState(hlp.authentication, State.NEW);
+				}
+				else {
+					this.currentAuthentication = new AuthenticationAndState(this.authenticationSupplier.get(),
+							State.REFRESHED);
+				}
+				hlp = this.currentAuthentication;
+			}
+		}
 		var eventState = hlp.state.toEventState();
 		if (eventState != null) {
 			this.notifyListeners(new NewAuthenticationEvent(this.targetUrl, eventState));


### PR DESCRIPTION
Part of CGE-971.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
