### PR TITLE
refactor: Ignore address from implicit .env file as long as credentials are not sourced from the same file.

### DIFF
--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/Neo4jDriverExtensionsIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/Neo4jDriverExtensionsIT.java
@@ -19,6 +19,7 @@
 package org.neo4j.jdbc.it.cp;
 
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -80,6 +81,83 @@ class Neo4jDriverExtensionsIT {
 				}
 			});
 
+	}
+
+	@Test
+	void urlFromImplicitFileShouldRejectedIfFileDoesNotContainAuth() throws Exception {
+
+		var dotEnvFile = Files.createFile(Paths.get("").resolve(".env"));
+		Files.write(dotEnvFile, List.of("NEO4J_URI=jdbc:neo4j://IAmEvil"));
+		try {
+			SystemLambda.withEnvironmentVariable("NEO4J_USERNAME", "neo4j")
+				.and("NEO4J_PASSWORD", this.neo4j.getAdminPassword())
+				.execute(() -> {
+					var connection = Neo4jDriver.fromEnv();
+					assertThat(connection).isEmpty();
+				});
+		}
+		finally {
+			Files.deleteIfExists(dotEnvFile);
+		}
+	}
+
+	@Test
+	void urlFromImplicitFileShouldNotRejectedIfDirIsSpecified() throws Exception {
+
+		var dotEnvFile = Files.createFile(Paths.get("").resolve(".env"));
+		Files.write(dotEnvFile, List
+			.of("NEO4J_URI=jdbc:neo4j://%s:%s".formatted(this.neo4j.getHost(), this.neo4j.getMappedPort(7687))));
+		try {
+			SystemLambda.withEnvironmentVariable("NEO4J_USERNAME", "neo4j")
+				.and("NEO4J_PASSWORD", this.neo4j.getAdminPassword())
+				.execute(() -> {
+					var connection = Neo4jDriver.fromEnv(dotEnvFile.toAbsolutePath().getParent());
+					assertThat(connection).isPresent();
+					connection.orElseThrow().close();
+				});
+		}
+		finally {
+			Files.deleteIfExists(dotEnvFile);
+		}
+	}
+
+	@Test
+	void urlFromImplicitFileShouldNotRejectedIfFileIsSpecified() throws Exception {
+
+		var dotEnvFile = Files.createFile(Paths.get("").resolve(".whatever"));
+		Files.write(dotEnvFile, List
+			.of("NEO4J_URI=jdbc:neo4j://%s:%s".formatted(this.neo4j.getHost(), this.neo4j.getMappedPort(7687))));
+		try {
+			SystemLambda.withEnvironmentVariable("NEO4J_USERNAME", "neo4j")
+				.and("NEO4J_PASSWORD", this.neo4j.getAdminPassword())
+				.execute(() -> {
+					var connection = Neo4jDriver.fromEnv(null, dotEnvFile.getFileName().toString());
+					assertThat(connection).isPresent();
+					connection.orElseThrow().close();
+				});
+		}
+		finally {
+			Files.deleteIfExists(dotEnvFile);
+		}
+	}
+
+	@Test
+	void urlFromImplicitFileShouldNotRejectedIfFileDoesContainAuth() throws Exception {
+
+		var dotEnvFile = Files.createFile(Paths.get("").resolve(".env"));
+		Files.write(dotEnvFile,
+				List.of("NEO4J_URI=jdbc:neo4j://%s:%s".formatted(this.neo4j.getHost(), this.neo4j.getMappedPort(7687)),
+						"NEO4J_USERNAME=neo4j", "NEO4J_PASSWORD=" + this.neo4j.getAdminPassword()));
+		try {
+
+			var connection = Neo4jDriver.fromEnv();
+			assertThat(connection).isPresent();
+			connection.orElseThrow().close();
+
+		}
+		finally {
+			Files.deleteIfExists(dotEnvFile);
+		}
 	}
 
 	@Test

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -61,6 +61,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import io.github.cdimascio.dotenv.Dotenv;
+import io.github.cdimascio.dotenv.DotenvEntry;
 import org.neo4j.bolt.connection.AuthToken;
 import org.neo4j.bolt.connection.AuthTokens;
 import org.neo4j.bolt.connection.BoltConnection;
@@ -1678,13 +1679,23 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 			if (directory != null) {
 				builder = builder.directory(directory.toAbsolutePath().toString());
 			}
+			boolean fileSpecified = false;
 			if (filename != null && !filename.isBlank()) {
 				builder = builder.filename(filename);
+				fileSpecified = true;
 			}
 
 			var env = builder.load();
+			var entriesFromFile = env.entries(Dotenv.Filter.DECLARED_IN_ENV_FILE)
+				.stream()
+				.map(DotenvEntry::getKey)
+				.collect(Collectors.toSet());
 
-			var address = env.get("NEO4J_URI");
+			String address = null;
+			if ((directory != null || fileSpecified) || !entriesFromFile.contains("NEO4J_URI")
+					|| entriesFromFile.containsAll(Set.of("NEO4J_USERNAME", "NEO4J_PASSWORD"))) {
+				address = env.get("NEO4J_URI");
+			}
 			if (address != null && !address.toLowerCase(Locale.ROOT).startsWith("jdbc:")) {
 				address = "jdbc:" + address;
 			}


### PR DESCRIPTION
Part of CGE-971.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
