### PR TITLE
fix: Don't use cached translations when SQL translation is not enabled.

### DIFF
--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/TranslationIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/TranslationIT.java
@@ -58,7 +58,7 @@ class TranslationIT extends IntegrationTestBase {
 			var stmt = connection.prepareStatement(sql);
 			assertThat(stmt).isNotNull();
 			assertThatExceptionOfType(SQLException.class).isThrownBy(stmt::executeQuery)
-				.withMessageContaining("error: syntax error or access rule violation - invalid syntax");
+				.withStackTraceContaining("Invalid input 'SELECT'");
 		}
 	}
 

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/TranslationIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/TranslationIT.java
@@ -51,6 +51,18 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 class TranslationIT extends IntegrationTestBase {
 
 	@Test
+	void mustNotUseCachedTranslationFromExplicitNativeCall() throws SQLException {
+		try (var connection = getConnection(false, false, "cacheSQLTranslations", "true")) {
+			var sql = "SELECT 1";
+			assertThat(connection.nativeSQL(sql)).isEqualTo("RETURN 1");
+			var stmt = connection.prepareStatement(sql);
+			assertThat(stmt).isNotNull();
+			assertThatExceptionOfType(SQLException.class).isThrownBy(stmt::executeQuery)
+				.withMessageContaining("error: syntax error or access rule violation - invalid syntax");
+		}
+	}
+
+	@Test
 	void shouldLoadTranslatorDirectly() throws SQLException {
 
 		var url = "jdbc:neo4j://%s:%d".formatted(this.neo4j.getHost(), this.neo4j.getMappedPort(7687));

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ConnectionImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ConnectionImpl.java
@@ -1155,7 +1155,4 @@ final class ConnectionImpl implements Neo4jConnection {
 
 	}
 
-	record SqlAndState(String sql, boolean forcedTranslation) {
-	}
-
 }

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ConnectionImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ConnectionImpl.java
@@ -221,11 +221,12 @@ final class ConnectionImpl implements Neo4jConnection {
 	UnaryOperator<String> getTranslator(boolean force, Consumer<SQLWarning> warningConsumer) throws SQLException {
 
 		List<Translator> resolvedTranslators;
-		if (!(this.enableSqlTranslation || force)) {
-			resolvedTranslators = List.of((statement, optionalDatabaseMetaData) -> statement);
+		var useTranslators = this.enableSqlTranslation || force;
+		if (useTranslators) {
+			resolvedTranslators = this.translators.resolve();
 		}
 		else {
-			resolvedTranslators = this.translators.resolve();
+			resolvedTranslators = List.of((statement, optionalDatabaseMetaData) -> statement);
 		}
 
 		if (resolvedTranslators.isEmpty()) {
@@ -235,7 +236,7 @@ final class ConnectionImpl implements Neo4jConnection {
 		var metaData = this.getMetaData();
 		var sqlTranslator = new TranslatorChain(resolvedTranslators, metaData, warningConsumer);
 
-		if (this.enableTranslationCaching) {
+		if (this.enableTranslationCaching && useTranslators) {
 			return sql -> {
 				synchronized (ConnectionImpl.this) {
 					if (this.l2cache.containsKey(sql)) {
@@ -1152,6 +1153,9 @@ final class ConnectionImpl implements Neo4jConnection {
 			return result;
 		}
 
+	}
+
+	record SqlAndState(String sql, boolean forcedTranslation) {
 	}
 
 }


### PR DESCRIPTION
Part of CGE-971.
