### PR TITLE
refactor: Don't allow arbitrary regex pattern for table and column search patterns.

### DIFF
--- a/neo4j-jdbc-authn/spi/src/main/java/org/neo4j/jdbc/authn/spi/UsernamePasswordAuthentication.java
+++ b/neo4j-jdbc-authn/spi/src/main/java/org/neo4j/jdbc/authn/spi/UsernamePasswordAuthentication.java
@@ -45,6 +45,8 @@ public record UsernamePasswordAuthentication(String username, String password, S
 	}
 
 	@Override
+	// That was the moment Sonar broke me a bit, complaining about the redacted password.
+	@SuppressWarnings({ "squid:S2068" })
 	public String toString() {
 		return "UsernamePasswordAuthentication{username='%s', password='******', realm='%s'}".formatted(this.username,
 				this.realm);

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/DatabaseMetadataIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/DatabaseMetadataIT.java
@@ -20,9 +20,15 @@ package org.neo4j.jdbc.it.cp;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -69,6 +75,31 @@ class DatabaseMetadataIT extends AbstractDatabaseMetadata {
 		var valueField = apocAvailableField.getType().getDeclaredField("resolved");
 		valueField.setAccessible(true);
 		valueField.set(apocAvailable, true);
+	}
+
+	static Stream<Arguments> getTablesWildcard() {
+		return Stream.of(Arguments.of("TabA%", List.of("TabAnton", "TabAnnabelle", "TabA%Weird", "TabA%2Weird")),
+				Arguments.of("TabA_", List.of()), Arguments.of("Tab_nton", List.of("TabAnton")),
+				Arguments.of("TabA\\%Weird", List.of("TabA%Weird")), Arguments.of("TabA_Weird", List.of("TabA%Weird")),
+				Arguments.of("TabA\\_Weird", List.of()), Arguments.of(".*", List.of()),
+				Arguments.of("(a+)+$", List.of()));
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void getTablesWildcard(String wildcard, List<String> expectedTables) throws SQLException {
+
+		try (var stmt = this.connection.createStatement()) {
+			stmt.executeUpdate("CREATE (:TabAnton), (:TabAnnabelle), (:`TabA%Weird`), (:`TabA%2Weird`), (:aaaaaaaa) ");
+		}
+
+		var meta = this.connection.getMetaData();
+		var resultSet = meta.getTables(null, null, wildcard, null);
+		var tables = new ArrayList<>();
+		while (resultSet.next()) {
+			tables.add(resultSet.getString("TABLE_NAME"));
+		}
+		assertThat(tables).containsExactlyInAnyOrderElementsOf(expectedTables);
 	}
 
 }

--- a/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/DatabaseMetadataVirtualGraphIT.java
+++ b/neo4j-jdbc-it/neo4j-jdbc-it-cp/src/test/java/org/neo4j/jdbc/it/cp/DatabaseMetadataVirtualGraphIT.java
@@ -243,7 +243,7 @@ class DatabaseMetadataVirtualGraphIT extends AbstractDatabaseMetadata {
 
 		try (var con = this.getConnection(false, true)) {
 			var meta = con.getMetaData();
-			var columnsRs = meta.getColumns(null, null, "Person_DIRECTED_Movie", null);
+			var columnsRs = meta.getColumns(null, null, "Person\\_DIRECTED\\_Movie", null);
 			var columns = new HashSet<String>();
 			while (columnsRs.next()) {
 				columns.add(columnsRs.getString("COLUMN_NAME"));

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
@@ -1142,8 +1142,8 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 		var vgSchema = this.virtualGraphSchema.resolve();
 		var selected = vgSchema.entrySet()
 			.stream()
-			.filter(table -> tableNamePattern.matches(table.getKey().TABLE_NAME)
-					&& table.getValue().stream().anyMatch(column -> columnNamePattern.matches(column.name())))
+			.filter(table -> tableNamePattern.matches(table.getKey().TABLE_NAME) && (columnNamePattern.isNull()
+					|| table.getValue().stream().anyMatch(column -> columnNamePattern.matches(column.name()))))
 			.map(table -> Map.entry(table.getKey(),
 					table.getValue().stream().filter(column -> columnNamePattern.matches(column.name())).toList()))
 			.toList();
@@ -2322,6 +2322,10 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 
 		boolean matches(String target) {
 			return target == null || this.value == null || Pattern.compile(this.value).asMatchPredicate().test(target);
+		}
+
+		boolean isNull() {
+			return this.value == null;
 		}
 	}
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/DatabaseMetadataImpl.java
@@ -45,10 +45,12 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -57,6 +59,7 @@ import org.neo4j.jdbc.Neo4jTransaction.ResultSummary;
 import org.neo4j.jdbc.Neo4jTransaction.RunResponse;
 import org.neo4j.jdbc.translator.spi.View;
 import org.neo4j.jdbc.translator.spi.View.Column;
+import org.neo4j.jdbc.values.AsValue;
 import org.neo4j.jdbc.values.MapValue;
 import org.neo4j.jdbc.values.Record;
 import org.neo4j.jdbc.values.Type;
@@ -224,6 +227,14 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 	private static final String DEFAULT_CATALOG = "neo4j";
 
 	private static final String TABLE_TYPE_RELATIONSHIP = "RELATIONSHIP";
+
+	private static final String SEARCH_STRING_ESCAPE = "\\";
+
+	private static final Pattern PATTERN_VALID_SQL_SEARCH_WILDCARDS = Pattern
+		.compile("(?<!%s)[%%_]".formatted(SEARCH_STRING_ESCAPE.repeat(2)));
+
+	private static final Pattern PATTERN_ESCAPED_SQL_SEARCH_WILDCARDS = Pattern
+		.compile("%s([%%_])".formatted(SEARCH_STRING_ESCAPE.repeat(2)));
 
 	static {
 		QUERIES = new Properties();
@@ -545,7 +556,7 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 
 	@Override
 	public String getSearchStringEscape() {
-		return "'";
+		return SEARCH_STRING_ESCAPE;
 	}
 
 	@Override
@@ -1119,7 +1130,8 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 		return Collections.unmodifiableSortedMap(tables);
 	}
 
-	private List<Record> getVirtualGraphColumns(String tableNamePattern, String columnNamePattern) {
+	private List<Record> getVirtualGraphColumns(FormattedSearchPattern tableNamePattern,
+			FormattedSearchPattern columnNamePattern) {
 
 		if (!isVirtualGraph()) {
 			return List.of();
@@ -1130,14 +1142,10 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 		var vgSchema = this.virtualGraphSchema.resolve();
 		var selected = vgSchema.entrySet()
 			.stream()
-			.filter(table -> (tableNamePattern == null || table.getKey().TABLE_NAME.matches(tableNamePattern))
-					&& (columnNamePattern == null
-							|| table.getValue().stream().anyMatch(column -> column.name().matches(columnNamePattern))))
+			.filter(table -> tableNamePattern.matches(table.getKey().TABLE_NAME)
+					&& table.getValue().stream().anyMatch(column -> columnNamePattern.matches(column.name())))
 			.map(table -> Map.entry(table.getKey(),
-					table.getValue()
-						.stream()
-						.filter(column -> columnNamePattern == null || column.name().matches(columnNamePattern))
-						.toList()))
+					table.getValue().stream().filter(column -> columnNamePattern.matches(column.name())).toList()))
 			.toList();
 
 		var records = new ArrayList<Record>();
@@ -1201,14 +1209,14 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 
 	private GetTablesCacheValue getTables0(GetTablesCacheKey key) {
 
-		var tableNamePattern = sanitizeNamePattern(key.tableNamePattern);
+		var tableNamePattern = FormattedSearchPattern.of(key.tableNamePattern);
 		var types = key.types();
 
 		if (isVirtualGraph()) {
 			var vgSchema = this.virtualGraphSchema.resolve();
 			var selected = vgSchema.keySet()
 				.stream()
-				.filter(table -> (tableNamePattern == null || table.TABLE_NAME.matches(tableNamePattern))
+				.filter(table -> tableNamePattern.matches(table.TABLE_NAME)
 						&& (types == null || Arrays.stream(types).anyMatch(type -> type.equals(table.TABLE_TYPE))))
 				.toList();
 			try {
@@ -1228,10 +1236,6 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 		catch (SQLException ex) {
 			throw new UncheckedSQLException(ex);
 		}
-	}
-
-	private static String sanitizeNamePattern(String tableNamePattern) {
-		return Optional.ofNullable(tableNamePattern).map(String::trim).map(v -> v.replace("%", ".*")).orElse(null);
 	}
 
 	@Override
@@ -1287,16 +1291,16 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 		assertCatalogIsNullOrEmpty(catalog);
 		assertSchemaIsPublicOrNull(schemaPattern);
 
-		tableNamePattern = sanitizeNamePattern(tableNamePattern);
-		columnNamePattern = sanitizeNamePattern(columnNamePattern);
-
+		var formattedTableNamePattern = FormattedSearchPattern.of(tableNamePattern);
+		var formattedColumnNamePattern = FormattedSearchPattern.of(columnNamePattern);
 		List<Record> records;
 		if (isVirtualGraph()) {
-			records = getVirtualGraphColumns(tableNamePattern, columnNamePattern);
+			records = getVirtualGraphColumns(formattedTableNamePattern, formattedColumnNamePattern);
 		}
 		else {
-			var request = getRequest("getColumns", "name", tableNamePattern, "column_name", columnNamePattern,
-					"sampleSize", this.relationshipSampleSize, "viewColumns", getViewColumns());
+			var request = getRequest("getColumns", "name", formattedTableNamePattern, "column_name",
+					formattedColumnNamePattern, "sampleSize", this.relationshipSampleSize, "viewColumns",
+					getViewColumns());
 			var innerColumnsResponse = doQueryForPullResponse(request);
 
 			records = innerColumnsResponse.records()
@@ -1392,7 +1396,7 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 				}
 			}
 			for (var additionalId : additionalIds) {
-				if (columnNamePattern != null && !additionalId.matches(columnNamePattern.replace("%", ".*"))) {
+				if (!formattedColumnNamePattern.matches(additionalId)) {
 					continue;
 				}
 
@@ -1752,7 +1756,7 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 		assertSchemaIsPublicOrNull(schema);
 
 		var intermediateResults = new ArrayList<>();
-		var request = getRequest("getIndexInfo", "name", table, "unique", unique);
+		var request = getRequest("getIndexInfo", "name", FormattedSearchPattern.of(table), "unique", unique);
 		try (var rs = doQueryForResultSet(request)) {
 			while (rs.next()) {
 				intermediateResults.add(Map.of("name", rs.getString("name"), "tableName",
@@ -2276,6 +2280,49 @@ final class DatabaseMetadataImpl implements Neo4jDatabaseMetaData {
 
 	private record VgTable(String TABLE_CAT, String TABLE_SCHEM, String TABLE_NAME, String TABLE_TYPE, String REMARKS,
 			String TYPE_CAT, String TYPE_SCHEM, String TYPE_NAME, String SELF_REFERENCES_COL_NAME) {
+	}
+
+	record FormattedSearchPattern(String value) implements AsValue {
+
+		static FormattedSearchPattern of(String input) {
+
+			if (input == null || input.isBlank()) {
+				return new FormattedSearchPattern(null);
+			}
+
+			BiFunction<Integer, Integer, String> quoteAndEscape = (start, end) -> {
+				var part = input.substring(start, end);
+				if (part.isEmpty()) {
+					return "";
+				}
+				return Pattern.quote(PATTERN_ESCAPED_SQL_SEARCH_WILDCARDS.matcher(part).replaceAll("$1"));
+			};
+
+			var matcher = PATTERN_VALID_SQL_SEARCH_WILDCARDS.matcher(input);
+			var result = new StringBuilder();
+
+			var lastStart = new AtomicInteger(0);
+			matcher.results().forEach(matchResult -> {
+				result.append(quoteAndEscape.apply(lastStart.getAndSet(matchResult.end()), matchResult.start()));
+				var replacement = switch (matchResult.group()) {
+					case "_" -> ".?+";
+					case "%" -> ".*+";
+					default -> "";
+				};
+				result.append(replacement);
+			});
+			result.append(quoteAndEscape.apply(lastStart.get(), input.length()));
+			return new FormattedSearchPattern(result.toString());
+		}
+
+		@Override
+		public Value asValue() {
+			return (this.value != null) ? Values.value(this.value) : Values.NULL;
+		}
+
+		boolean matches(String target) {
+			return target == null || this.value == null || Pattern.compile(this.value).asMatchPredicate().test(target);
+		}
 	}
 
 }

--- a/neo4j-jdbc/src/main/resources/queries/DatabaseMetadata.properties
+++ b/neo4j-jdbc/src/main/resources/queries/DatabaseMetadata.properties
@@ -220,10 +220,10 @@ ORDER BY TABLE_TYPE DESC, TABLE_NAME
 
 getColumns=// First part gets simple node properties \
 \n CALL db.schema.nodeTypeProperties() YIELD nodeLabels, propertyName, propertyTypes WITH * \
-\n WHERE ($name IS NULL OR $name = '%' OR ANY (label IN nodeLabels WHERE label =~ $name)) \
+\n WHERE ($name IS NULL OR ANY (label IN nodeLabels WHERE label =~ $name)) \
 \n   AND propertyName IS NOT NULL \
 \n   AND ($column_name IS NULL OR propertyName =~ $column_name) \
-\n RETURN [x IN nodeLabels WHERE $name IS NULL OR $name = '%' OR x = $name] AS tables, \
+\n RETURN [x IN nodeLabels WHERE $name IS NULL OR x =~ $name] AS tables, \
 \n        propertyName, propertyTypes, "TABLE" AS TABLE_TYPE, null AS relationshipType, \
 \n        null AS SCOPE_TABLE \
 \n UNION \
@@ -243,7 +243,7 @@ getColumns=// First part gets simple node properties \
 \n WITH from, to, relationshipType, \
 \n      propertyName AS relPropertyName, propertyTypes AS relPropertyTypes, \
 \n      from + '_' + relationshipType + '_' + to AS tableName \
-\n WHERE ($name IS NULL OR $name = '%' OR tableName =~ $name) \
+\n WHERE ($name IS NULL OR tableName =~ $name) \
 \n CALL { \
 \n   // Subquery to unionise the relationship properties with the properties of start and end node \
 \n   WITH from, to, relPropertyName, relPropertyTypes \
@@ -265,7 +265,7 @@ getColumns=// First part gets simple node properties \
 \n UNION \
 \n UNWIND $viewColumns AS viewColumn \
 \n WITH viewColumn \
-\n WHERE ($name IS NULL OR $name = '%' OR viewColumn.viewName =~ $name) \
+\n WHERE ($name IS NULL OR viewColumn.viewName =~ $name) \
 \n   AND ($column_name IS NULL OR viewColumn.propertyName  =~ $column_name) \
 \n RETURN [viewColumn.viewName] AS tables, \
 \n        viewColumn.propertyName AS propertyName, \
@@ -282,7 +282,7 @@ RETURN count(*) > 0
 
 getIndexInfo=SHOW INDEXES YIELD name, type, labelsOrTypes, properties, owningConstraint, entityType \
 ORDER BY name \
-WHERE ($name IS NULL OR $name = '%' OR $name IN labelsOrTypes) \
+WHERE ($name IS NULL OR ANY (item IN labelsOrTypes WHERE item =~ $name)) \
 AND size(labelsOrTypes) = 1 \
 AND entityType = 'NODE' \
 AND type <> 'LOOKUP' \

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/DatabaseMetadataImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/DatabaseMetadataImplTests.java
@@ -33,6 +33,8 @@ import java.util.concurrent.CompletionStage;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 import org.neo4j.bolt.connection.BoltConnection;
 import org.neo4j.bolt.connection.BoltConnectionProvider;
@@ -260,6 +262,26 @@ class DatabaseMetadataImplTests {
 				assertThat(rs.getInt("NUM_PREC_RADIX")).isEqualTo(10);
 			}
 		}
+	}
+
+	@Test
+	void getSearchStringEscapeShouldNotChange() throws SQLException {
+		var meta = newConnection().getMetaData();
+		assertThat(meta.getSearchStringEscape()).isEqualTo("\\");
+	}
+
+	@ParameterizedTest
+	@CsvSource(textBlock = """
+			Nothing                  , \\QNothing\\E
+			NULL                     , NULL
+			''                       , NULL
+			Das?_ist_ein%T*st        , \\QDas?\\E.?+\\Qist\\E.?+\\Qein\\E.*+\\QT*st\\E
+			Das\\%ist auch\\_ein Test, \\QDas%ist auch_ein Test\\E
+			%_                       , .*+.?+
+			""", nullValues = "NULL")
+	void shouldEscapeSearchPatterns(String in, String expected) {
+		var formatted = DatabaseMetadataImpl.FormattedSearchPattern.of(in);
+		assertThat(formatted.value()).isEqualTo(expected);
 	}
 
 	@Test


### PR DESCRIPTION
This restricts table and column patterns to use `%` and `_`, aligned with the JDBC standard.
All other parts of the search string are quoted to be safely used serverside in a regex.
Also, the search string excape character is now obeyed and one can use for literal  and underscores.

Part of CGE-971.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
