### PR TITLE
fix: Make sure updates and join operations are not allowed with views, even without database connection.

### DIFF
--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/SqlToCypher.java
@@ -375,10 +375,6 @@ final class SqlToCypher implements Translator {
 			this.views = views;
 		}
 
-		private boolean ownsView(CbvPointer cbvPointer) {
-			return this.views.containsKey(cbvPointer.viewName());
-		}
-
 		private static IllegalArgumentException unsupported(QueryPart p) {
 			var typeMsg = (p != null) ? " (Was of type " + p.getClass().getName() + ")" : "";
 			return new IllegalArgumentException("Unsupported SQL expression: " + p + typeMsg);
@@ -788,10 +784,9 @@ final class SqlToCypher implements Translator {
 		 */
 		private List<? extends Table<?>> extractQueriedTables(Select<?> src, List<CbvPointer> cbvs) {
 			// Retrieve all Cypher-backed views
-			var allCbvs = loadCypherBackedViews();
 			return unnestFromClause(getFromClause(src), false, (table, partOfJoin) -> {
 				var p = CbvPointer.of(table);
-				if (allCbvs.contains(p.viewName()) && ownsView(p)) {
+				if (isCbv(p)) {
 					if (partOfJoin) {
 						throw new IllegalArgumentException("Cypher-backed views cannot be used with a JOIN clause");
 					}
@@ -800,9 +795,17 @@ final class SqlToCypher implements Translator {
 			});
 		}
 
+		private boolean isCbv(CbvPointer p) {
+			// this.views contains all views this translator has loaded. We consult them
+			// first, as the chance that any other translator is present, is neglectable
+			// in most cases. If there is no result, try toe metadata (if connected), and
+			// thus, all other translators (if available)
+			return this.views.containsKey(p.viewName()) || loadAllCypherBackedViews().contains(p.viewName());
+		}
+
 		// The empty and already stated to be ignored catch block
 		@SuppressWarnings("squid:S108")
-		private Set<String> loadCypherBackedViews() {
+		private Set<String> loadAllCypherBackedViews() {
 			if (this.databaseMetaData == null) {
 				return Set.of();
 			}
@@ -1332,9 +1335,7 @@ final class SqlToCypher implements Translator {
 		}
 
 		private void assertCypherBackedViewUsage(String s, Table<?> table) {
-			var allCbvs = loadCypherBackedViews();
-			var p = CbvPointer.of(table);
-			if (allCbvs.contains(p.viewName()) && ownsView(p)) {
+			if (isCbv(CbvPointer.of(table))) {
 				throw new IllegalArgumentException(s);
 			}
 		}

--- a/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/SqlToCypherTests.java
+++ b/neo4j-jdbc-translator/impl/src/test/java/org/neo4j/jdbc/translator/impl/SqlToCypherTests.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -833,6 +834,22 @@ class SqlToCypherTests {
 		assertThat(result).doesNotContain("__with_col_");
 		assertThat(result).doesNotContain("__having_col_");
 		assertThat(result).isEqualTo("MATCH (p:People) RETURN p.name AS name");
+	}
+
+	@ParameterizedTest
+	@CsvSource(
+			textBlock = """
+					SELECT * FROM CountryCountsView NATURAL JOIN Whatever | Cypher-backed views cannot be used with a JOIN clause
+					DELETE FROM CountryCountsView                         | Cypher-backed views cannot be deleted from
+					UPDATE CountryCountsView SET title = 'asdas'          | Cypher-backed views cannot be updated
+					INSERT INTO CountryCountsView (title) VALUES ('x')    | Cypher-backed views cannot be inserted to
+					""",
+			delimiterString = "|")
+	void cbvUsageMustBePreventedEvenWithoutMetadataInSomeCases(String sql, String expectedMessage) {
+
+		var resource = Objects.requireNonNull(this.getClass().getResource("/cbv/default.json")).toString();
+		var sqlToCypher = SqlToCypher.with(SqlToCypherConfig.builder().withViewDefinitions(resource).build());
+		assertThatIllegalArgumentException().isThrownBy(() -> sqlToCypher.translate(sql)).withMessage(expectedMessage);
 	}
 
 	private record SqlAndCypher(String name, String sql, String cypher) {


### PR DESCRIPTION
Cypher backed views can come from the individual translator that is fixed here (the `SqlToCypher` one), and all other
translators. As the other translators are accesible only via database metadata (aka an open database connection), asking
the meta data is the only way to get a holistic view over all views. While the general finding via LLM is correct—a
broken metadata connection (which cannot happen anymore) or none at all alone must not decide on whether a table name
points to a view—the LLM got it all wrong, and it's funny that it taunts me in its report still. While it does refer to
the docs in which I state

> We do prevent Cypher-backed views from being used in a SQL update statements, such as INSERT, DELETE or UPDATE

it was not able to figure out the general translator interface contract, its documentation and the implications thereof
right here: `org.neo4j.jdbc.translator.spi.Translator#getViews`.

Part of CGE-971.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
