### PR TITLE
chore: Address various other problems.

### DIFF
--- a/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/ViewDefinitionReader.java
+++ b/neo4j-jdbc-translator/impl/src/main/java/org/neo4j/jdbc/translator/impl/ViewDefinitionReader.java
@@ -64,7 +64,7 @@ final class ViewDefinitionReader {
 			throw new IllegalArgumentException(
 					"Unsupported scheme: %s, supported schemes are %s".formatted(scheme, SUPPORTED_SCHEMES));
 		}
-		if ("file".equals(scheme) && uri.getPath() == null || uri.getPath().isBlank()) {
+		if ("file".equals(scheme) && (uri.getPath() == null || uri.getPath().isBlank())) {
 			throw new IllegalArgumentException(
 					"No path specified in this url: %s (%s is %s in that format, not the path; you probably meant file:///%2$s)"
 						.formatted(url, Optional.ofNullable(uri.getHost()).orElseGet(uri::getSchemeSpecificPart),

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/CallableStatementImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/CallableStatementImpl.java
@@ -1230,7 +1230,7 @@ final class CallableStatementImpl extends PreparedStatementImpl implements Neo4j
 
 	private static final String VALID_IDENTIFIER = "\\p{javaJavaIdentifierStart}[.\\p{javaJavaIdentifierPart}]*";
 
-	private static final Predicate<String> IS_NUMBER = Pattern.compile("\\$?[1-9]+").asMatchPredicate();
+	private static final Predicate<String> IS_NUMBER = Pattern.compile("\\$?[1-9]\\d*").asMatchPredicate();
 
 	private static final Pattern VALID_IDENTIFIER_PATTERN = Pattern.compile(VALID_IDENTIFIER);
 

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ConnectionImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/ConnectionImpl.java
@@ -1116,21 +1116,22 @@ final class ConnectionImpl implements Neo4jConnection {
 		public String apply(String statement) {
 
 			Throwable lastException = null;
-			String result = null;
-			String in = statement;
+			String result = statement;
+			boolean validResult = false;
 
 			for (var translator : this.translators) {
 				// Break out early if any of the translators indicates a final Cypher
 				// statement
-				if (forceCypher(in)) {
-					result = in;
+				if (forceCypher(result)) {
+					validResult = true;
 					break;
 				}
 				try {
-					result = translator.translate(in, this.metaData);
+					var newResult = translator.translate(result, this.metaData);
 					// Don't overwrite previous results if the intermediate is null
-					if (result != null) {
-						in = result;
+					if (newResult != null) {
+						validResult = true;
+						result = newResult;
 					}
 				}
 				catch (IllegalArgumentException ex) {
@@ -1138,7 +1139,7 @@ final class ConnectionImpl implements Neo4jConnection {
 						throw ex;
 					}
 					this.warningSink.accept(new SQLWarning(
-							"Translator %s failed to translate `%s`".formatted(translator.getClass().getName(), in),
+							"Translator %s failed to translate `%s`".formatted(translator.getClass().getName(), result),
 							ex));
 					if (ex.getCause() != null) {
 						lastException = ex.getCause();
@@ -1149,7 +1150,7 @@ final class ConnectionImpl implements Neo4jConnection {
 				}
 			}
 
-			if (result == null) {
+			if (!validResult) {
 				throw new IllegalStateException("No suitable translator for input `%s`".formatted(statement),
 						lastException);
 			}

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Lazy.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Lazy.java
@@ -73,7 +73,7 @@ final class Lazy<T> {
 			return this.resolve();
 		}
 		catch (Exception ex) {
-			if (type.isAssignableFrom(ex.getCause().getClass())) {
+			if (ex.getCause() != null && type.isInstance(ex.getCause())) {
 				throw type.cast(ex.getCause());
 			}
 			throw ex;

--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/Neo4jDriver.java
@@ -449,7 +449,7 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 
 	private final Map<String, Object> transactionMetadata = new ConcurrentHashMap<>();
 
-	private final Set<DriverListener> listeners = new HashSet<>();
+	private final Set<DriverListener> listeners = ConcurrentHashMap.newKeySet();
 
 	private Neo4jTracer tracer;
 
@@ -713,7 +713,7 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 		var regex = "^(?<name>\\S+)=(?<value>\\S+)$";
 		var pattern = Pattern.compile(regex);
 		for (String param : urlParams) {
-			var matcher = pattern.matcher(param);
+			var matcher = pattern.matcher(param.trim());
 			if (matcher.matches()) {
 				var name = URLDecoder.decode(matcher.group("name"), StandardCharsets.UTF_8);
 				var value = URLDecoder.decode(matcher.group("value"), StandardCharsets.UTF_8);
@@ -1359,7 +1359,7 @@ public final class Neo4jDriver implements Neo4jDriverExtensions {
 			append(result, PROPERTY_SQL_TRANSLATION_ENABLED, this.enableSQLTranslation()).append("&");
 			append(result, PROPERTY_SQL_TRANSLATION_CACHING_ENABLED, this.enableTranslationCaching()).append("&");
 			append(result, PROPERTY_REWRITE_BATCHED_STATEMENTS, this.rewriteBatchedStatements()).append("&");
-			append(result, PROPERTY_REWRITE_PLACEHOLDERS, this.rewriteBatchedStatements()).append("&");
+			append(result, PROPERTY_REWRITE_PLACEHOLDERS, this.rewritePlaceholders()).append("&");
 			append(result, PROPERTY_USE_BOOKMARKS, this.useBookmarks()).append("&");
 			if (this.tryTcpFastOpen()) {
 				append(result, PROPERTY_TRY_TCP_FAST_OPEN, this.tryTcpFastOpen()).append("&");

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/CallableStatementImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/CallableStatementImplTests.java
@@ -577,6 +577,7 @@ class CallableStatementImplTests {
 					'CALL f($0)', f, NONE, 0,,'CALL f($0)'
 					'CALL f(?, ''blub'', $2, ?, $3, $1, ?, ''foo'')', f, NONE, 6,,'CALL f($4, ''blub'', $2, $5, $3, $1, $6, ''foo'')'
 					'CALL f(?, ''blub'', $2, ?, $3, $1, ''foo'', ?)', f, NONE, 6,,'CALL f($4, ''blub'', $2, $5, $3, $1, ''foo'', $6)'
+					'CALL f($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $20, $30, ?)', f, NONE, 13,,'CALL f($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $20, $30, $11)'
 					""")
 	void shouldBeAbleToParseValidCallStatements(String statement, String expectedFqn,
 			CallableStatementImpl.ReturnType expectedReturnType, long expectedNumParameters, String names,

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ConnectionImplTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/ConnectionImplTests.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;
@@ -94,6 +95,26 @@ class ConnectionImplTests {
 		var connection = makeConnection(mock(BoltConnection.class));
 		assertThatExceptionOfType(SQLException.class).isThrownBy(() -> connection.nativeSQL("M"))
 			.withMessage("general processing exception - No translators available");
+	}
+
+	@Test
+	void chainingShouldNotDitchResultOnIntermediateNull() throws SQLException {
+
+		var connection = makeConnection(mock(BoltConnection.class),
+				() -> List.of((statement, optionalDatabaseMetaData) -> "1",
+						(statement, optionalDatabaseMetaData) -> null,
+						(statement, optionalDatabaseMetaData) -> statement + "3"));
+
+		assertThat(connection.nativeSQL("init")).isEqualTo("13");
+	}
+
+	@Test
+	void chainingShouldNotDitchResultOnLastNull() throws SQLException {
+
+		var connection = makeConnection(mock(BoltConnection.class), () -> List
+			.of((statement, optionalDatabaseMetaData) -> "1", (statement, optionalDatabaseMetaData) -> null));
+
+		assertThat(connection.nativeSQL("init")).isEqualTo("1");
 	}
 
 	@Test
@@ -840,9 +861,14 @@ class ConnectionImplTests {
 	}
 
 	ConnectionImpl makeConnection(BoltConnection boltConnection) {
+		return makeConnection(boltConnection, List::of);
+
+	}
+
+	ConnectionImpl makeConnection(BoltConnection boltConnection, Supplier<List<Translator>> translators) {
 		return new ConnectionImpl(URI.create("jdbc:neo4j://localhost"), Authentication::none, auth -> boltConnection,
-				List::of, false, false, true, false, new NoopBookmarkManagerImpl(), Map.of(), 23, "aBeautifulDatabase",
-				null, List.of());
+				translators, false, false, true, false, new NoopBookmarkManagerImpl(), Map.of(), 23,
+				"aBeautifulDatabase", null, List.of());
 
 	}
 

--- a/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDriverTests.java
+++ b/neo4j-jdbc/src/test/java/org/neo4j/jdbc/Neo4jDriverTests.java
@@ -58,6 +58,12 @@ class Neo4jDriverTests {
 	}
 
 	@Test
+	void urlParamsWithTrailingSpaces() {
+		var mergedConfig = Neo4jDriver.mergeConfig(new String[] { "sslMode=verify-full " }, new Properties());
+		assertThat(mergedConfig).containsEntry("sslMode", "verify-full");
+	}
+
+	@Test
 	void getParentLoggerShouldWork() {
 
 		var driver = new Neo4jDriver();


### PR DESCRIPTION
- Make listener management thread-safe (P2-04)
- Don't discard url parameters with leading or trailing spaces (P2-01)
- Don't drop previous translation results if last translator returns `null` (P2-06)
- Allow more than 9 parameters in a callable statement (P2-08)
- Report `rewritePlaceholders` instead of `rewriteBatchedStatements` twice in URL config representation (P2-09)
- Prevent possible NPE in `Lazy` when resolving throwing without a cause (P2-10)
- Prevent possible NPE in `ViewDefinitionReader` (P2-11)

Part of CGE-971.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
